### PR TITLE
Updating ToolTasklet to allo MRv2 jobs to fail

### DIFF
--- a/src/main/java/org/springframework/data/hadoop/mapreduce/ToolTasklet.java
+++ b/src/main/java/org/springframework/data/hadoop/mapreduce/ToolTasklet.java
@@ -16,21 +16,46 @@
 package org.springframework.data.hadoop.mapreduce;
 
 import org.apache.hadoop.util.Tool;
+import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.StepContribution;
 import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.SimpleSystemProcessExitCodeMapper;
+import org.springframework.batch.core.step.tasklet.SystemProcessExitCodeMapper;
 import org.springframework.batch.core.step.tasklet.Tasklet;
 import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.util.Assert;
+
+import java.io.IOException;
 
 /**
  * Tasklet for executing Hadoop {@link Tool}s.
  * 
  * @author Costin Leau
  */
-public class ToolTasklet extends ToolExecutor implements Tasklet {
+public class ToolTasklet extends ToolExecutor implements Tasklet, InitializingBean {
+
+    private SystemProcessExitCodeMapper systemProcessExitCodeMapper = new SimpleSystemProcessExitCodeMapper();
 
 	@Override
 	public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
-		runCode();
+        int exitCode = runCode();
+        if(systemProcessExitCodeMapper.getExitStatus(exitCode) == ExitStatus.FAILED)
+            throw new IOException("Hadoop tool failed with exit code: "+exitCode);
 		return RepeatStatus.FINISHED;
 	}
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        Assert.notNull(systemProcessExitCodeMapper, "SystemProcessExitCodeMapper must be set");
+    }
+
+    /**
+     * @param systemProcessExitCodeMapper maps system process return value to
+     * <code>ExitStatus</code> returned by Tasklet.
+     * {@link SimpleSystemProcessExitCodeMapper} is used by default.
+     */
+    public void setSystemProcessExitCodeMapper(SystemProcessExitCodeMapper systemProcessExitCodeMapper) {
+        this.systemProcessExitCodeMapper = systemProcessExitCodeMapper;
+    }
 }


### PR DESCRIPTION
MRv1 jobs run with the JobClient which throws an exception when they fail. MRv2 Job class returns a boolean to indicate success instead of throwing an exception. The existing ToolTasklet does not allow MRv2 jobs to fail the tasklet.

Hadoop tools should be using exit codes for success/failure so I pulled in the SystemProcessExitCodeMapper which will allow MRv2 tools to fail with exit codes and MRv1 jobs will still fail when errors are thrown.
