### PR TITLE
Added support to access Hbase over REST

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,8 +12,10 @@ description = 'Spring for Apache Hadoop'
 group = 'org.springframework.data'
 
 repositories {
+/*
   maven { url "http://repo.springsource.org/libs-snapshot" }
-  maven { url 'http://localhost:8081/archiva/repository/internal' }
+*/
+  maven { url 'http://nexus.kohls.com/content/groups/public' }
 }
 
 apply plugin: "java"

--- a/src/main/java/org/springframework/data/hadoop/hbase/HBaseProtocol.java
+++ b/src/main/java/org/springframework/data/hadoop/hbase/HBaseProtocol.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2011-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.hadoop.hbase;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.client.HTableInterface;
+import org.apache.hadoop.hbase.client.HTableInterfaceFactory;
+
+import java.nio.charset.Charset;
+
+/**
+ * @author Muhammad Ashraf
+ * @since 4/9/13
+ */
+public interface HBaseProtocol {
+
+
+    /**
+     * Retrieves an Hbase table instance identified by its name and charset using the given table factory.
+     *
+     * @param tableName     table name
+     * @param configuration Hbase configuration object
+     * @param charset       name charset (may be null)
+     * @param tableFactory  table factory (may be null)
+     * @return table instance
+     */
+    public HTableInterface getHTable(String tableName, Configuration configuration, Charset charset, HTableInterfaceFactory tableFactory);
+
+    /**
+     * Releases (or closes) the given table, created via the given configuration if it is not managed externally (or bound to the thread).
+     *
+     * @param tableName
+     * @param table
+     */
+    public  void releaseTable(String tableName, HTableInterface table, HTableInterfaceFactory tableFactory);
+}

--- a/src/main/java/org/springframework/data/hadoop/hbase/HBaseRestProtocol.java
+++ b/src/main/java/org/springframework/data/hadoop/hbase/HBaseRestProtocol.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2011-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.hadoop.hbase;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.client.HTableInterface;
+import org.apache.hadoop.hbase.client.HTableInterfaceFactory;
+import org.apache.hadoop.hbase.rest.client.Client;
+import org.apache.hadoop.hbase.rest.client.Cluster;
+import org.apache.hadoop.hbase.rest.client.RemoteHTable;
+import org.springframework.util.Assert;
+
+import java.nio.charset.Charset;
+import java.util.List;
+
+/**
+ * Provides functionality to access Hbase over REST by wrapping Hbase {@link org.apache.hadoop.hbase.rest.client.Client}
+ *
+ * @author Muhammad Ashraf
+ * @since 4/9/13
+ */
+public class HBaseRestProtocol implements HBaseProtocol {
+    /**
+     * Thread safe HTTP Client for Hbase
+     */
+    private final Client client;
+
+    public HBaseRestProtocol(List<String> addresses) {
+        Assert.notNull(addresses, " remote HBase address is required");
+        final Cluster cluster = createHBaseRemoteCluster(addresses);
+        client = new Client(cluster);
+
+    }
+
+    private Cluster createHBaseRemoteCluster(List<String> addresses) {
+        final Cluster cluster = new Cluster();
+        for (String address : addresses) {
+
+            cluster.add(address);
+        }
+        return cluster;
+    }
+
+
+    @Override
+    public HTableInterface getHTable(String tableName, Configuration configuration, Charset charset, HTableInterfaceFactory tableFactory) {
+        try {
+            return new RemoteHTable(client, tableName);
+        } catch (Exception e) {
+            throw HbaseUtils.convertHbaseException(e);
+        }
+    }
+
+    @Override
+    public void releaseTable(String tableName, HTableInterface table, HTableInterfaceFactory tableFactory) {
+        /**
+         * NO OP operation as calling table.close() on RemoteHTable shuts down underlying http client.
+         */
+    }
+
+    public void shutdown() {
+        client.shutdown();
+    }
+
+}

--- a/src/main/java/org/springframework/data/hadoop/hbase/HBaseZookeeperProtocol.java
+++ b/src/main/java/org/springframework/data/hadoop/hbase/HBaseZookeeperProtocol.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2011-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.hadoop.hbase;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.client.HTableInterface;
+import org.apache.hadoop.hbase.client.HTableInterfaceFactory;
+
+import java.nio.charset.Charset;
+
+/**
+ * Provides functionality to access Hbase through Zookeeper
+ * @author Muhammad Ashraf
+ * @since 4/9/13
+ */
+public class HBaseZookeeperProtocol implements HBaseProtocol {
+
+    @Override
+    public HTableInterface getHTable(String tableName, Configuration configuration, Charset charset, HTableInterfaceFactory tableFactory) {
+        return HbaseUtils.getHTable(tableName, configuration, charset, tableFactory);
+    }
+
+    @Override
+    public void releaseTable(String tableName, HTableInterface table, HTableInterfaceFactory tableFactory) {
+        HbaseUtils.releaseTable(tableName, table, tableFactory);
+    }
+}

--- a/src/main/java/org/springframework/data/hadoop/hbase/HbaseAccessor.java
+++ b/src/main/java/org/springframework/data/hadoop/hbase/HbaseAccessor.java
@@ -31,8 +31,8 @@ import org.springframework.util.Assert;
  */
 public abstract class HbaseAccessor implements InitializingBean {
 
-	private String encoding;
-	private Charset charset = HbaseUtils.getCharset(encoding);
+	protected String encoding;
+	protected Charset charset = HbaseUtils.getCharset(encoding);
 
 	private HTableInterfaceFactory tableFactory;
 	private Configuration configuration;

--- a/src/main/java/org/springframework/data/hadoop/hbase/HbaseTemplate.java
+++ b/src/main/java/org/springframework/data/hadoop/hbase/HbaseTemplate.java
@@ -29,168 +29,184 @@ import org.springframework.dao.DataAccessException;
 import org.springframework.util.Assert;
 
 /**
- * Central class for accessing the HBase API. Simplifies the use of HBase and helps to avoid common errors. 
- * It executes core HBase workflow, leaving application code to invoke actions and extract results. 
- * 
+ * Central class for accessing the HBase API. Simplifies the use of HBase and helps to avoid common errors.
+ * It executes core HBase workflow, leaving application code to invoke actions and extract results.
+ *
  * @author Costin Leau
  */
 public class HbaseTemplate extends HbaseAccessor implements HbaseOperations {
 
-	private boolean autoFlush = true;
+    private boolean autoFlush = true;
+    private HBaseProtocol protocol;
 
-	public HbaseTemplate() {
-	}
+    public HbaseTemplate() {
+    }
 
-	public HbaseTemplate(Configuration configuration) {
-		setConfiguration(configuration);
-		afterPropertiesSet();
-	}
+    public HbaseTemplate(Configuration configuration) {
+        setConfiguration(configuration);
+        afterPropertiesSet();
+    }
 
-	@Override
-	public <T> T execute(String tableName, TableCallback<T> action) {
-		Assert.notNull(action, "Callback object must not be null");
-		Assert.notNull(tableName, "No table specified");
+    @Override
+    public <T> T execute(String tableName, TableCallback<T> action) {
+        Assert.notNull(action, "Callback object must not be null");
+        Assert.notNull(tableName, "No table specified");
 
-		HTableInterface table = getTable(tableName);
+        HTableInterface table = getTable(tableName);
 
-		try {
-			boolean previousFlushSetting = applyFlushSetting(table);
-			T result = action.doInTable(table);
-			flushIfNecessary(table, previousFlushSetting);
-			return result;
-		} catch (Throwable th) {
-			if (th instanceof Error) {
-				throw ((Error) th);
-			}
-			if (th instanceof RuntimeException) {
-				throw ((RuntimeException) th);
-			}
-			throw convertHbaseAccessException((Exception) th);
-		} finally {
-			releaseTable(tableName, table);
-		}
-	}
+        try {
+            boolean previousFlushSetting = applyFlushSetting(table);
+            T result = action.doInTable(table);
+            flushIfNecessary(table, previousFlushSetting);
+            return result;
+        } catch (Throwable th) {
+            if (th instanceof Error) {
+                throw ((Error) th);
+            }
+            if (th instanceof RuntimeException) {
+                throw ((RuntimeException) th);
+            }
+            throw convertHbaseAccessException((Exception) th);
+        } finally {
+            releaseTable(tableName, table);
+        }
+    }
 
-	private HTableInterface getTable(String tableName) {
-		return HbaseUtils.getHTable(tableName, getConfiguration(), getCharset(), getTableFactory());
-	}
+    private HTableInterface getTable(String tableName) {
+        return protocol.getHTable(tableName, getConfiguration(), getCharset(), getTableFactory());
+    }
 
-	private void releaseTable(String tableName, HTableInterface table) {
-		HbaseUtils.releaseTable(tableName, table, getTableFactory());
-	}
+    private void releaseTable(String tableName, HTableInterface table) {
+        protocol.releaseTable(tableName, table, getTableFactory());
+    }
 
-	private boolean applyFlushSetting(HTableInterface table) {
-		boolean autoFlush = table.isAutoFlush();
-		if (table instanceof HTable) {
-			((HTable) table).setAutoFlush(this.autoFlush);
-		}
-		return autoFlush;
-	}
+    private boolean applyFlushSetting(HTableInterface table) {
+        boolean autoFlush = table.isAutoFlush();
+        if (table instanceof HTable) {
+            ((HTable) table).setAutoFlush(this.autoFlush);
+        }
+        return autoFlush;
+    }
 
-	private void restoreFlushSettings(HTableInterface table, boolean oldFlush) {
-		if (table instanceof HTable) {
-			if (table.isAutoFlush() != oldFlush) {
-				((HTable) table).setAutoFlush(oldFlush);
-			}
-		}
-	}
+    private void restoreFlushSettings(HTableInterface table, boolean oldFlush) {
+        if (table instanceof HTable) {
+            if (table.isAutoFlush() != oldFlush) {
+                ((HTable) table).setAutoFlush(oldFlush);
+            }
+        }
+    }
 
-	private void flushIfNecessary(HTableInterface table, boolean oldFlush) throws IOException {
-		// TODO: check whether we can consider or not a table scope
-		table.flushCommits();
-		restoreFlushSettings(table, oldFlush);
-	}
+    private void flushIfNecessary(HTableInterface table, boolean oldFlush) throws IOException {
+        // TODO: check whether we can consider or not a table scope
+        table.flushCommits();
+        restoreFlushSettings(table, oldFlush);
+    }
 
-	public DataAccessException convertHbaseAccessException(Exception ex) {
-		return HbaseUtils.convertHbaseException(ex);
-	}
+    public DataAccessException convertHbaseAccessException(Exception ex) {
+        return HbaseUtils.convertHbaseException(ex);
+    }
 
-	@Override
-	public <T> T find(String tableName, String family, final ResultsExtractor<T> action) {
-		Scan scan = new Scan();
-		scan.addFamily(family.getBytes(getCharset()));
-		return find(tableName, scan, action);
-	}
+    @Override
+    public <T> T find(String tableName, String family, final ResultsExtractor<T> action) {
+        Scan scan = new Scan();
+        scan.addFamily(family.getBytes(getCharset()));
+        return find(tableName, scan, action);
+    }
 
-	@Override
-	public <T> T find(String tableName, String family, String qualifier, final ResultsExtractor<T> action) {
-		Scan scan = new Scan();
-		scan.addColumn(family.getBytes(getCharset()), qualifier.getBytes(getCharset()));
-		return find(tableName, scan, action);
-	}
+    @Override
+    public <T> T find(String tableName, String family, String qualifier, final ResultsExtractor<T> action) {
+        Scan scan = new Scan();
+        scan.addColumn(family.getBytes(getCharset()), qualifier.getBytes(getCharset()));
+        return find(tableName, scan, action);
+    }
 
-	@Override
-	public <T> T find(String tableName, final Scan scan, final ResultsExtractor<T> action) {
-		return execute(tableName, new TableCallback<T>() {
-			@Override
-			public T doInTable(HTableInterface htable) throws Throwable {
-				ResultScanner scanner = htable.getScanner(scan);
-				try {
-					return action.extractData(scanner);
-				} finally {
-					scanner.close();
-				}
-			}
-		});
-	}
+    @Override
+    public <T> T find(String tableName, final Scan scan, final ResultsExtractor<T> action) {
+        return execute(tableName, new TableCallback<T>() {
+            @Override
+            public T doInTable(HTableInterface htable) throws Throwable {
+                ResultScanner scanner = htable.getScanner(scan);
+                try {
+                    return action.extractData(scanner);
+                } finally {
+                    scanner.close();
+                }
+            }
+        });
+    }
 
-	@Override
-	public <T> List<T> find(String tableName, String family, final RowMapper<T> action) {
-		Scan scan = new Scan();
-		scan.addFamily(family.getBytes(getCharset()));
-		return find(tableName, scan, action);
-	}
+    @Override
+    public <T> List<T> find(String tableName, String family, final RowMapper<T> action) {
+        Scan scan = new Scan();
+        scan.addFamily(family.getBytes(getCharset()));
+        return find(tableName, scan, action);
+    }
 
-	@Override
-	public <T> List<T> find(String tableName, String family, String qualifier, final RowMapper<T> action) {
-		Scan scan = new Scan();
-		scan.addColumn(family.getBytes(getCharset()), qualifier.getBytes(getCharset()));
-		return find(tableName, scan, action);
-	}
+    @Override
+    public <T> List<T> find(String tableName, String family, String qualifier, final RowMapper<T> action) {
+        Scan scan = new Scan();
+        scan.addColumn(family.getBytes(getCharset()), qualifier.getBytes(getCharset()));
+        return find(tableName, scan, action);
+    }
 
-	@Override
-	public <T> List<T> find(String tableName, final Scan scan, final RowMapper<T> action) {
-		return find(tableName, scan, new RowMapperResultsExtractor<T>(action));
-	}
+    @Override
+    public <T> List<T> find(String tableName, final Scan scan, final RowMapper<T> action) {
+        return find(tableName, scan, new RowMapperResultsExtractor<T>(action));
+    }
 
-	@Override
-	public <T> T get(String tableName, String rowName, final RowMapper<T> mapper) {
-		return get(tableName, rowName, null, null, mapper);
-	}
+    @Override
+    public <T> T get(String tableName, String rowName, final RowMapper<T> mapper) {
+        return get(tableName, rowName, null, null, mapper);
+    }
 
-	@Override
-	public <T> T get(String tableName, String rowName, String familyName, final RowMapper<T> mapper) {
-		return get(tableName, rowName, familyName, null, mapper);
-	}
+    @Override
+    public <T> T get(String tableName, String rowName, String familyName, final RowMapper<T> mapper) {
+        return get(tableName, rowName, familyName, null, mapper);
+    }
 
-	@Override
-	public <T> T get(String tableName, final String rowName, final String familyName, final String qualifier, final RowMapper<T> mapper) {
-		return execute(tableName, new TableCallback<T>() {
-			@Override
-			public T doInTable(HTableInterface htable) throws Throwable {
-				Get get = new Get(rowName.getBytes(getCharset()));
-				if (familyName != null) {
-					byte[] family = familyName.getBytes(getCharset());
+    @Override
+    public <T> T get(String tableName, final String rowName, final String familyName, final String qualifier, final RowMapper<T> mapper) {
+        return execute(tableName, new TableCallback<T>() {
+            @Override
+            public T doInTable(HTableInterface htable) throws Throwable {
+                Get get = new Get(rowName.getBytes(getCharset()));
+                if (familyName != null) {
+                    byte[] family = familyName.getBytes(getCharset());
 
-					if (qualifier != null) {
-						get.addColumn(family, qualifier.getBytes(getCharset()));
-					}
-					else {
-						get.addFamily(family);
-					}
-				}
-				Result result = htable.get(get);
-				return mapper.mapRow(result, 0);
-			}
-		});
-	}
+                    if (qualifier != null) {
+                        get.addColumn(family, qualifier.getBytes(getCharset()));
+                    } else {
+                        get.addFamily(family);
+                    }
+                }
+                Result result = htable.get(get);
+                return mapper.mapRow(result, 0);
+            }
+        });
+    }
 
-	/**
-	 * Sets the auto flush.
-	 *
-	 * @param autoFlush The autoFlush to set.
-	 */
-	public void setAutoFlush(boolean autoFlush) {
-		this.autoFlush = autoFlush;
-	}
+    /**
+     * Sets the auto flush.
+     *
+     * @param autoFlush The autoFlush to set.
+     */
+    public void setAutoFlush(boolean autoFlush) {
+        this.autoFlush = autoFlush;
+    }
+
+    public void setProtocol(HBaseProtocol protocol) {
+        this.protocol = protocol;
+    }
+
+    @Override
+    public void afterPropertiesSet() {
+        if (protocol == null) {
+            protocol = new HBaseZookeeperProtocol();
+        }
+        if (protocol instanceof HBaseZookeeperProtocol) {
+            Assert.notNull(getConfiguration(), " a valid configuration is required");
+        }
+        charset = HbaseUtils.getCharset(encoding);
+
+    }
 }

--- a/src/test/java/org/springframework/data/hadoop/hbase/HBaseRemoteTest.java
+++ b/src/test/java/org/springframework/data/hadoop/hbase/HBaseRemoteTest.java
@@ -1,0 +1,120 @@
+package org.springframework.data.hadoop.hbase;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.client.*;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import javax.annotation.Resource;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Muhammad Ashraf
+ * @since 4/10/13
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+public class HBaseRemoteTest {
+
+    @Autowired
+    HbaseTemplate template;
+
+    @Resource(name = "hbaseConfiguration")
+    Configuration config;
+
+    String tableName = "myRemoteTable";
+    String columnName = "myColumnFamily";
+    String rowName = "myLittleRow";
+    String qualifier = "someQualifier";
+    String value = "Some Value";
+
+    @Test
+    public void testHBaseConnection() throws Exception {
+        HBaseAdmin admin = new HBaseAdmin(config);
+        if (admin.tableExists(tableName)) {
+            System.out.println("deleting table...");
+            admin.disableTable(tableName);
+            admin.deleteTable(tableName);
+        }
+
+        HTableDescriptor tableDescriptor = new HTableDescriptor(tableName);
+        tableDescriptor.addFamily(new HColumnDescriptor(columnName));
+        assertTrue(tableDescriptor.hasFamily(Bytes.toBytes(columnName)));
+        admin.createTable(tableDescriptor);
+
+        // block A
+        System.out.println("Created table...");
+        HTable table = new HTable(config, tableName);
+
+        Put p = new Put(Bytes.toBytes(rowName));
+        p.add(Bytes.toBytes(columnName), Bytes.toBytes(qualifier), Bytes.toBytes(value));
+        table.put(p);
+
+        System.out.println("Doing put..");
+        Get g = new Get(Bytes.toBytes(rowName));
+        Result r = table.get(g);
+        byte[] val = r.getValue(Bytes.toBytes(columnName), Bytes.toBytes(qualifier));
+
+        assertEquals(value, Bytes.toString(val));
+        System.out.println("Doing get..");
+
+
+        // block B
+        Scan s = new Scan();
+        s.addColumn(Bytes.toBytes(columnName), Bytes.toBytes(qualifier));
+        ResultScanner scanner = table.getScanner(s);
+
+        try {
+            // Scanners return Result instances.
+            for (Result rr : scanner) {
+                System.out.println("Found row: " + rr);
+            }
+        } catch (Exception ex) {
+            System.out.println("Caught exception " + ex);
+        } finally {
+            // Make sure you close your scanners when you are done!
+            // Thats why we have it inside a try/finally clause
+            scanner.close();
+        }
+    }
+
+
+    @Test
+    public void testTemplate() throws Exception {
+
+        template.execute(tableName, new TableCallback<Object>() {
+            @Override
+            public Object doInTable(HTableInterface table) throws Throwable {
+                Put p = new Put(Bytes.toBytes(rowName));
+                p.add(Bytes.toBytes(columnName), Bytes.toBytes(qualifier), Bytes.toBytes(value));
+                table.put(p);
+
+                System.out.println("Doing put..");
+                Get g = new Get(Bytes.toBytes(rowName));
+                Result r = table.get(g);
+                byte[] val = r.getValue(Bytes.toBytes(columnName), Bytes.toBytes(qualifier));
+
+                assertEquals(value, Bytes.toString(val));
+                return null;
+            }
+        });
+
+
+
+        // equivalent of block B
+        System.out.println("Found rows " + template.find(tableName, columnName, qualifier, new RowMapper<String>() {
+            @Override
+            public String mapRow(Result result, int rowNum) throws Exception {
+                return result.toString();
+            }
+        }));
+
+    }
+}

--- a/src/test/resources/org/springframework/data/hadoop/hbase/HBaseRemoteTest-context.xml
+++ b/src/test/resources/org/springframework/data/hadoop/hbase/HBaseRemoteTest-context.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:util="http://www.springframework.org/schema/util"
+       xmlns:hdp="http://www.springframework.org/schema/hadoop"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+
+    <import resource="../hadoop-ctx.xml"/>
+
+    <hdp:hbase-configuration zk-quorum="${hbase.host}" zk-port="${hbase.port}">
+        head=bucket
+    </hdp:hbase-configuration>
+
+    <util:list id="addressList" value-type="java.lang.String">
+        <value>${hbase.rest.url}</value>
+    </util:list>
+
+    <bean id="hbaseRestProtocol" class="org.springframework.data.hadoop.hbase.HBaseRestProtocol"
+          destroy-method="shutdown">
+        <constructor-arg name="addresses" ref="addressList"/>
+    </bean>
+    <bean id="template" class="org.springframework.data.hadoop.hbase.HbaseTemplate">
+        <property name="protocol" ref="hbaseRestProtocol"/>
+    </bean>
+
+    <context:property-placeholder location="test.properties"/>
+</beans>

--- a/src/test/resources/test.properties
+++ b/src/test/resources/test.properties
@@ -19,9 +19,8 @@
 #
 # Hadoop settings
 #
-
 ## M&R
-hadoop.fs=${hd.fs|hdfs://localhost:8020}
+hadoop.fs=${hd.fs|hdfs://localhost:9000}
 hadoop.jt=${hd.jt|local}
 
 ## Hive
@@ -32,6 +31,7 @@ hive.url=jdbc:hive://${hive.host}:${hive.port}
 ## HBase
 hbase.host=${hd.hbase.host|localhost}
 hbase.port=${hd.hbase.port|2181}
+hbase.rest.url:localhost:8081
 
 ## Pig Execution
 ## externalized since CDH3 VM Pig install has issues (SL4J CNFE) 


### PR DESCRIPTION
Modified HBaseTemplate to support accessing HBase over REST by wrapping HBase rest client (http://hbase.apache.org/apidocs/org/apache/hadoop/hbase/rest/client/package-summary.html). This is useful in environments where HBase is not directly accessible through Zookeeper and needs to be accessed over HTTP/REST. Changes are backward compatible and should not effect existing behavior. 
