### PR TITLE
XD-1: Inial commit of the HdfsItemWriter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ metastore_db
 /samples/pig-scripting/src/main/resources/ml-100k/u.data
 /src/test/resources/s3.properties
 /.idea/
+.DS_Store

--- a/src/main/java/org/springframework/data/hadoop/fs/HdfsItemWriter.java
+++ b/src/main/java/org/springframework/data/hadoop/fs/HdfsItemWriter.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2013 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.hadoop.fs;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.IOUtils;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.item.ItemStreamException;
+import org.springframework.batch.item.ItemStreamWriter;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.core.serializer.Serializer;
+import org.springframework.transaction.support.TransactionSynchronizationAdapter;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+/**
+ * An {@link ItemWriter} implementation used to write the incoming items to
+ * HDFS.  Due to the HDFS limitation that files cannot be deleted or modified, the
+ * ability to roll back a file to a previously known state is not possible.  This
+ * prevents the ability to restart using this {@link ItemWriter}.
+ * <br/>
+ * This {@link ItemWriter} is <em>not</em> thread-safe.
+ * 
+ * @author Michael Minella
+ */
+public class HdfsItemWriter<T> implements ItemStreamWriter<T> {
+
+	private static final String BUFFER_KEY_PREFIX = HdfsItemWriter.class.getName() + ".BUFFER_KEY";
+	private final String bufferKey;
+	private String fileName;
+	private FileSystem fileSystem;
+	private FSDataOutputStream fsDataOutputStream;
+	private Serializer<T> itemSerializer;
+
+	/**
+	 * Constructor
+	 * 
+	 * @param fileSystem - HDFS {@link FileSystem} reference
+	 * @param itemSerializer - Strategy for serializing items
+	 * @param fileName - Name of the file to be written to
+	 */
+	public HdfsItemWriter(FileSystem fileSystem, Serializer<T> itemSerializer, String fileName) {
+		Assert.notNull(fileSystem, "Hadoop FileSystem is required.");
+		Assert.notNull(itemSerializer, "A Serializer implementation is required");
+		Assert.isTrue(StringUtils.hasText(fileName), "A non-empty fileName is required.");
+		this.fileSystem = fileSystem;
+		this.bufferKey = BUFFER_KEY_PREFIX + "." + hashCode();
+		this.itemSerializer = itemSerializer;
+		this.fileName = fileName;
+	}
+
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	private List<? extends T> getCurrentBuffer() {
+		if(!TransactionSynchronizationManager.hasResource(bufferKey)) {
+			TransactionSynchronizationManager.bindResource(bufferKey, new ArrayList());
+
+			TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronizationAdapter() {
+				@Override
+				public void beforeCommit(boolean readOnly) {
+					List items = (List) TransactionSynchronizationManager.getResource(bufferKey);
+
+					if(!CollectionUtils.isEmpty(items)) {
+						if(!readOnly) {
+							doWrite(items);
+						}
+					}
+				}
+
+				@Override
+				public void afterCompletion(int status) {
+					if(TransactionSynchronizationManager.hasResource(bufferKey)) {
+						TransactionSynchronizationManager.unbindResource(bufferKey);
+					}
+				}
+			});
+		}
+
+		return (List) TransactionSynchronizationManager.getResource(bufferKey);
+	}
+
+	/**
+	 * Performs the actual write to the store via the template.
+	 * This can be overridden by a subclass if necessary.
+	 *
+	 * @param items the list of items to be persisted.
+	 */
+	protected void doWrite(List<? extends T> items) {
+		if(! CollectionUtils.isEmpty(items)) {
+			try {
+				fsDataOutputStream.write(getPayloadAsBytes(items));
+			} catch (IOException ioe) {
+				throw new RuntimeException("Error writing to HDFS", ioe);
+			}
+		}
+	}
+
+	@Override
+	public void open(ExecutionContext executionContext)
+			throws ItemStreamException {
+		try {
+			Path name = null;
+
+			name = new Path(fileName);
+			fileSystem.createNewFile(name);
+			this.fsDataOutputStream = fileSystem.create(name);
+		} catch (IOException ioe) {
+			throw new RuntimeException("Unable to open file to write to", ioe);
+		}
+	}
+
+	@Override
+	public void update(ExecutionContext executionContext)
+			throws ItemStreamException {
+		// TODO: determine the state to maintain, if any
+	}
+
+	@Override
+	@SuppressWarnings({"rawtypes", "unchecked"})
+	public void write(List<? extends T> items) throws Exception {
+		if(!transactionActive()) {
+			doWrite(items);
+			return;
+		}
+
+		List bufferedItems = getCurrentBuffer();
+		bufferedItems.addAll(items);
+	}
+
+	@Override
+	public void close() {
+		if (fsDataOutputStream != null) {
+			IOUtils.closeStream(fsDataOutputStream);
+		}
+	}
+
+	/**
+	 * Extracts the payload as a byte array.
+	 * @param message
+	 * @return
+	 */
+	private byte[] getPayloadAsBytes(List<? extends T> items) throws IOException{
+		ByteArrayOutputStream stream = new ByteArrayOutputStream();
+
+		for (T item : items) {
+			itemSerializer.serialize(item, stream);
+		}
+
+		return stream.toByteArray();
+	}
+
+	private boolean transactionActive() {
+		return TransactionSynchronizationManager.isActualTransactionActive();
+	}
+}

--- a/src/test/java/org/springframework/data/hadoop/fs/HdfsItemWriterTest.java
+++ b/src/test/java/org/springframework/data/hadoop/fs/HdfsItemWriterTest.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2013 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.hadoop.fs;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.support.transaction.ResourcelessTransactionManager;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.core.serializer.DefaultSerializer;
+import org.springframework.core.serializer.Serializer;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * @author Michael Minella
+ *
+ */
+public class HdfsItemWriterTest {
+
+	private HdfsItemWriter<String> writer;
+	@SuppressWarnings("rawtypes")
+	private Serializer itemSerializer;
+	private final String fileName = "/tmp/myFile.txt";
+
+	@Mock
+	private FileSystem fileSystem;
+	@Mock
+	private FSDataOutputStream fsDataOutputStream;
+	private PlatformTransactionManager transactionManager = new ResourcelessTransactionManager();
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@Before
+	@SuppressWarnings("unchecked")
+	public void setUp() throws Exception {
+		MockitoAnnotations.initMocks(this);
+		itemSerializer = new DefaultSerializer();
+		writer = new HdfsItemWriter<String>(fileSystem, itemSerializer, fileName);
+	}
+
+	@Test
+	@SuppressWarnings("serial")
+	public void testWriteNoTransaction() throws Exception {
+		List<String> items = new ArrayList<String>() {{
+			add(new String("one"));
+			add(new String("two"));
+		}};
+
+		when(fileSystem.createNewFile(new Path(fileName))).thenReturn(true);
+		when(fileSystem.create(new Path(fileName))).thenReturn(fsDataOutputStream);
+
+		writer.open(null);
+		writer.write(items);
+
+		ByteArrayOutputStream stream = new ByteArrayOutputStream();
+		getBytes(items.get(0), stream);
+		getBytes(items.get(1), stream);
+
+		verify(fsDataOutputStream).write(stream.toByteArray());
+	}
+
+	@Test
+	public void testWriteNoTransactionNoItems() throws Exception {
+		when(fileSystem.createNewFile(new Path(fileName))).thenReturn(true);
+		when(fileSystem.create(new Path(fileName))).thenReturn(fsDataOutputStream);
+
+		writer.open(null);
+		writer.write(new ArrayList<String>());
+
+		verifyZeroInteractions(fsDataOutputStream);
+	}
+
+	@Test
+	@SuppressWarnings("serial")
+	public void testWriteTransaction() throws Exception {
+		final List<String> items = new ArrayList<String>() {{
+			add(new String("one"));
+			add(new String("two"));
+		}};
+
+		when(fileSystem.createNewFile(new Path(fileName))).thenReturn(true);
+		when(fileSystem.create(new Path(fileName))).thenReturn(fsDataOutputStream);
+
+		writer.open(null);
+
+		new TransactionTemplate(transactionManager).execute(new TransactionCallback<Object>() {
+			@Override
+			public Object doInTransaction(TransactionStatus status) {
+				try {
+					writer.write(items);
+				} catch (Exception e) {
+					fail("An exception was thrown while writing: " + e.getMessage());
+				}
+
+				return null;
+			}
+		});
+
+		ByteArrayOutputStream stream = new ByteArrayOutputStream();
+		getBytes(items.get(0), stream);
+		getBytes(items.get(1), stream);
+
+		verify(fsDataOutputStream).write(stream.toByteArray());
+	}
+
+	@Test
+	@SuppressWarnings("serial")
+	public void testWriteTransactionFails() throws Exception {
+		final List<String> items = new ArrayList<String>() {{
+			add(new String("one"));
+			add(new String("two"));
+		}};
+
+		when(fileSystem.createNewFile(new Path(fileName))).thenReturn(true);
+		when(fileSystem.create(new Path(fileName))).thenReturn(fsDataOutputStream);
+
+		writer.open(null);
+
+		try {
+			new TransactionTemplate(transactionManager).execute(new TransactionCallback<Object>() {
+				@Override
+				public Object doInTransaction(TransactionStatus status) {
+					try {
+						writer.write(items);
+					} catch (Exception e) {
+						fail("An exception was thrown while writing: " + e.getMessage());
+					}
+
+					throw new RuntimeException("force rollback");
+				}
+			});
+		} catch (RuntimeException re) {
+			assertEquals(re.getMessage(), "force rollback");
+		} catch (Throwable t) {
+			fail("Unexpected exception was thrown: " + t.getMessage());
+		}
+
+		verifyZeroInteractions(fsDataOutputStream);
+	}
+
+	/**
+	 * A pointless use case but validates that the flag is still honored.
+	 *
+	 * @throws Exception
+	 */
+	@Test
+	@SuppressWarnings("serial")
+	public void testWriteTransactionReadOnly() throws Exception {
+		final List<String> items = new ArrayList<String>() {{
+			add(new String("one"));
+			add(new String("two"));
+		}};
+
+		when(fileSystem.createNewFile(new Path(fileName))).thenReturn(true);
+		when(fileSystem.create(new Path(fileName))).thenReturn(fsDataOutputStream);
+
+		writer.open(null);
+
+		try {
+			TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+			transactionTemplate.setReadOnly(true);
+			transactionTemplate.execute(new TransactionCallback<Object>() {
+
+				@Override
+				public Object doInTransaction(TransactionStatus status) {
+					try {
+						writer.write(items);
+					} catch (Exception e) {
+						fail("An exception was thrown while writing: " + e.getMessage());
+					}
+
+					return null;
+				}
+			});
+		} catch (Throwable t) {
+			fail("Unexpected exception was thrown: " + t.getMessage());
+		}
+
+		verifyZeroInteractions(fsDataOutputStream);
+	}
+
+	@Test
+	public void testWithinJob() throws Exception {
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("/org/springframework/data/hadoop/fs/HdfsItemWriterTest-context.xml");
+		JobLauncher launcher = context.getBean(JobLauncher.class);
+		Job job = context.getBean(Job.class);
+
+		JobParameters jobParameters = new JobParametersBuilder().toJobParameters();
+
+		JobExecution execution = launcher.run(job, jobParameters);
+		assertTrue("status was: " + execution.getStatus(), execution.getStatus() == BatchStatus.COMPLETED);
+	}
+
+	@SuppressWarnings("unchecked")
+	private void getBytes(Object src, ByteArrayOutputStream stream) {
+		try {
+			itemSerializer.serialize(src, stream);
+		} catch (IOException ignore) {
+		}
+	}
+}

--- a/src/test/resources/org/springframework/data/hadoop/fs/HdfsItemWriterTest-context.xml
+++ b/src/test/resources/org/springframework/data/hadoop/fs/HdfsItemWriterTest-context.xml
@@ -1,0 +1,58 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:batch="http://www.springframework.org/schema/batch"
+	xmlns:hdp="http://www.springframework.org/schema/hadoop"
+	xmlns:p="http://www.springframework.org/schema/p"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+      	http://www.springframework.org/schema/batch	http://www.springframework.org/schema/batch/spring-batch-2.1.xsd
+      	http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+
+	<import resource="../batch-common.xml"/>
+	<import resource="../hadoop-ctx.xml"/>
+	
+	<job id="mainJob" xmlns="http://www.springframework.org/schema/batch">
+		<step id="import" next="do">
+			<tasklet>
+				<chunk reader="itemReader" writer="hdfsItemWriter" commit-interval="100"/>
+			</tasklet>
+		</step>
+		<step id="do" next="clean">
+			<tasklet ref="hadoop-tasklet"/>
+		</step>
+		<step id="clean">
+			<hdp:script-tasklet id="script-tasklet">
+				<hdp:script language="javascript">
+if (fsh.test("/test/word/")) fsh.rmr("/test/word/")
+				</hdp:script>
+			</hdp:script-tasklet>
+		</step>
+	</job>
+	
+	<bean id="itemReader" class="org.springframework.batch.item.file.FlatFileItemReader">
+		<property name="resource" value="/data/babynames-short.txt"/>
+		<property name="lineMapper">
+			<bean class="org.springframework.batch.item.file.mapping.PassThroughLineMapper"/>
+		</property>
+	</bean>
+	
+	<bean id="hdfsItemWriter" class="org.springframework.data.hadoop.fs.HdfsItemWriter">
+		<constructor-arg>
+			<bean class="org.springframework.data.hadoop.fs.FileSystemFactoryBean" p:configuration-ref="hadoopConfiguration"/>
+		</constructor-arg>
+		<constructor-arg>
+			<bean class="org.springframework.core.serializer.DefaultSerializer"/>
+		</constructor-arg>
+		<constructor-arg value="/test/word/input/out.txt"/>
+	</bean>
+
+	<bean id="hadoop-tasklet" class="org.springframework.data.hadoop.mapreduce.JobTasklet" p:job-ref="mr-job" p:wait-for-completion="true"/>
+	
+	<bean id="mr-job" class="org.springframework.data.hadoop.mapreduce.JobFactoryBean"
+		p:configuration-ref="hadoopConfiguration"
+		p:input-path="/test/word/input/"
+		p:output-path="/test/word/output/"
+		p:mapper="org.apache.hadoop.examples.WordCount.TokenizerMapper"
+		p:reducer="org.apache.hadoop.examples.WordCount.IntSumReducer"
+		p:jar="mini-hadoop-examples.jar"
+	/>
+</beans>


### PR DESCRIPTION
A couple notes on this PR:
1. It is modeled after most of the other ItemWriter implementations in batch that work with non-transactional stores (files, Mongo, etc) in that the actual persistence is delayed until the last moment before committing.
2. I didn't see an obvious division between unit tests and integration tests in this project, so my test is actually both.  It is a unit test for the writer and it also executes the writer within the context of a job.  I'd like to factor that test out, I just need to understand where it belongs.
