### PR TITLE
Fixing wrong handling of server socket SHDP-138

### DIFF
--- a/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/support/DefaultPortExposingTcpSocketSupport.java
+++ b/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/support/DefaultPortExposingTcpSocketSupport.java
@@ -29,15 +29,11 @@ import org.springframework.yarn.support.NetworkUtils;
  */
 public class DefaultPortExposingTcpSocketSupport implements PortExposingTcpSocketSupport {
 
-	private int serverSocketPort = -1;
-	private String serverSocketAddress;
+	private ServerSocket serverSocket;
 
 	@Override
 	public void postProcessServerSocket(ServerSocket serverSocket) {
-		serverSocketPort = serverSocket.getLocalPort();
-		serverSocketAddress = NetworkUtils.getDefaultAddress();
-		// TODO: do better address resolving
-		//serverSocketAddress = serverSocket.getInetAddress().getHostAddress();
+		this.serverSocket = serverSocket;
 	}
 
 	@Override
@@ -46,13 +42,13 @@ public class DefaultPortExposingTcpSocketSupport implements PortExposingTcpSocke
 
 	@Override
 	public int getServerSocketPort() {
-		return serverSocketPort;
+		return serverSocket != null ? serverSocket.getLocalPort() : -1;
 	}
 
 	@Override
 	public String getServerSocketAddress() {
-		return serverSocketAddress;
+		// TODO: do better address resolving
+		return serverSocket != null ? NetworkUtils.getDefaultAddress() : null;
 	}
-
 
 }

--- a/spring-yarn/spring-yarn-integration/src/test/java/org/springframework/yarn/integration/support/PortExposingTcpSocketSupportNetTests.java
+++ b/spring-yarn/spring-yarn-integration/src/test/java/org/springframework/yarn/integration/support/PortExposingTcpSocketSupportNetTests.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.yarn.integration.support;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.yarn.am.AppmasterService;
+
+/**
+ * Testing socket support logic through appmaster service
+ * if net sockets are used.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@ContextConfiguration
+@RunWith(SpringJUnit4ClassRunner.class)
+public class PortExposingTcpSocketSupportNetTests {
+
+	@Autowired
+	AppmasterService mindAppmasterService;
+
+	@Test
+	public void testExposedSocketPort() throws Exception {
+		assertNotNull(mindAppmasterService);
+		assertThat(mindAppmasterService.getPort(), greaterThan(0));
+	}
+
+}

--- a/spring-yarn/spring-yarn-integration/src/test/java/org/springframework/yarn/integration/support/PortExposingTcpSocketSupportNioTests.java
+++ b/spring-yarn/spring-yarn-integration/src/test/java/org/springframework/yarn/integration/support/PortExposingTcpSocketSupportNioTests.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.yarn.integration.support;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.yarn.am.AppmasterService;
+
+/**
+ * Testing socket support logic through appmaster service
+ * if nio sockets are used.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@ContextConfiguration
+@RunWith(SpringJUnit4ClassRunner.class)
+public class PortExposingTcpSocketSupportNioTests {
+
+	@Autowired
+	AppmasterService mindAppmasterService;
+
+	@Test
+	public void testExposedSocketPort() throws Exception {
+		assertNotNull(mindAppmasterService);
+		assertThat(mindAppmasterService.getPort(), greaterThan(0));
+	}
+
+}

--- a/spring-yarn/spring-yarn-integration/src/test/resources/org/springframework/yarn/integration/support/PortExposingTcpSocketSupportNetTests-context.xml
+++ b/spring-yarn/spring-yarn-integration/src/test/resources/org/springframework/yarn/integration/support/PortExposingTcpSocketSupportNetTests-context.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns="http://www.springframework.org/schema/beans"
+	xmlns:ip="http://www.springframework.org/schema/integration/ip"
+	xmlns:yarn-int="http://www.springframework.org/schema/yarn/integration"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans
+			http://www.springframework.org/schema/beans/spring-beans.xsd
+			http://www.springframework.org/schema/yarn/integration
+			http://www.springframework.org/schema/yarn/integration/spring-yarn-integration.xsd
+			http://www.springframework.org/schema/integration
+			http://www.springframework.org/schema/integration/spring-integration.xsd
+			http://www.springframework.org/schema/integration/ip
+			http://www.springframework.org/schema/integration/ip/spring-integration-ip.xsd">
+
+	<bean id="tcpIpUtils" class="org.springframework.integration.test.util.SocketUtils" />
+
+	<bean id="socketSupport" class="org.springframework.yarn.integration.support.DefaultPortExposingTcpSocketSupport" />
+
+	<ip:tcp-connection-factory id="serverConnectionFactory"
+		type="server"
+		using-nio="false"
+		port="#{tcpIpUtils.findAvailableServerSocket(7400)}"
+		socket-support="socketSupport"/>
+
+	<ip:tcp-inbound-gateway id="inboundGateway"
+		connection-factory="serverConnectionFactory"
+		request-channel="serverChannel" />
+
+	<int:channel id="serverChannel" />
+
+	<bean id="mindAppmasterService" class="org.springframework.yarn.integration.ip.mind.TestService" >
+		<property name="socketSupport" ref="socketSupport"/>
+		<property name="messageChannel" ref="serverChannel"/>
+	</bean>
+
+</beans>

--- a/spring-yarn/spring-yarn-integration/src/test/resources/org/springframework/yarn/integration/support/PortExposingTcpSocketSupportNioTests-context.xml
+++ b/spring-yarn/spring-yarn-integration/src/test/resources/org/springframework/yarn/integration/support/PortExposingTcpSocketSupportNioTests-context.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns="http://www.springframework.org/schema/beans"
+	xmlns:ip="http://www.springframework.org/schema/integration/ip"
+	xmlns:yarn-int="http://www.springframework.org/schema/yarn/integration"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans
+			http://www.springframework.org/schema/beans/spring-beans.xsd
+			http://www.springframework.org/schema/yarn/integration
+			http://www.springframework.org/schema/yarn/integration/spring-yarn-integration.xsd
+			http://www.springframework.org/schema/integration
+			http://www.springframework.org/schema/integration/spring-integration.xsd
+			http://www.springframework.org/schema/integration/ip
+			http://www.springframework.org/schema/integration/ip/spring-integration-ip.xsd">
+
+	<bean id="tcpIpUtils" class="org.springframework.integration.test.util.SocketUtils" />
+
+	<bean id="socketSupport" class="org.springframework.yarn.integration.support.DefaultPortExposingTcpSocketSupport" />
+
+	<ip:tcp-connection-factory id="serverConnectionFactory"
+		type="server"
+		using-nio="true"
+		port="#{tcpIpUtils.findAvailableServerSocket(7400)}"
+		socket-support="socketSupport"/>
+
+	<ip:tcp-inbound-gateway id="inboundGateway"
+		connection-factory="serverConnectionFactory"
+		request-channel="serverChannel" />
+
+	<int:channel id="serverChannel" />
+
+	<bean id="mindAppmasterService" class="org.springframework.yarn.integration.ip.mind.TestService" >
+		<property name="socketSupport" ref="socketSupport"/>
+		<property name="messageChannel" ref="serverChannel"/>
+	</bean>
+
+</beans>


### PR DESCRIPTION
Should fix the tests and there was an actual bug outside of tests which caused problems. Two new tests for better testing. Previous commit disabling some testing code in master should be reverted.
