### PR TITLE
SHDP-200 Change test timeouts, junit and hamcrest changes.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -77,7 +77,7 @@ cglibVersion = 2.2.2
 cascadingVersion = 2.1.4
 
 # Common testing libraries
-junitVersion = 4.8.2
+junitVersion = 4.11
 mockitoVersion = 1.8.5
 groovyVersion = 1.8.5
 jrubyVersion = 1.6.5.1
@@ -85,7 +85,7 @@ jythonVersion = 2.5.2
 antlrVersion = 3.4
 dataNucleusVersion = 2.0.3
 thriftVersion = 0.5.0
-hamcrestVersion = 1.2.1
+hamcrestVersion = 1.3
 
 # --------------------
 # Project wide version


### PR DESCRIPTION
Adding better asserts and modifying app running timeout from
60 sec to 120 sec.

Change junit from 4.8.2 to 4.11 and hamcrest from 1.2.1
to 1.3. This works better and removes bundled hamcrest
classes in junit which is messing with a classpath.
