### PR TITLE
SHDP-221 Add profile support for testing with minicluster

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -833,6 +833,7 @@ if (gradle.ext.mr2) {
 			compile("org.apache.hadoop:hadoop-common:$hadoopVersion") { dep ->
 				exclude module: "junit"
 			}
+			testCompile project(":spring-yarn:spring-yarn-test-core")
 			testCompile("org.mockito:mockito-core:$mockitoVersion") { dep ->
 				exclude group: "org.hamcrest"
 			}
@@ -856,6 +857,9 @@ if (gradle.ext.mr2) {
 				projProps.each { k,v ->
 						if (k.toString().startsWith("hd.")) {
 							systemProperties[k] = projProps[k]
+						}
+						if (k.toString().equals("profiles")) {
+							systemProperties['spring.profiles.active'] = projProps[k]
 						}
 				}
 			}

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/client/ClientRmTemplateTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/client/ClientRmTemplateTests.java
@@ -34,6 +34,8 @@ import org.junit.runner.RunWith;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.yarn.rpc.YarnRpcCallback;
+import org.springframework.yarn.test.context.MiniYarnCluster;
+import org.springframework.yarn.test.context.YarnDelegatingSmartContextLoader;
 
 /**
  * Tests for {@link ClientRmTemplate}.
@@ -42,7 +44,8 @@ import org.springframework.yarn.rpc.YarnRpcCallback;
  *
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration
+@ContextConfiguration(loader=YarnDelegatingSmartContextLoader.class)
+@MiniYarnCluster
 public class ClientRmTemplateTests {
 
 	@Resource(name = "yarnClientRmTemplate")

--- a/spring-yarn/spring-yarn-core/src/test/resources/org/springframework/yarn/client/ClientRmTemplateTests-context.xml
+++ b/spring-yarn/spring-yarn-core/src/test/resources/org/springframework/yarn/client/ClientRmTemplateTests-context.xml
@@ -8,15 +8,13 @@
 		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
 		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
-	<context:property-placeholder location="hadoop.properties"/>
-
-	<yarn:configuration>
-	  fs.default.name=${hd.fs}
-	  yarn.resourcemanager.address=${hd.rm}
-	</yarn:configuration>
-
 	<bean id="yarnClientRmTemplate" class="org.springframework.yarn.client.ClientRmTemplate">
 		<constructor-arg index="0"><ref bean="yarnConfiguration"/></constructor-arg>
 	</bean>
+
+	<beans profile="nominicluster">
+		<context:property-placeholder location="hadoop.properties"/>
+		<yarn:configuration fs-uri="${hd.fs}" rm-address="${hd.rm}"/>
+	</beans>
 
 </beans>

--- a/spring-yarn/spring-yarn-test-core/src/main/java/org/springframework/yarn/test/YarnTestSystemConstants.java
+++ b/spring-yarn/spring-yarn-test-core/src/main/java/org/springframework/yarn/test/YarnTestSystemConstants.java
@@ -25,14 +25,17 @@ public class YarnTestSystemConstants {
 
 	/** Base hdfs path for tests. */
 	public static final String HDFS_TESTS_BASE_PATH = "/syarn/";
-	
+
 	/** Default bean id for mini yarn cluster. */
 	public static final String DEFAULT_ID_MINIYARNCLUSTER = "yarnCluster";
-	
+
 	/** Default bean id for mini yarn cluster configured configuration. */
 	public static final String DEFAULT_ID_MINIYARNCLUSTER_CONFIG = "yarnConfiguration";
 
 	/** Default id for mini yarn cluster. */
 	public static final String DEFAULT_ID_CLUSTER = "default";
-	
+
+	/** Default id for no minicluster profile. */
+	public static final String PROFILE_ID_NOMINICLUSTER = "nominicluster";
+
 }

--- a/spring-yarn/spring-yarn-test-core/src/main/java/org/springframework/yarn/test/context/YarnClusterInjectingAnnotationConfigContextLoader.java
+++ b/spring-yarn/spring-yarn-test-core/src/main/java/org/springframework/yarn/test/context/YarnClusterInjectingAnnotationConfigContextLoader.java
@@ -15,27 +15,39 @@
  */
 package org.springframework.yarn.test.context;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.test.context.MergedContextConfiguration;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.yarn.test.YarnTestSystemConstants;
 
 /**
- * Extending generic annotation based context loader able to 
+ * Extending generic annotation based context loader able to
  * manage and inject Yarn mini clusters. This loader is
  * used from {@link YarnDelegatingSmartContextLoader}.
- * 
+ *
  * @author Janne Valkealahti
  *
  */
 public class YarnClusterInjectingAnnotationConfigContextLoader extends AnnotationConfigContextLoader {
 
+	private final static Log log = LogFactory.getLog(YarnClusterInjectingAnnotationConfigContextLoader.class);
+
 	@Override
 	protected void loadBeanDefinitions(GenericApplicationContext context,
 			MergedContextConfiguration mergedConfig) {
 
+		String[] activeProfiles = context.getEnvironment().getActiveProfiles();
+		log.info("Active profiles: " + StringUtils.arrayToCommaDelimitedString(activeProfiles));
+
 		// let parent do its magic
-		super.loadBeanDefinitions(context, mergedConfig);		
-		YarnClusterInjectUtils.handleClusterInject(context, mergedConfig);
+		super.loadBeanDefinitions(context, mergedConfig);
+		if (!ObjectUtils.containsElement(activeProfiles, YarnTestSystemConstants.PROFILE_ID_NOMINICLUSTER)) {
+			YarnClusterInjectUtils.handleClusterInject(context, mergedConfig);
+		}
 	}
-	
+
 }

--- a/spring-yarn/spring-yarn-test-core/src/main/java/org/springframework/yarn/test/context/YarnClusterInjectingXmlContextLoader.java
+++ b/spring-yarn/spring-yarn-test-core/src/main/java/org/springframework/yarn/test/context/YarnClusterInjectingXmlContextLoader.java
@@ -15,27 +15,39 @@
  */
 package org.springframework.yarn.test.context;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.test.context.MergedContextConfiguration;
 import org.springframework.test.context.support.GenericXmlContextLoader;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.yarn.test.YarnTestSystemConstants;
 
 /**
- * Extending generic xml based context loader able to 
+ * Extending generic xml based context loader able to
  * manage and inject Yarn mini clusters. This loader is
  * used from {@link YarnDelegatingSmartContextLoader}.
- * 
+ *
  * @author Janne Valkealahti
  *
  */
 public class YarnClusterInjectingXmlContextLoader extends GenericXmlContextLoader {
-	
+
+	private final static Log log = LogFactory.getLog(YarnClusterInjectingXmlContextLoader.class);
+
 	@Override
 	protected void loadBeanDefinitions(GenericApplicationContext context,
 			MergedContextConfiguration mergedConfig) {
 
+		String[] activeProfiles = context.getEnvironment().getActiveProfiles();
+		log.info("Active profiles: " + StringUtils.arrayToCommaDelimitedString(activeProfiles));
+
 		// let parent do its magic
 		super.loadBeanDefinitions(context, mergedConfig);
-		YarnClusterInjectUtils.handleClusterInject(context, mergedConfig);
+		if (!ObjectUtils.containsElement(activeProfiles, YarnTestSystemConstants.PROFILE_ID_NOMINICLUSTER)) {
+			YarnClusterInjectUtils.handleClusterInject(context, mergedConfig);
+		}
 	}
 
 }


### PR DESCRIPTION
Modify testing system to intercept minicluster handling by
checking if "nominicluster" profile is activated. From
there a context configuration can choose to add normal
configuation as seen below.

<beans profile="nominicluster">
  <context:property-placeholder location="hadoop.properties"/>
  <yarn:configuration fs-uri="${hd.fs}" rm-address="${hd.rm}"/>
</beans>

gradle build and test can be used with -Pprofiles option.
-Pprofiles="nominicluster"
