### PR TITLE
SHDP-238 Fix store file naming with codec

### DIFF
--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/support/OutputStoreObjectSupport.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/support/OutputStoreObjectSupport.java
@@ -58,9 +58,7 @@ public abstract class OutputStoreObjectSupport extends StoreObjectSupport {
     public OutputStoreObjectSupport(Configuration configuration, Path basePath, CodecInfo codec) {
         super(configuration, basePath, codec);
         this.outputContext = new OutputContext();
-        if (codec != null && outputContext != null) {
-            outputContext.setCodecInfo(codec);
-        }
+        this.outputContext.setCodecInfo(codec);
     }
 
     /**
@@ -80,6 +78,7 @@ public abstract class OutputStoreObjectSupport extends StoreObjectSupport {
      */
     public void setFileNamingStrategy(FileNamingStrategy fileNamingStrategy) {
         outputContext.setFileNamingStrategy(fileNamingStrategy);
+        outputContext.setCodecInfo(getCodec());
     }
 
     /**

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TextFileStoreTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TextFileStoreTests.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.springframework.data.hadoop.store.codec.Codecs;
 import org.springframework.data.hadoop.store.input.TextFileReader;
 import org.springframework.data.hadoop.store.output.TextFileWriter;
+import org.springframework.data.hadoop.store.strategy.naming.CodecFileNamingStrategy;
 import org.springframework.data.hadoop.store.strategy.naming.RollingFileNamingStrategy;
 import org.springframework.data.hadoop.store.strategy.rollover.SizeRolloverStrategy;
 
@@ -75,6 +76,18 @@ public class TextFileStoreTests extends AbstractStoreTests {
 
 		TextFileReader reader = new TextFileReader(testConfig, testDefaultPath,
 				Codecs.BZIP2.getCodecInfo());
+		TestUtils.readDataAndAssert(reader, DATA09ARRAY);
+	}
+
+	@Test
+	public void testWriteReadManyLinesWithGzipWithCodecNaming() throws IOException {
+		TextFileWriter writer = new TextFileWriter(testConfig, testDefaultPath,
+				Codecs.GZIP.getCodecInfo());
+		writer.setFileNamingStrategy(new CodecFileNamingStrategy());
+		TestUtils.writeData(writer, DATA09ARRAY);
+
+		TextFileReader reader = new TextFileReader(testConfig, testDefaultPath.suffix(".gzip"),
+				Codecs.GZIP.getCodecInfo());
 		TestUtils.readDataAndAssert(reader, DATA09ARRAY);
 	}
 


### PR DESCRIPTION
File name is now set if codec is used together with
CodecFileNamingStrategy. Also added a simple
test case to verify this behaviour.
