### PR TITLE
SHDP-239 Add support for reading/writing delimited fields

### DIFF
--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/input/DelimitedTextFileReader.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/input/DelimitedTextFileReader.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.hadoop.store.input;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.springframework.data.hadoop.store.DataStoreReader;
+import org.springframework.data.hadoop.store.codec.CodecInfo;
+import org.springframework.data.hadoop.store.support.StoreUtils;
+import org.springframework.util.StringUtils;
+
+/**
+ * A {@code DelimitedTextFileReader} is a {@code DataStoreReader} implementation
+ * able to read {@code String}s from a raw hdfs files as delimited fields.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class DelimitedTextFileReader implements DataStoreReader<List<String>> {
+
+	/** CSV Mode */
+    public final static byte[] CSV = StoreUtils.getUTF8CsvDelimiter();
+
+    /** TAB Mode */
+    public final static byte[] TAB = StoreUtils.getUTF8TabDelimiter();
+
+    /** Underlying text writer */
+	private TextFileReader textFileReader;
+
+	/** Field delimiter */
+    private final String fieldDelimiter;
+
+	/**
+	 * Instantiates a new delimited text file reader.
+	 *
+	 * @param configuration the configuration
+	 * @param basePath the base path
+	 * @param codec the codec
+	 */
+	public DelimitedTextFileReader(Configuration configuration, Path basePath, CodecInfo codec) {
+		this(configuration, basePath, codec, CSV, null);
+	}
+
+	/**
+	 * Instantiates a new delimited text file reader.
+	 *
+	 * @param configuration the configuration
+	 * @param basePath the base path
+	 * @param codec the codec
+	 * @param fieldDelimiter the field delimiter
+	 */
+	public DelimitedTextFileReader(Configuration configuration, Path basePath, CodecInfo codec, byte[] fieldDelimiter) {
+		this(configuration, basePath, codec, fieldDelimiter, null);
+	}
+
+	/**
+	 * Instantiates a new delimited text file reader.
+	 *
+	 * @param configuration the configuration
+	 * @param basePath the base path
+	 * @param codec the codec
+	 * @param fieldDelimiter the field delimiter
+	 * @param textDelimiter the text delimiter
+	 */
+	public DelimitedTextFileReader(Configuration configuration, Path basePath, CodecInfo codec, byte[] fieldDelimiter, byte[] textDelimiter) {
+		this.fieldDelimiter = new String(fieldDelimiter);
+		this.textFileReader = new TextFileReader(configuration, basePath, codec, textDelimiter);
+	}
+
+	@Override
+	public List<String> read() throws IOException {
+		String line = textFileReader.read();
+		return StringUtils.hasText(line) ? Arrays.asList(line.split(fieldDelimiter)) : null;
+	}
+
+	@Override
+	public void close() throws IOException {
+		textFileReader.close();
+	}
+
+}

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/input/TextFileReader.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/input/TextFileReader.java
@@ -40,6 +40,8 @@ public class TextFileReader extends AbstractDataStreamReader implements DataStor
 
 	private LineReader lineReader;
 
+	private final byte[] delimiter;
+
 	/**
 	 * Instantiates a new text file reader.
 	 *
@@ -48,7 +50,20 @@ public class TextFileReader extends AbstractDataStreamReader implements DataStor
 	 * @param codec the compression codec info
 	 */
 	public TextFileReader(Configuration configuration, Path basePath, CodecInfo codec) {
+		this(configuration, basePath, codec, null);
+	}
+
+	/**
+	 * Instantiates a new text file reader.
+	 *
+	 * @param configuration the configuration
+	 * @param basePath the base path
+	 * @param codec the codec
+	 * @param delimiter the delimiter
+	 */
+	public TextFileReader(Configuration configuration, Path basePath, CodecInfo codec, byte[] delimiter) {
 		super(configuration, basePath, codec);
+		this.delimiter = delimiter;
 	}
 
 	@Override
@@ -66,7 +81,7 @@ public class TextFileReader extends AbstractDataStreamReader implements DataStor
 	public String read() throws IOException {
 		if (streamsHolder == null) {
 			streamsHolder = getInput(getPath());
-			lineReader = new LineReader(streamsHolder.getStream());
+			lineReader = new LineReader(streamsHolder.getStream(), delimiter);
 		}
 		Text text = new Text();
 		lineReader.readLine(text);

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/DelimitedTextFileWriter.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/DelimitedTextFileWriter.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.hadoop.store.output;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.springframework.data.hadoop.store.DataStoreWriter;
+import org.springframework.data.hadoop.store.codec.CodecInfo;
+import org.springframework.data.hadoop.store.support.StoreUtils;
+
+/**
+ * A {@code DelimitedTextFileWriter} is a {@code DataStoreWriter} implementation
+ * able to write {@code String}s into raw hdfs files as delimited fields.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class DelimitedTextFileWriter implements DataStoreWriter<List<String>> {
+
+	/** CSV Mode */
+    public final static byte[] CSV = StoreUtils.getUTF8CsvDelimiter();
+
+    /** TAB Mode */
+    public final static byte[] TAB = StoreUtils.getUTF8TabDelimiter();
+
+    /** Underlying text writer */
+	private TextFileWriter textFileWriter;
+
+	/** Field delimiter */
+    private final String fieldDelimiter;
+
+	/**
+	 * Instantiates a new delimited text file writer.
+	 *
+	 * @param configuration the configuration
+	 * @param basePath the base path
+	 * @param codec the codec
+	 */
+	public DelimitedTextFileWriter(Configuration configuration, Path basePath, CodecInfo codec) {
+		this(configuration, basePath, codec, CSV);
+	}
+
+	/**
+	 * Instantiates a new delimited text file writer.
+	 *
+	 * @param configuration the configuration
+	 * @param basePath the base path
+	 * @param codec the codec
+	 * @param fieldDelimiter the field delimiter
+	 */
+	public DelimitedTextFileWriter(Configuration configuration, Path basePath, CodecInfo codec, byte[] fieldDelimiter) {
+		this.fieldDelimiter = new String(fieldDelimiter);
+		this.textFileWriter = new TextFileWriter(configuration, basePath, codec);
+	}
+
+	/**
+	 * Instantiates a new delimited text file writer.
+	 *
+	 * @param configuration the configuration
+	 * @param basePath the base path
+	 * @param codec the codec
+	 * @param fieldDelimiter the field delimiter
+	 * @param textDelimiter the text delimiter
+	 */
+	public DelimitedTextFileWriter(Configuration configuration, Path basePath, CodecInfo codec, byte[] fieldDelimiter, byte[] textDelimiter) {
+		this.fieldDelimiter = new String(fieldDelimiter);
+		this.textFileWriter = new TextFileWriter(configuration, basePath, codec, textDelimiter);
+	}
+
+	@Override
+	public void write(final List<String> entity) throws IOException {
+		StringBuilder buf = new StringBuilder();
+		for (int i = 0; i < entity.size(); i++) {
+			buf.append(entity.get(i));
+			if (i < (entity.size() - 1)) {
+				buf.append(fieldDelimiter);
+			}
+		}
+		textFileWriter.write(buf.toString());
+	}
+
+	@Override
+	public void flush() throws IOException {
+		textFileWriter.flush();
+	}
+
+	@Override
+	public void close() throws IOException {
+		textFileWriter.close();
+	}
+
+}

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/DelimitedTextFileStoreTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/DelimitedTextFileStoreTests.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.hadoop.store;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+import org.springframework.data.hadoop.store.input.DelimitedTextFileReader;
+import org.springframework.data.hadoop.store.output.DelimitedTextFileWriter;
+
+public class DelimitedTextFileStoreTests extends AbstractStoreTests {
+
+	@Test
+	public void testWriteReadTextOneDelimitedLine() throws IOException {
+
+		List<List<String>> data = new ArrayList<List<String>>();
+		data.add(Arrays.asList(DATA09ARRAY));
+
+		DelimitedTextFileWriter writer = new DelimitedTextFileWriter(testConfig, testDefaultPath, null);
+		TestUtils.writeData(writer, data);
+
+		DelimitedTextFileReader reader = new DelimitedTextFileReader(testConfig, testDefaultPath, null);
+		List<List<String>> list = TestUtils.readDataList(reader);
+		assertThat(list, notNullValue());
+		assertThat(list.size(), is(1));
+		assertThat(list.get(0).size(), is(10));
+	}
+
+	@Test
+	public void testWriteReadTextManyDelimitedLine() throws IOException {
+
+		List<List<String>> data = new ArrayList<List<String>>();
+		data.add(Arrays.asList(DATA09ARRAY));
+		data.add(Arrays.asList(DATA09ARRAY));
+		data.add(Arrays.asList(DATA09ARRAY));
+
+		DelimitedTextFileWriter writer = new DelimitedTextFileWriter(testConfig, testDefaultPath, null);
+		TestUtils.writeData(writer, data);
+
+		DelimitedTextFileReader reader = new DelimitedTextFileReader(testConfig, testDefaultPath, null);
+		List<List<String>> list = TestUtils.readDataList(reader);
+		assertThat(list, notNullValue());
+		assertThat(list.size(), is(3));
+		assertThat(list.get(0).size(), is(10));
+		assertThat(list.get(1).size(), is(10));
+		assertThat(list.get(2).size(), is(10));
+	}
+
+}

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TestUtils.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TestUtils.java
@@ -32,6 +32,20 @@ import java.util.List;
  */
 public abstract class TestUtils {
 
+	public static void writeData(DataStoreWriter<List<String>> writer, List<List<String>> data) throws IOException {
+		writeData(writer, data, true);
+	}
+
+	public static void writeData(DataStoreWriter<List<String>> writer, List<List<String>> data, boolean close) throws IOException {
+		for (List<String> d : data) {
+			writer.write(d);
+		}
+		writer.flush();
+		if (close) {
+			writer.close();
+		}
+	}
+
 	public static void writeData(DataStoreWriter<String> writer, String[] data) throws IOException {
 		writeData(writer, data, true);
 	}
@@ -67,5 +81,13 @@ public abstract class TestUtils {
 		return ret;
 	}
 
+	public static List<List<String>> readDataList(DataStoreReader<List<String>> reader) throws IOException {
+		List<List<String>> ret = new ArrayList<List<String>>();
+		List<String> line = null;
+		while ((line = reader.read()) != null) {
+			ret.add(line);
+		}
+		return ret;
+	}
 
 }


### PR DESCRIPTION
This is now meant to write and read csv, tab or some other
custom data where fields are also delimited.

For example DelimitedTextFileWriter is using existing TextFileWriter
and just adds logic for delimiting of fields.
