### PR TITLE
SHDP-242 Added test for rolling by size with a codec

### DIFF
--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TextFileStoreTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TextFileStoreTests.java
@@ -113,4 +113,28 @@ public class TextFileStoreTests extends AbstractStoreTests {
 		assertThat(splitData1.size() + splitData2.size() + splitData3.size(), is(DATA09ARRAY.length));
 	}
 
+	@Test
+	public void testWriteReadManyLinesWithNamingAndRolloverWithGzip() throws IOException {
+
+		TextFileWriter writer = new TextFileWriter(testConfig, testDefaultPath, Codecs.GZIP.getCodecInfo());
+		writer.setFileNamingStrategy(new RollingFileNamingStrategy());
+		writer.setRolloverStrategy(new SizeRolloverStrategy(40));
+
+		// codec is buffering so we need to write some amount of
+		// data before anything is actually written into a file/stream
+		// writing same data over and over again is compressing a lot
+		for (int i = 0; i<45000; i++) {
+			TestUtils.writeData(writer, DATA09ARRAY, false);
+		}
+		TestUtils.writeData(writer, DATA09ARRAY, true);
+
+		TextFileReader reader1 = new TextFileReader(testConfig, testDefaultPath.suffix("0"), Codecs.GZIP.getCodecInfo());
+		List<String> splitData1 = TestUtils.readData(reader1);
+
+		TextFileReader reader2 = new TextFileReader(testConfig, testDefaultPath.suffix("1"), Codecs.GZIP.getCodecInfo());
+		List<String> splitData2 = TestUtils.readData(reader2);
+
+		assertThat(splitData1.size() + splitData2.size(), is(450010));
+	}
+
 }

--- a/spring-hadoop-store/src/test/resources/log4j.properties
+++ b/spring-hadoop-store/src/test/resources/log4j.properties
@@ -4,4 +4,4 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} %5p %40.40c:%4L - %m%n
 
-log4j.category.org.springframework.data.hadoop.store=DEBUG
+log4j.category.org.springframework.data.hadoop.store=INFO


### PR DESCRIPTION
Rolling with codec is not actually broken, instead we just
need to write some amount of data before anything is actually
written in a stream/file. This is due to internal
buffering in hadoop codecs.

Also removed debug from a log4j for tests.
