### PR TITLE
SHDP-251 Add snake yaml dependency to boot

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1043,6 +1043,7 @@ if (gradle.ext.mr2) {
 			compile project(":spring-yarn:spring-yarn-core")
 			provided project(":spring-yarn:spring-yarn-batch")
 			compile "org.springframework.boot:spring-boot-autoconfigure:$springBootVersion"
+			runtime "org.yaml:snakeyaml:$snakeYamlVersion"
 		}
 	}
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -72,6 +72,7 @@ jackson2Version = 2.1.4
 commonsioVersion = 2.1
 cglibVersion = 2.2.2
 cascadingVersion = 2.1.4
+snakeYamlVersion = 1.12
 
 ## Common testing libraries
 junitVersion = 4.11


### PR DESCRIPTION
Adding runtime dependency to snake yaml for
spring-yarn-boot. This is anyway needed so
user doesn't need to handle this manually in
gradle or maven build file.
