### PR TITLE
SHDP-268 Updating build to use 2.2.0 as default Hadoop distro

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ defaultTasks 'build'
 
 buildscript {
 	repositories {
-		maven { url "http://repo.springsource.org/plugins-release" }
-		maven { url "http://repo.springsource.org/plugins-milestone" }
+		maven { url "http://repo.spring.io/plugins-release" }
+		maven { url "http://repo.spring.io/plugins-milestone" }
 	}
 	dependencies {
 		classpath("org.springframework.boot:spring-boot-gradle-plugin:$springBootVersion")
@@ -19,7 +19,7 @@ allprojects {
 
 	repositories {
 		mavenCentral()
-		maven { url 'http://repo.springsource.org/libs-milestone' }
+		maven { url 'http://repo.spring.io/libs-milestone' }
 	}
 }
 
@@ -46,9 +46,9 @@ println "Using Spring Framework version: [$springVersion]"
 //
 def List hadoopArtifacts = []
 def List hadoopTestArtifacts = []
-def hadoopDefault = "hadoop12"
+def hadoopDefault = "hadoop22"
 def hadoopDistro = project.hasProperty("distro") ? project.getProperty("distro") : hadoopDefault
-def hadoopVersion = hd12Version
+def hadoopVersion = hd22Version
 
 // Common Hadoop libraries
 def hiveVersion = defaultHiveVersion
@@ -62,7 +62,7 @@ def pigQualifier = ''
 // handle older Hive version
 def hiveGroup = "org.apache.hive"
 
-// default is Hadoop 1.2.x
+// default is Hadoop 2.2.x
 switch (hadoopDistro) {
 
 	// Cloudera CDH5 YARN 2.2.x base
@@ -90,7 +90,7 @@ switch (hadoopDistro) {
 					"org.apache.hadoop:hadoop-mapreduce-client-hs:$hadoopVersion",
 					"org.apache.hadoop:hadoop-yarn-server-tests:$hadoopVersion",
 					"org.apache.hadoop:hadoop-yarn-server-tests:$hadoopVersion:tests"]
-		break;	
+		break;
 
 	// Cloudera CDH5 MR1
 	case "cdh5mr1":
@@ -212,10 +212,35 @@ switch (hadoopDistro) {
 		thriftVersion = hdp20ThriftVersion
 		break;
 
-	// Hadoop 2.2 GA
-	case "hadoop22":
+	// Hadoop 1.2.x Stable
+	case "hadoop12":
+		hadoopVersion = hd12Version
+		println "Using Apache Hadoop 1.2.x [$hadoopVersion]"
+		hadoopArtifacts = ["org.apache.hadoop:hadoop-streaming:$hadoopVersion",
+				   "org.apache.hadoop:hadoop-tools:$hadoopVersion"]
+		hadoopTestArtifacts = ["org.apache.hadoop:hadoop-test:$hadoopVersion"]
+		hbaseVersion = hd12HbaseVersion
+		hbaseArtifacts = ["org.apache.hbase:hbase:$hbaseVersion"]
+		hiveVersion = hd12HiveVersion
+		pigVersion = hd12PigVersion
+		thriftVersion = hd12ThriftVersion
+		break;
+
+	// Hadoop 2.2.x Stable
+	default:
+		if (!project.hasProperty("distro")) {
+			println "Using default distro: Apache Hadoop [$hadoopVersion]"
+		} else {
+			if (hadoopDistro == hadoopDefault) {
+				println "Using Apache Hadoop 2.2 - [$hadoopVersion]"
+			} else {
+				println "Failing build: $hadoopDistro is not a supported distro"
+				println "Supported distros: hadoop12, hadoop22[*], hdp13, hdp20, cdh4, cdh4yarn, cdh5, cdh5mr1 and phd1"
+				println "* default"
+				throw new InvalidUserDataException("$hadoopDistro is not a supported distro")
+			}
+		}
 		hadoopVersion = hd22Version
-		println "Using Apache Hadoop 2.2 - [$hadoopVersion]"
 		hadoopArtifacts = ["org.apache.hadoop:hadoop-common:$hadoopVersion",
 				   "org.apache.hadoop:hadoop-hdfs:$hadoopVersion",
 				   "org.apache.hadoop:hadoop-mapreduce-client-core:$hadoopVersion",
@@ -237,30 +262,6 @@ switch (hadoopDistro) {
 		pigVersion = hd22PigVersion
 		pigQualifier = ':h2'
 		thriftVersion = hd22ThriftVersion
-		break;
-
-	default:
-		if (!project.hasProperty("distro")) {
-			println "Using default distro: Apache Hadoop [$hadoopVersion]"
-		} else {
-			if (hadoopDistro == hadoopDefault) {
-				println "Using Apache Hadoop 1.2.x [$hadoopVersion]"
-			} else {
-				println "Failing build: $hadoopDistro is not a supported distro"
-				println "Supported distros: hadoop11, hadoop12[*], hadoop22, hdp13, hdp20, cdh4, cdh4yarn, cdh5, cdh5mr1 and phd1"
-				println "* default"
-				throw new InvalidUserDataException("$hadoopDistro is not a supported distro")
-			}
-		}
-		hadoopVersion = hd12Version
-		hadoopArtifacts = ["org.apache.hadoop:hadoop-streaming:$hadoopVersion",
-				   "org.apache.hadoop:hadoop-tools:$hadoopVersion"]
-		hadoopTestArtifacts = ["org.apache.hadoop:hadoop-test:$hadoopVersion"]
-		hbaseVersion = hd12HbaseVersion
-		hbaseArtifacts = ["org.apache.hbase:hbase:$hbaseVersion"]
-		hiveVersion = hd12HiveVersion
-		pigVersion = hd12PigVersion
-		thriftVersion = hd12ThriftVersion
 }
 
 configure(javaProjects()) {
@@ -303,6 +304,7 @@ configure(javaProjects()) {
 		compile "org.springframework:spring-context-support:$springVersion"
 		compile "org.springframework:spring-jdbc:$springVersion"
 		compile "org.springframework:spring-tx:$springVersion"
+		testRuntime "com.google.guava:guava:$guavaVersion"
 	}
 
 	task sourcesJar(type: Jar) {
@@ -399,7 +401,7 @@ configure(javaProjects()) {
 
 configure(hadoopProjects()) {
 
-	// default is Hadoop 1.2.x
+	// default is Hadoop 2.2.x
 	switch (hadoopDistro) {
 
 		// Cloudera CDH5 YARN
@@ -458,7 +460,7 @@ configure(hadoopProjects()) {
 			}
 			break;	
 
-		// Pivotal HD 2.0
+		// Pivotal HD 1.0
 		case "phd1":
 			dependencies {
 				compile "org.apache.hive:hive-common:$hiveVersion"
@@ -487,25 +489,19 @@ configure(hadoopProjects()) {
 			}
 			break;
 
-		// Hadoop 2.2 GA
-		case "hadoop22":
+		// Hadoop 1.2.x Stable
+		case "hadoop12":
 			dependencies {
-				testCompile "org.apache.hadoop:hadoop-mapreduce-examples:$hadoopVersion"
-				testRuntime "org.apache.hadoop:hadoop-mapreduce-client-jobclient:$hadoopVersion"
+				testCompile "org.apache.hadoop:hadoop-examples:$hadoopVersion"
 				testRuntime "dk.brics.automaton:automaton:1.11-8"
 			}
 			break;
 
-		// Hadoop 1.1.x
-		case "hadoop11":
-			dependencies {
-				testCompile "org.apache.hadoop:hadoop-examples:$hadoopVersion"
-			}
-			break;
-
+		// Hadoop 2.2.x Stable
 		default:
 			dependencies {
-				testCompile "org.apache.hadoop:hadoop-examples:$hadoopVersion"
+				testCompile "org.apache.hadoop:hadoop-mapreduce-examples:$hadoopVersion"
+				testRuntime "org.apache.hadoop:hadoop-mapreduce-client-jobclient:$hadoopVersion"
 				testRuntime "dk.brics.automaton:automaton:1.11-8"
 			}
 	}
@@ -726,7 +722,7 @@ project('spring-data-hadoop-store') {
 	description = 'Spring for Apache Hadoop Store Features'
 
 	dependencies {
-		compile "org.kitesdk:kite-data-core:0.10.1"
+		compile "org.kitesdk:kite-data-core:$kiteVersion"
 		testCompile project(":spring-data-hadoop")
 		testCompile project(path:":spring-hadoop-test-core", configuration:"testArtifacts")
 		testCompile "org.springframework:spring-test:$springVersion"

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,21 +25,21 @@ phd1PigVersion = 0.10.1-gphd-2.1.0.0
 phd1ThriftVersion = 0.9.0
 
 ## Cloudera CDH5
-cdh5Version = 2.2.0-cdh5.0.0-beta-1
-cdh5MR1Version = 2.2.0-mr1-cdh5.0.0-beta-1
-cdh5YARNVersion = 2.2.0-cdh5.0.0-beta-1
-cdh5HbaseVersion = 0.95.2-cdh5.0.0-beta-1
-cdh5HiveVersion = 0.11.0-cdh5.0.0-beta-1
-cdh5PigVersion = 0.11.0-cdh5.0.0-beta-1
+cdh5Version = 2.2.0-cdh5.0.0-beta-2
+cdh5MR1Version = 2.2.0-mr1-cdh5.0.0-beta-2
+cdh5YARNVersion = 2.2.0-cdh5.0.0-beta-2
+cdh5HbaseVersion = 0.96.1.1-cdh5.0.0-beta-2
+cdh5HiveVersion = 0.12.0-cdh5.0.0-beta-2
+cdh5PigVersion = 0.12.0-cdh5.0.0-beta-2
 cdh5ThriftVersion = 0.9.0
 
 ## Cloudera CDH4
-cdh4Version = 2.0.0-cdh4.3.1
-cdh4MR1Version = 2.0.0-mr1-cdh4.3.1
-cdh4YARNVersion = 2.0.0-cdh4.3.1
-cdh4HbaseVersion = 0.94.6-cdh4.3.1
-cdh4HiveVersion = 0.10.0-cdh4.3.1
-cdh4PigVersion = 0.11.0-cdh4.3.1
+cdh4Version = 2.0.0-cdh4.5.0
+cdh4MR1Version = 2.0.0-mr1-cdh4.5.0
+cdh4YARNVersion = 2.0.0-cdh4.5.0
+cdh4HbaseVersion = 0.94.6-cdh4.5.0
+cdh4HiveVersion = 0.10.0-cdh4.5.0
+cdh4PigVersion = 0.11.0-cdh4.5.0
 cdh4ThriftVersion = 0.9.0
 
 ## Hortonworks Data Platform 1.3
@@ -62,17 +62,19 @@ defaultPigVersion = 0.10.1
 defaultHbaseVersion = 0.94.11
 
 ## Common libraries
-spring3Version = 3.2.6.RELEASE
-spring4Version = 4.0.0.RELEASE
+spring3Version = 3.2.7.RELEASE
+spring4Version = 4.0.1.RELEASE
 springBatchVersion = 2.2.3.RELEASE
 springBootVersion = 1.0.0.RC1
-springIntVersion = 3.0.0.RELEASE
+springIntVersion = 3.0.1.RELEASE
 jacksonVersion = 1.8.8
 jackson2Version = 2.1.4
 commonsioVersion = 2.1
 cglibVersion = 2.2.2
-cascadingVersion = 2.1.4
+cascadingVersion = 2.5.2
 snakeYamlVersion = 1.12
+guavaVersion = 14.0.1
+kiteVersion = 0.11.0
 
 ## Common testing libraries
 junitVersion = 4.11

--- a/settings.gradle
+++ b/settings.gradle
@@ -28,14 +28,11 @@ switch (ext.hadoopDistro) {
 	case "hdp20":
 		ext.mr2 = true
 		break
-	case "hadoop22":
-		ext.mr2 = true
-		break
-	case "hadoop11":
+	case "hadoop12":
 		ext.mr2 = false
 		break
 	default:
-		ext.mr2 = false
+		ext.mr2 = true
 }
 
 gradle.ext.mr2 = mr2
@@ -55,6 +52,3 @@ if (mr2) {
   print "Based on selected distro (${hadoopDistro}) we are including spring-yarn\n"
   include 'spring-yarn:spring-yarn-core','spring-yarn:spring-yarn-integration','spring-yarn:spring-yarn-batch','spring-yarn:spring-yarn-test-core','spring-yarn:spring-yarn-test','spring-yarn:spring-yarn-boot','spring-yarn:spring-yarn-boot-test'
 }
-
-
-

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/DatasetRepositoryFactory.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/DatasetRepositoryFactory.java
@@ -64,7 +64,7 @@ public class DatasetRepositoryFactory implements InitializingBean {
 	public void afterPropertiesSet() throws Exception {
 		Assert.notNull(conf, "The configuration property is required");
 		this.repo = new FileSystemDatasetRepository.Builder()
-				.rootDirectory(new URI(basePath)).configuration(conf).get();
+				.rootDirectory(new URI(basePath)).configuration(conf).build();
 	}
 
 	/**

--- a/spring-hadoop-test/src/test/java/org/springframework/data/hadoop/fs/HftpFsShellTest.java
+++ b/spring-hadoop-test/src/test/java/org/springframework/data/hadoop/fs/HftpFsShellTest.java
@@ -16,8 +16,8 @@
 package org.springframework.data.hadoop.fs;
 
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.hdfs.HftpFileSystem;
 import org.junit.runner.RunWith;
+import org.springframework.data.hadoop.HadoopException;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -25,13 +25,36 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * Integration test for FsShell using the default file system.
  * 
  * @author Costin Leau
+ * @Thomas Risberg
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
 public class HftpFsShellTest extends AbstractROFsShellTest {
 
+	public static final String HFTP_FILESYSTEM_CLASS_NAME_FOR_V1_THRU_V2_2 =
+			"org.apache.hadoop.hdfs.HftpFileSystem";
+	public static final String HFTP_FILESYSTEM_CLASS_NAME_SINCE_V2_3 =
+			"org.apache.hadoop.hdfs.web.HftpFileSystem";
+
 	@Override
 	Class<? extends FileSystem> fsClass() {
-		return HftpFileSystem.class;
+		return getHftpFileSystemClass();
+	}
+
+	Class<? extends FileSystem> getHftpFileSystemClass() {
+		Class<? extends FileSystem> clazz = null;
+		try {
+			clazz = (Class<? extends FileSystem>) Class.forName(
+					HFTP_FILESYSTEM_CLASS_NAME_FOR_V1_THRU_V2_2);
+		} catch (ClassNotFoundException e) {
+			try {
+				clazz = (Class<? extends FileSystem>) Class.forName(
+						HFTP_FILESYSTEM_CLASS_NAME_SINCE_V2_3);
+			} catch (ClassNotFoundException e1) {
+				throw new HadoopException("HftpFileSystem class not available " +
+						e1.getMessage(), e1);
+			}
+		}
+		return clazz;
 	}
 }

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/allocate/AbstractPollingAllocator.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/allocate/AbstractPollingAllocator.java
@@ -222,7 +222,7 @@ public abstract class AbstractPollingAllocator extends AbstractAllocator {
 			String nodeId = token.getNodeId().toString();
 			if (log.isDebugEnabled()) {
 				log.info("Token from allocateResponse token=" + token);
-				if (tokenCache.containsNMToken(nodeId)) {
+				if (NMTokenCacheCompat.containsToken(tokenCache, nodeId)) {
 					log.debug("Replacing token for : " + nodeId);
 				} else {
 					log.debug("Received new token for : " + nodeId);

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/compat/NMTokenCacheCompat.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/compat/NMTokenCacheCompat.java
@@ -26,7 +26,7 @@ import org.springframework.util.ReflectionUtils;
  * Compat class for {@link NMTokenCache}.
  *
  * @author Janne Valkealahti
- *
+ * @Thomas Risberg
  */
 public class NMTokenCacheCompat {
 
@@ -69,4 +69,20 @@ public class NMTokenCacheCompat {
 		return nmTokenCache;
 	}
 
+	public static boolean containsToken(NMTokenCache nmTokenCache, String nodeId) {
+		if (nmTokenCache != null) {
+			Method method = ReflectionUtils.findMethod(NMTokenCache.class, "containsNMToken", String.class);
+			if (method == null) {
+				method = ReflectionUtils.findMethod(NMTokenCache.class, "containsToken", String.class);
+			}
+			if (method != null) {
+				boolean results = (Boolean)ReflectionUtils.invokeMethod(method, nmTokenCache, nodeId);
+				log.debug("NMTokenCache method " + method.getName() + " returned " + results);
+				return results;
+			} else {
+				log.debug("Unable to determine the name for 'containsToken' method on NMTokenCache class");
+			}
+		}
+		return false;
+	}
 }


### PR DESCRIPTION
- changing repository definitions to use http://repo.spring.io
- updating Cloudera CDH4 to cdh4.5.0
- updating Cloudera CDH5 to cdh5.0.0-beta-2
- updating Spring 3 version to 3.2.7.RELEASE
- updating Spring 4 version to 4.0.1.RELEASE
- updating Spring Integration version to 3.0.1.RELEASE
- updating Cascading version to 2.5.2
- updating Kite SDK version to 0.11.0
