### PR TITLE
SHDP-281 Composed annotation for minicluster tests

### DIFF
--- a/spring-yarn/spring-yarn-test-core/src/main/java/org/springframework/yarn/test/context/MetaAnnotationUtils.java
+++ b/spring-yarn/spring-yarn-test-core/src/main/java/org/springframework/yarn/test/context/MetaAnnotationUtils.java
@@ -1,0 +1,346 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.yarn.test.context;
+
+import java.lang.annotation.Annotation;
+
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.core.annotation.AnnotationAttributes;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.core.style.ToStringCreator;
+import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
+
+import static org.springframework.core.annotation.AnnotationUtils.*;
+
+/**
+ * {@code MetaAnnotationUtils} is a collection of utility methods that complements
+ * support already available in {@link AnnotationUtils}.
+ *
+ * <p>Whereas {@code AnnotationUtils} only provides utilities for <em>getting</em>
+ * or <em>finding</em> an annotation, {@code MetaAnnotationUtils} provides
+ * additional support for determining the <em>root class</em> on which an
+ * annotation is declared, either directly or via a <em>composed annotation</em>.
+ * This additional information is encapsulated in an {@link AnnotationDescriptor}.
+ *
+ * <p>The additional information provided by an {@code AnnotationDescriptor} is
+ * required in the <em>Spring TestContext Framework</em> in order to be able to
+ * support class hierarchy traversals for <em>inherited</em> annotations such as
+ * {@link ContextConfiguration @ContextConfiguration},
+ * {@link TestExecutionListeners @TestExecutionListeners}, and
+ * {@link ActiveProfiles @ActiveProfiles}.
+ *
+ * <p>NOTE: copied from spring-test due to it being package scoped
+ *
+ * @author Sam Brannen
+ * @author Janne Valkealahti
+ * @see AnnotationUtils
+ * @see AnnotationDescriptor
+ */
+abstract class MetaAnnotationUtils {
+
+	private MetaAnnotationUtils() {
+		/* no-op */
+	}
+
+	/**
+	 * Find the {@link AnnotationDescriptor} for the supplied {@code annotationType}
+	 * from the supplied {@link Class}, traversing its annotations and superclasses
+	 * if no annotation can be found on the given class itself.
+	 *
+	 * <p>This method explicitly handles class-level annotations which are not
+	 * declared as {@linkplain java.lang.annotation.Inherited inherited} <em>as
+	 * well as meta-annotations</em>.
+	 *
+	 * <p>The algorithm operates as follows:
+	 * <ol>
+	 *   <li>Search for a local declaration of the annotation on the given class
+	 *   and return a corresponding {@code AnnotationDescriptor} if found.
+	 *   <li>Search through all annotations that the given class declares,
+	 *   returning an {@code AnnotationDescriptor} for the first matching
+	 *   candidate, if any.
+	 *   <li>Proceed with introspection of the superclass hierarchy of the given
+	 *   class by returning to step #1 with the superclass as the class to look
+	 *   for annotations on.
+	 * </ol>
+	 *
+	 * <p>If the supplied {@code clazz} is an interface, only the interface
+	 * itself will be checked; the inheritance hierarchy for interfaces will not
+	 * be traversed.
+	 *
+	 * @param clazz the class to look for annotations on
+	 * @param annotationType the annotation class to look for, both locally and
+	 * as a meta-annotation
+	 * @return the corresponding annotation descriptor if the annotation was found;
+	 * otherwise {@code null}
+	 * @see AnnotationUtils#findAnnotationDeclaringClass(Class, Class)
+	 * @see #findAnnotationDescriptorForTypes(Class, Class...)
+	 */
+	public static <T extends Annotation> AnnotationDescriptor<T> findAnnotationDescriptor(Class<?> clazz,
+			Class<T> annotationType) {
+
+		Assert.notNull(annotationType, "Annotation type must not be null");
+
+		if (clazz == null || clazz.equals(Object.class)) {
+			return null;
+		}
+
+		// Declared locally?
+		if (isAnnotationDeclaredLocally(annotationType, clazz)) {
+			return new AnnotationDescriptor<T>(clazz, clazz.getAnnotation(annotationType));
+		}
+
+		// Declared on a composed annotation (i.e., as a meta-annotation)?
+		if (!Annotation.class.isAssignableFrom(clazz)) {
+			for (Annotation composedAnnotation : clazz.getAnnotations()) {
+				T annotation = composedAnnotation.annotationType().getAnnotation(annotationType);
+				if (annotation != null) {
+					return new AnnotationDescriptor<T>(clazz, composedAnnotation, annotation);
+				}
+			}
+		}
+
+		// Declared on a superclass?
+		return findAnnotationDescriptor(clazz.getSuperclass(), annotationType);
+	}
+
+	/**
+	 * Find the {@link UntypedAnnotationDescriptor} for the first {@link Class}
+	 * in the inheritance hierarchy of the specified {@code clazz} (including
+	 * the specified {@code clazz} itself) which declares at least one of the
+	 * specified {@code annotationTypes}, or {@code null} if none of the
+	 * specified annotation types could be found.
+	 *
+	 * <p>This method traverses the annotations and superclasses of the specified
+	 * {@code clazz} if no annotation can be found on the given class itself.
+	 *
+	 * <p>This method explicitly handles class-level annotations which are not
+	 * declared as {@linkplain java.lang.annotation.Inherited inherited} <em>as
+	 * well as meta-annotations</em>.
+	 *
+	 * <p>The algorithm operates as follows:
+	 * <ol>
+	 *   <li>Search for a local declaration of one of the annotation types on
+	 *   the given class and return a corresponding {@code UntypedAnnotationDescriptor}
+	 *   if found.
+	 *   <li>Search through all annotations that the given class declares,
+	 *   returning an {@code UntypedAnnotationDescriptor} for the first matching
+	 *   candidate, if any.
+	 *   <li>Proceed with introspection of the superclass hierarchy of the given
+	 *   class by returning to step #1 with the superclass as the class to look
+	 *   for annotations on.
+	 * </ol>
+	 *
+	 * <p>If the supplied {@code clazz} is an interface, only the interface
+	 * itself will be checked; the inheritance hierarchy for interfaces will not
+	 * be traversed.
+	 *
+	 * @param clazz the class to look for annotations on
+	 * @param annotationTypes the types of annotations to look for, both locally
+	 * and as meta-annotations
+	 * @return the corresponding annotation descriptor if one of the annotations
+	 * was found; otherwise {@code null}
+	 * @see AnnotationUtils#findAnnotationDeclaringClassForTypes(java.util.List, Class)
+	 * @see #findAnnotationDescriptor(Class, Class)
+	 */
+	public static UntypedAnnotationDescriptor findAnnotationDescriptorForTypes(Class<?> clazz,
+			Class<? extends Annotation>... annotationTypes) {
+
+		assertNonEmptyAnnotationTypeArray(annotationTypes, "The list of annotation types must not be empty");
+
+		if (clazz == null || clazz.equals(Object.class)) {
+			return null;
+		}
+
+		// Declared locally?
+		for (Class<? extends Annotation> annotationType : annotationTypes) {
+			if (isAnnotationDeclaredLocally(annotationType, clazz)) {
+				return new UntypedAnnotationDescriptor(clazz, clazz.getAnnotation(annotationType));
+			}
+		}
+
+		// Declared on a composed annotation (i.e., as a meta-annotation)?
+		if (!Annotation.class.isAssignableFrom(clazz)) {
+			for (Annotation composedAnnotation : clazz.getAnnotations()) {
+				for (Class<? extends Annotation> annotationType : annotationTypes) {
+					Annotation annotation = composedAnnotation.annotationType().getAnnotation(annotationType);
+					if (annotation != null) {
+						return new UntypedAnnotationDescriptor(clazz, composedAnnotation, annotation);
+					}
+				}
+			}
+		}
+
+		// Declared on a superclass?
+		return findAnnotationDescriptorForTypes(clazz.getSuperclass(), annotationTypes);
+	}
+
+
+	/**
+	 * Descriptor for an {@link Annotation}, including the {@linkplain
+	 * #getDeclaringClass() class} on which the annotation is <em>declared</em>
+	 * as well as the actual {@linkplain #getAnnotation() annotation} instance.
+	 *
+	 * <p>
+	 * If the annotation is used as a meta-annotation, the descriptor also includes
+	 * the {@linkplain #getComposedAnnotation() composed annotation} on which the
+	 * annotation is present. In such cases, the <em>root declaring class</em> is
+	 * not directly annotated with the annotation but rather indirectly via the
+	 * composed annotation.
+	 *
+	 * <p>
+	 * Given the following example, if we are searching for the {@code @Transactional}
+	 * annotation <em>on</em> the {@code TransactionalTests} class, then the
+	 * properties of the {@code AnnotationDescriptor} would be as follows.
+	 *
+	 * <ul>
+	 *   <li>rootDeclaringClass: {@code TransactionalTests} class object</li>
+	 *   <li>declaringClass: {@code TransactionalTests} class object</li>
+	 *   <li>composedAnnotation: {@code null}</li>
+	 *   <li>annotation: instance of the {@code Transactional} annotation</li>
+	 * </ul>
+	 *
+	 * <pre style="code">
+	 * &#064;Transactional
+	 * &#064;ContextConfiguration({"/test-datasource.xml", "/repository-config.xml"})
+	 * public class TransactionalTests { }
+	 * </pre>
+	 *
+	 * <p>
+	 * Given the following example, if we are searching for the {@code @Transactional}
+	 * annotation <em>on</em> the {@code UserRepositoryTests} class, then the
+	 * properties of the {@code AnnotationDescriptor} would be as follows.
+	 *
+	 * <ul>
+	 *   <li>rootDeclaringClass: {@code UserRepositoryTests} class object</li>
+	 *   <li>declaringClass: {@code RepositoryTests} class object</li>
+	 *   <li>composedAnnotation: instance of the {@code RepositoryTests} annotation</li>
+	 *   <li>annotation: instance of the {@code Transactional} annotation</li>
+	 * </ul>
+	 *
+	 * <pre style="code">
+	 * &#064;Transactional
+	 * &#064;ContextConfiguration({"/test-datasource.xml", "/repository-config.xml"})
+	 * &#064;Retention(RetentionPolicy.RUNTIME)
+	 * public &#064;interface RepositoryTests { }
+	 *
+	 * &#064;RepositoryTests
+	 * public class UserRepositoryTests { }
+	 * </pre>
+	 *
+	 * @author Sam Brannen
+	 */
+	public static class AnnotationDescriptor<T extends Annotation> {
+
+		private final Class<?> rootDeclaringClass;
+		private final Class<?> declaringClass;
+		private final Annotation composedAnnotation;
+		private final T annotation;
+		private final AnnotationAttributes annotationAttributes;
+
+
+		public AnnotationDescriptor(Class<?> rootDeclaringClass, T annotation) {
+			this(rootDeclaringClass, null, annotation);
+		}
+
+		public AnnotationDescriptor(Class<?> rootDeclaringClass, Annotation composedAnnotation, T annotation) {
+			Assert.notNull(rootDeclaringClass, "rootDeclaringClass must not be null");
+			Assert.notNull(annotation, "annotation must not be null");
+
+			this.rootDeclaringClass = rootDeclaringClass;
+			this.declaringClass = (composedAnnotation != null) ? composedAnnotation.annotationType()
+					: rootDeclaringClass;
+			this.composedAnnotation = composedAnnotation;
+			this.annotation = annotation;
+			this.annotationAttributes = AnnotatedElementUtils.getAnnotationAttributes(rootDeclaringClass,
+				annotation.annotationType().getName());
+		}
+
+		public Class<?> getRootDeclaringClass() {
+			return this.rootDeclaringClass;
+		}
+
+		public Class<?> getDeclaringClass() {
+			return this.declaringClass;
+		}
+
+		public T getAnnotation() {
+			return this.annotation;
+		}
+
+		public Class<? extends Annotation> getAnnotationType() {
+			return this.annotation.annotationType();
+		}
+
+		public AnnotationAttributes getAnnotationAttributes() {
+			return this.annotationAttributes;
+		}
+
+		public Annotation getComposedAnnotation() {
+			return this.composedAnnotation;
+		}
+
+		public Class<? extends Annotation> getComposedAnnotationType() {
+			return this.composedAnnotation == null ? null : this.composedAnnotation.annotationType();
+		}
+
+		/**
+		 * Provide a textual representation of this {@code AnnotationDescriptor}.
+		 */
+		@Override
+		public String toString() {
+			return new ToStringCreator(this)//
+			.append("rootDeclaringClass", rootDeclaringClass)//
+			.append("declaringClass", declaringClass)//
+			.append("composedAnnotation", composedAnnotation)//
+			.append("annotation", annotation)//
+			.toString();
+		}
+	}
+
+	/**
+	 * <em>Untyped</em> extension of {@code AnnotationDescriptor} that is used
+	 * to describe the declaration of one of several candidate annotation types
+	 * where the actual annotation type cannot be predetermined.
+	 *
+	 * @author Sam Brannen
+	 */
+	public static class UntypedAnnotationDescriptor extends AnnotationDescriptor<Annotation> {
+
+		public UntypedAnnotationDescriptor(Class<?> declaringClass, Annotation annotation) {
+			super(declaringClass, annotation);
+		}
+
+		public UntypedAnnotationDescriptor(Class<?> declaringClass, Annotation composedAnnotation, Annotation annotation) {
+			super(declaringClass, composedAnnotation, annotation);
+		}
+	}
+
+
+	private static void assertNonEmptyAnnotationTypeArray(Class<?>[] annotationTypes, String message) {
+		if (ObjectUtils.isEmpty(annotationTypes)) {
+			throw new IllegalArgumentException(message);
+		}
+
+		for (Class<?> clazz : annotationTypes) {
+			if (!Annotation.class.isAssignableFrom(clazz)) {
+				throw new IllegalArgumentException("Array elements must be of type Annotation");
+			}
+		}
+	}
+
+}

--- a/spring-yarn/spring-yarn-test-core/src/main/java/org/springframework/yarn/test/context/MiniYarnClusterTest.java
+++ b/spring-yarn/spring-yarn-test-core/src/main/java/org/springframework/yarn/test/context/MiniYarnClusterTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.yarn.test.context;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * Composed annotation having &#064;{@link MiniYarnCluster},
+ * &#064;{@link ContextConfiguration} using loader {@link YarnDelegatingSmartContextLoader}
+ * and empty Spring &#064;{@link Configuration}.
+ * <p>
+ * Typical use for this annotation would look like:
+ * <p>
+ * <pre>
+ * &#064;MiniYarnClusterTest
+ * public class AppTests extends AbstractBootYarnClusterTests {
+ *
+ *   &#064;Test
+ *   public void testApp() {
+ *     // test methods
+ *   }
+ *
+ * }
+ * </pre>
+ *
+ * <p>
+ * Drawback of using a composed annotation like this is that the
+ * &#064;{@link Configuration} is then applied from an annotation
+ * class itself and user can't no longer add a static &#064;{@link Configuration}
+ * class in a test class itself and expect Spring to pick it up from
+ * there which is a normal behaviour in Spring testing support.
+ * <p>
+ * If user wants to use a simple composed annotation and use a
+ * custom &#064;{@link Configuration}, one can simply duplicate
+ * functionality of this &#064;{@code MiniYarnClusterTest} annotation.
+ * <p>
+ * <pre>
+ * &#064;Retention(RetentionPolicy.RUNTIME)
+ * &#064;Target(ElementType.TYPE)
+ * &#064;ContextConfiguration(loader=YarnDelegatingSmartContextLoader.class)
+ * &#064;MiniYarnCluster
+ * public &#064;interface CustomMiniYarnClusterTest {
+ *
+ *   &#064;Configuration
+ *   public static class Config {
+ *
+ *     &#064;Bean
+ *     public String myCustomBean() {
+ *       return "myCustomBean";
+ *     }
+ *
+ *   }
+ *
+ * }
+ * </pre>
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@ContextConfiguration(loader=YarnDelegatingSmartContextLoader.class)
+@MiniYarnCluster
+public @interface MiniYarnClusterTest {
+
+	@Configuration
+	public static class Config {
+	}
+
+}

--- a/spring-yarn/spring-yarn-test-core/src/main/java/org/springframework/yarn/test/context/YarnClusterInjectUtils.java
+++ b/spring-yarn/spring-yarn-test-core/src/main/java/org/springframework/yarn/test/context/YarnClusterInjectUtils.java
@@ -18,6 +18,7 @@ package org.springframework.yarn.test.context;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.test.context.MergedContextConfiguration;
+import org.springframework.yarn.test.context.MetaAnnotationUtils.AnnotationDescriptor;
 import org.springframework.yarn.test.support.ClusterDelegatingFactoryBean;
 import org.springframework.yarn.test.support.ConfigurationDelegatingFactoryBean;
 
@@ -37,12 +38,12 @@ abstract class YarnClusterInjectUtils {
 	 */
 	public static void handleClusterInject(GenericApplicationContext context,
 			MergedContextConfiguration mergedConfig) {
-		final Class<MiniYarnCluster> annotationType = MiniYarnCluster.class;
 		Class<?> testClass = mergedConfig.getTestClass();
-		boolean hasMiniYarnCluster = testClass.isAnnotationPresent(annotationType);
-		MiniYarnCluster annotation = testClass.getAnnotation(annotationType);
+		AnnotationDescriptor<MiniYarnCluster> annotationDescriptor = MetaAnnotationUtils.findAnnotationDescriptor(
+				testClass, MiniYarnCluster.class);
 
-		if (hasMiniYarnCluster) {
+		if (annotationDescriptor != null && annotationDescriptor.getAnnotation() != null) {
+			MiniYarnCluster annotation = annotationDescriptor.getAnnotation();
 			String clusterName = annotation.clusterName();
 			String configName = annotation.configName();
 			String id = annotation.id();

--- a/spring-yarn/spring-yarn-test-core/src/main/java/org/springframework/yarn/test/context/YarnDelegatingSmartContextLoader.java
+++ b/spring-yarn/spring-yarn-test-core/src/main/java/org/springframework/yarn/test/context/YarnDelegatingSmartContextLoader.java
@@ -15,250 +15,34 @@
  */
 package org.springframework.yarn.test.context;
 
-import java.util.Arrays;
-import java.util.List;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.springframework.context.ApplicationContext;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.ContextConfigurationAttributes;
-import org.springframework.test.context.ContextLoader;
-import org.springframework.test.context.MergedContextConfiguration;
 import org.springframework.test.context.SmartContextLoader;
-import org.springframework.test.context.support.AnnotationConfigContextLoader;
-import org.springframework.util.Assert;
-import org.springframework.util.ObjectUtils;
+import org.springframework.test.context.support.AbstractDelegatingSmartContextLoader;
 
 /**
- * {@code DelegatingSmartContextLoader} is an implementation of the {@link SmartContextLoader}
- * SPI that delegates to a set of <em>candidate</em> SmartContextLoaders (i.e.,
- * {@link YarnClusterInjectingXmlContextLoader} and {@link YarnClusterInjectingAnnotationConfigContextLoader}) to
- * determine which context loader is appropriate for a given test classes configuration.
- * Each candidate is given a chance to {@link #processContextConfiguration process} the
- * {@link ContextConfigurationAttributes} for each class in the test class hierarchy that
- * is annotated with {@link ContextConfiguration @ContextConfiguration}, and the candidate
- * that supports the merged, processed configuration will be used to actually
- * {@link #loadContext load} the context.
- * 
- * <p>Placing an empty {@code @ContextConfiguration} annotation on a test class signals
- * that default resource locations (i.e., XML configuration files) or default
- * {@link org.springframework.context.annotation.Configuration configuration classes}
- * should be detected. Furthermore, if a specific {@link ContextLoader} or
- * {@link SmartContextLoader} is not explicitly declared via
- * {@code @ContextConfiguration}, {@code DelegatingSmartContextLoader} will be used as
- * the default loader, thus providing automatic support for either XML configuration
- * files or configuration classes, but not both simultaneously.
- * 
- * <p>NOTE: This is a copy from a spring-test order to add custom yarn
- * specific testing logic.
- * 
- * @author Sam Brannen
+ * {@code YarnDelegatingSmartContextLoader} is a concrete implementation of
+ * {@link AbstractDelegatingSmartContextLoader} that delegates to a
+ * {@link YarnClusterInjectingXmlContextLoader} and an
+ * {@link YarnClusterInjectingAnnotationConfigContextLoader}.
+ *
  * @author Janne Valkealahti
- * 
  * @see SmartContextLoader
+ * @see AbstractDelegatingSmartContextLoader
  * @see YarnClusterInjectingXmlContextLoader
  * @see YarnClusterInjectingAnnotationConfigContextLoader
  */
-public class YarnDelegatingSmartContextLoader implements SmartContextLoader {
-
-	private static final Log logger = LogFactory.getLog(YarnDelegatingSmartContextLoader.class);
+public class YarnDelegatingSmartContextLoader extends AbstractDelegatingSmartContextLoader {
 
 	private final SmartContextLoader xmlLoader = new YarnClusterInjectingXmlContextLoader();
 	private final SmartContextLoader annotationConfigLoader = new YarnClusterInjectingAnnotationConfigContextLoader();
 
-	// --- SmartContextLoader --------------------------------------------------
-
-	private static String name(SmartContextLoader loader) {
-		return loader.getClass().getSimpleName();
+	@Override
+	protected SmartContextLoader getXmlLoader() {
+		return this.xmlLoader;
 	}
 
-	private static void delegateProcessing(SmartContextLoader loader, ContextConfigurationAttributes configAttributes) {
-		if (logger.isDebugEnabled()) {
-			logger.debug(String.format("Delegating to %s to process context configuration %s.", name(loader),
-				configAttributes));
-		}
-		loader.processContextConfiguration(configAttributes);
-	}
-
-	private static boolean supports(SmartContextLoader loader, MergedContextConfiguration mergedConfig) {
-		if (loader instanceof AnnotationConfigContextLoader) {
-			return ObjectUtils.isEmpty(mergedConfig.getLocations()) && !ObjectUtils.isEmpty(mergedConfig.getClasses());
-		}
-		else {
-			return !ObjectUtils.isEmpty(mergedConfig.getLocations()) && ObjectUtils.isEmpty(mergedConfig.getClasses());
-		}
-	}
-
-	/**
-	 * Delegates to candidate {@code SmartContextLoaders} to process the supplied
-	 * {@link ContextConfigurationAttributes}.
-	 * 
-	 * <p>Delegation is based on explicit knowledge of the implementations of
-	 * {@link YarnClusterInjectingXmlContextLoader} and {@link YarnClusterInjectingAnnotationConfigContextLoader}.
-	 * Specifically, the delegation algorithm is as follows:
-	 * 
-	 * <ul>
-	 * <li>If the resource locations or configuration classes in the supplied
-	 * {@code ContextConfigurationAttributes} are not empty, the appropriate 
-	 * candidate loader will be allowed to process the configuration <em>as is</em>,
-	 * without any checks for detection of defaults.</li>
-	 * <li>Otherwise, {@code YarnClusterInjectingXmlContextLoader} will be allowed to process
-	 * the configuration in order to detect default resource locations. If
-	 * {@code YarnClusterInjectingXmlContextLoader} detects default resource locations,
-	 * an {@code info} message will be logged.</li>
-	 * <li>Subsequently, {@code YarnClusterInjectingAnnotationConfigContextLoader} will be allowed to
-	 * process the configuration in order to detect default configuration classes.
-	 * If {@code YarnClusterInjectingAnnotationConfigContextLoader} detects default configuration
-	 * classes, an {@code info} message will be logged.</li>
-	 * </ul>
-	 * 
-	 * @param configAttributes the context configuration attributes to process
-	 * @throws IllegalArgumentException if the supplied configuration attributes are
-	 * <code>null</code>, or if the supplied configuration attributes include both
-	 * resource locations and configuration classes
-	 * @throws IllegalStateException if {@code YarnClusterInjectingXmlContextLoader} detects default
-	 * configuration classes; if {@code YarnClusterInjectingAnnotationConfigContextLoader} detects default
-	 * resource locations; if neither candidate loader detects defaults for the supplied
-	 * context configuration; or if both candidate loaders detect defaults for the
-	 * supplied context configuration
-	 */
-	public void processContextConfiguration(final ContextConfigurationAttributes configAttributes) {
-
-		Assert.notNull(configAttributes, "configAttributes must not be null");
-		Assert.isTrue(!(configAttributes.hasLocations() && configAttributes.hasClasses()), String.format(
-			"Cannot process locations AND configuration classes for context "
-					+ "configuration %s; configure one or the other, but not both.", configAttributes));
-
-		// If the original locations or classes were not empty, there's no
-		// need to bother with default detection checks; just let the
-		// appropriate loader process the configuration.
-		if (configAttributes.hasLocations()) {
-			delegateProcessing(xmlLoader, configAttributes);
-		}
-		else if (configAttributes.hasClasses()) {
-			delegateProcessing(annotationConfigLoader, configAttributes);
-		}
-		else {
-			// Else attempt to detect defaults...
-
-			// Let the XML loader process the configuration.
-			delegateProcessing(xmlLoader, configAttributes);
-			boolean xmlLoaderDetectedDefaults = configAttributes.hasLocations();
-
-			if (xmlLoaderDetectedDefaults) {
-				if (logger.isInfoEnabled()) {
-					logger.info(String.format("%s detected default locations for context configuration %s.",
-						name(xmlLoader), configAttributes));
-				}
-			}
-
-			if (configAttributes.hasClasses()) {
-				throw new IllegalStateException(String.format(
-					"%s should NOT have detected default configuration classes for context configuration %s.",
-					name(xmlLoader), configAttributes));
-			}
-
-			// Now let the annotation config loader process the configuration.
-			delegateProcessing(annotationConfigLoader, configAttributes);
-
-			if (configAttributes.hasClasses()) {
-				if (logger.isInfoEnabled()) {
-					logger.info(String.format(
-						"%s detected default configuration classes for context configuration %s.",
-						name(annotationConfigLoader), configAttributes));
-				}
-			}
-
-			if (!xmlLoaderDetectedDefaults && configAttributes.hasLocations()) {
-				throw new IllegalStateException(String.format(
-					"%s should NOT have detected default locations for context configuration %s.",
-					name(annotationConfigLoader), configAttributes));
-			}
-
-			// If neither loader detected defaults, throw an exception.
-			if (!configAttributes.hasResources()) {
-				throw new IllegalStateException(String.format(
-					"Neither %s nor %s was able to detect defaults for context configuration %s.", name(xmlLoader),
-					name(annotationConfigLoader), configAttributes));
-			}
-
-			if (configAttributes.hasLocations() && configAttributes.hasClasses()) {
-				String message = String.format(
-					"Configuration error: both default locations AND default configuration classes "
-							+ "were detected for context configuration %s; configure one or the other, but not both.",
-					configAttributes);
-				logger.error(message);
-				throw new IllegalStateException(message);
-			}
-		}
-	}
-
-	/**
-	 * Delegates to an appropriate candidate {@code SmartContextLoader} to load
-	 * an {@link ApplicationContext}.
-	 * 
-	 * <p>Delegation is based on explicit knowledge of the implementations of
-	 * {@link YarnClusterInjectingXmlContextLoader} and {@link YarnClusterInjectingAnnotationConfigContextLoader}.
-	 * Specifically, the delegation algorithm is as follows:
-	 * 
-	 * <ul>
-	 * <li>If the resource locations in the supplied {@code MergedContextConfiguration}
-	 * are not empty and the configuration classes are empty,
-	 * {@code YarnClusterInjectingXmlContextLoader} will load the {@code ApplicationContext}.</li>
-	 * <li>If the configuration classes in the supplied {@code MergedContextConfiguration}
-	 * are not empty and the resource locations are empty,
-	 * {@code YarnClusterInjectingAnnotationConfigContextLoader} will load the {@code ApplicationContext}.</li>
-	 * </ul>
-	 * 
-	 * @param mergedConfig the merged context configuration to use to load the application context
-	 * @throws IllegalArgumentException if the supplied merged configuration is <code>null</code>
-	 * @throws IllegalStateException if neither candidate loader is capable of loading an
-	 * {@code ApplicationContext} from the supplied merged context configuration
-	 */
-	public ApplicationContext loadContext(MergedContextConfiguration mergedConfig) throws Exception {
-		Assert.notNull(mergedConfig, "mergedConfig must not be null");
-
-		List<SmartContextLoader> candidates = Arrays.asList(xmlLoader, annotationConfigLoader);
-
-		for (SmartContextLoader loader : candidates) {
-			// Determine if each loader can load a context from the
-			// mergedConfig. If it can, let it; otherwise, keep iterating.
-			if (supports(loader, mergedConfig)) {
-				if (logger.isDebugEnabled()) {
-					logger.debug(String.format("Delegating to %s to load context from %s.", name(loader), mergedConfig));
-				}
-				return loader.loadContext(mergedConfig);
-			}
-		}
-
-		throw new IllegalStateException(String.format(
-			"Neither %s nor %s was able to load an ApplicationContext from %s.", name(xmlLoader),
-			name(annotationConfigLoader), mergedConfig));
-	}
-
-	// --- ContextLoader -------------------------------------------------------
-
-	/**
-	 * {@code DelegatingSmartContextLoader} does not support the
-	 * {@link ContextLoader#processLocations(Class, String...)} method. Call
-	 * {@link #processContextConfiguration(ContextConfigurationAttributes)} instead.
-	 * @throws UnsupportedOperationException
-	 */
-	public String[] processLocations(Class<?> clazz, String... locations) {
-		throw new UnsupportedOperationException("DelegatingSmartContextLoader does not support the ContextLoader SPI. "
-				+ "Call processContextConfiguration(ContextConfigurationAttributes) instead.");
-	}
-
-	/**
-	 * {@code DelegatingSmartContextLoader} does not support the
-	 * {@link ContextLoader#loadContext(String...) } method. Call
-	 * {@link #loadContext(MergedContextConfiguration)} instead.
-	 * @throws UnsupportedOperationException
-	 */
-	public ApplicationContext loadContext(String... locations) throws Exception {
-		throw new UnsupportedOperationException("DelegatingSmartContextLoader does not support the ContextLoader SPI. "
-				+ "Call loadContext(MergedContextConfiguration) instead.");
+	@Override
+	protected SmartContextLoader getAnnotationConfigLoader() {
+		return this.annotationConfigLoader;
 	}
 
 }

--- a/spring-yarn/spring-yarn-test-core/src/test/java/org/springframework/yarn/test/context/ComposedAnnotationTests.java
+++ b/spring-yarn/spring-yarn-test-core/src/test/java/org/springframework/yarn/test/context/ComposedAnnotationTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.yarn.test.context;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import javax.annotation.Resource;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * Tests for custom composed annotations.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@CustomMiniYarnClusterTest
+public class ComposedAnnotationTests {
+
+	@Autowired
+	private ApplicationContext ctx;
+
+	@Resource(name = "yarnConfiguration")
+	Configuration configuration;
+
+	@Test
+	public void testLoaderAndConfig() {
+		assertNotNull(ctx);
+		assertTrue(ctx.containsBean("yarnCluster"));
+		assertTrue(ctx.containsBean("yarnConfiguration"));
+		assertTrue(ctx.containsBean("myCustomBean"));
+		Configuration config = (Configuration) ctx.getBean("yarnConfiguration");
+		assertNotNull(config);
+	}
+
+}

--- a/spring-yarn/spring-yarn-test-core/src/test/java/org/springframework/yarn/test/context/CustomMiniYarnClusterTest.java
+++ b/spring-yarn/spring-yarn-test-core/src/test/java/org/springframework/yarn/test/context/CustomMiniYarnClusterTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.yarn.test.context;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * Custom composed annotation used to test if
+ * user creates one manually.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@ContextConfiguration(loader=YarnDelegatingSmartContextLoader.class)
+@MiniYarnCluster
+public @interface CustomMiniYarnClusterTest {
+
+	@Configuration
+	public static class Config {
+		@Bean
+		public String myCustomBean() {
+			return "myCustomBean";
+		}
+	}
+
+}

--- a/spring-yarn/spring-yarn-test-core/src/test/java/org/springframework/yarn/test/context/YarnClusterInjectingMiniYarnClusterTestContextLoaderTests.java
+++ b/spring-yarn/spring-yarn-test-core/src/test/java/org/springframework/yarn/test/context/YarnClusterInjectingMiniYarnClusterTestContextLoaderTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.yarn.test.context;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import javax.annotation.Resource;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * Tests using {@link MiniYarnClusterTest}.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@MiniYarnClusterTest
+public class YarnClusterInjectingMiniYarnClusterTestContextLoaderTests {
+
+	@Autowired
+	private ApplicationContext ctx;
+
+	@Resource(name = "yarnConfiguration")
+	Configuration configuration;
+
+	@Test
+	public void testLoaderAndConfig() {
+		assertNotNull(ctx);
+		assertTrue(ctx.containsBean("yarnCluster"));
+		assertTrue(ctx.containsBean("yarnConfiguration"));
+		Configuration config = (Configuration) ctx.getBean("yarnConfiguration");
+		assertNotNull(config);
+	}
+
+}


### PR DESCRIPTION
- New MiniYarnClusterTest annotation which wraps
  needed logic to use minicluster and empty config.
- User can create similar custom composed annotations
- Cleaned YarnDelegatingSmartContextLoader
- YarnClusterInjectUtils can now find annotations from
  composed annotations.
