### PR TITLE
SHDP-266 Better exit code handling

### DIFF
--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/AbstractYarnContainer.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/AbstractYarnContainer.java
@@ -18,6 +18,8 @@ package org.springframework.yarn.container;
 import java.util.Map;
 import java.util.Properties;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.springframework.yarn.listener.CompositeContainerStateListener;
 import org.springframework.yarn.listener.ContainerStateListener;
@@ -32,6 +34,8 @@ import org.springframework.yarn.listener.ContainerStateListener.ContainerState;
  *
  */
 public abstract class AbstractYarnContainer implements LongRunningYarnContainer, YarnContainerRuntime {
+
+	private final static Log log = LogFactory.getLog(AbstractYarnContainer.class);
 
 	/** Environment variables for the process. */
 	private Map<String, String> environment;
@@ -138,7 +142,8 @@ public abstract class AbstractYarnContainer implements LongRunningYarnContainer,
 	 * @param state the state
 	 * @param exit the exit
 	 */
-	protected void notifyContainerState(ContainerState state, int exit) {
+	protected void notifyContainerState(ContainerState state, Object exit) {
+		log.info("Notifying listeners of ContainerState=" + state + " and exit=" + exit);
 		stateListener.state(state, exit);
 	}
 

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/CommandLineContainerRunner.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/CommandLineContainerRunner.java
@@ -60,7 +60,7 @@ public class CommandLineContainerRunner extends AbstractCommandLineRunner<YarnCo
 			latch = new CountDownLatch(1);
 			((LongRunningYarnContainer)bean).addContainerStateListener(new ContainerStateListener() {
 				@Override
-				public void state(ContainerState state, int exit) {
+				public void state(ContainerState state, Object exit) {
 					stateWrapper.state = state;
 					// TODO: should handle exit value
 					latch.countDown();

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/DefaultYarnContainer.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/DefaultYarnContainer.java
@@ -50,21 +50,9 @@ public class DefaultYarnContainer extends AbstractYarnContainer implements BeanF
 		log.info("Container state based on result=[" + result + "] runtimeException=[" + runtimeException + "]");
 
 		if (runtimeException != null) {
-			notifyContainerState(ContainerState.FAILED, 1);
-		} else if (result != null && result instanceof Integer) {
-			int val = ((Integer)result).intValue();
-			if (val < 0) {
-				notifyContainerState(ContainerState.FAILED, val);
-			} else {
-				notifyContainerState(ContainerState.COMPLETED, val);
-			}
-		} else if (result != null && result instanceof Boolean) {
-			boolean val = ((Boolean)result).booleanValue();
-			if (val) {
-				notifyContainerState(ContainerState.COMPLETED, 0);
-			} else {
-				notifyContainerState(ContainerState.FAILED, -1);
-			}
+			notifyContainerState(ContainerState.FAILED, runtimeException);
+		} else if (result != null) {
+			notifyContainerState(ContainerState.COMPLETED, result);
 		} else {
 			notifyCompleted();
 		}
@@ -73,6 +61,13 @@ public class DefaultYarnContainer extends AbstractYarnContainer implements BeanF
 	@Override
 	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
 		this.beanFactory = beanFactory;
+	}
+
+	@Override
+	public boolean isWaitCompleteState() {
+		// we need to tell boot ContainerLauncherRunner that we're
+		// about to notify state via events so it should wait
+		return true;
 	}
 
 }

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/launch/ExitCodeMapper.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/launch/ExitCodeMapper.java
@@ -48,6 +48,16 @@ public interface ExitCodeMapper {
 	 * @return The corresponding exit status as known by the calling
 	 *         environment.
 	 */
-	public int intValue(String exitCode);
+	int intValue(String exitCode);
+
+	/**
+	 * Convert the exit code from Boolean into an integer that the calling
+	 * environment as an operating system can interpret as an exit status.
+	 *
+	 * @param exitCode The exit code which is used internally.
+	 * @return The corresponding exit status as known by the calling
+	 *         environment.
+	 */
+	int intValue(Boolean exitCode);
 
 }

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/launch/ExitStatus.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/launch/ExitStatus.java
@@ -35,6 +35,11 @@ import org.springframework.util.StringUtils;
 public class ExitStatus implements Serializable, Comparable<ExitStatus> {
 
 	/**
+	 * Convenient constant value representing finished processing.
+	 */
+	public static final ExitStatus COMPLETED = new ExitStatus("COMPLETED");
+
+	/**
 	 * Convenient constant value representing unknown state - assumed not
 	 * continuable.
 	 */
@@ -52,7 +57,7 @@ public class ExitStatus implements Serializable, Comparable<ExitStatus> {
 	/**
 	 * Convenient constant value representing finished processing.
 	 */
-	public static final ExitStatus COMPLETED = new ExitStatus("COMPLETED");
+	public static final ExitStatus OK = new ExitStatus("OK");
 
 	/**
 	 * Convenient constant value representing job that did no processing (e.g.
@@ -111,8 +116,9 @@ public class ExitStatus implements Serializable, Comparable<ExitStatus> {
 	 *
 	 * Severity is defined by the exit code:
 	 * <ul>
+	 * <li>Codes beginning with COMPLETED have severity 0</li>
 	 * <li>Codes beginning with EXECUTING have severity 1</li>
-	 * <li>Codes beginning with COMPLETED have severity 2</li>
+	 * <li>Codes beginning with OK have severity 2</li>
 	 * <li>Codes beginning with NOOP have severity 3</li>
 	 * <li>Codes beginning with STOPPED have severity 4</li>
 	 * <li>Codes beginning with FAILED have severity 5</li>
@@ -159,10 +165,13 @@ public class ExitStatus implements Serializable, Comparable<ExitStatus> {
 	 * @return mapped exit code
 	 */
 	private int severity(ExitStatus status) {
+		if (status.exitCode.startsWith(COMPLETED.exitCode)) {
+			return 0;
+		}
 		if (status.exitCode.startsWith(EXECUTING.exitCode)) {
 			return 1;
 		}
-		if (status.exitCode.startsWith(COMPLETED.exitCode)) {
+		if (status.exitCode.startsWith(OK.exitCode)) {
 			return 2;
 		}
 		if (status.exitCode.startsWith(NOOP.exitCode)) {

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/launch/SimpleJvmExitCodeMapper.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/launch/SimpleJvmExitCodeMapper.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.util.ObjectUtils;
 
 /**
  * An implementation of {@link ExitCodeMapper} that can be configured through a
@@ -80,6 +81,11 @@ public class SimpleJvmExitCodeMapper implements ExitCodeMapper {
 		}
 
 		return (statusCode != null) ? statusCode.intValue() : JVM_EXITCODE_GENERIC_ERROR;
+	}
+
+	@Override
+	public int intValue(Boolean exitCode) {
+		return ObjectUtils.nullSafeEquals(exitCode, true) ? JVM_EXITCODE_COMPLETED : JVM_EXITCODE_GENERIC_ERROR;
 	}
 
 }

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/listener/CompositeContainerStateListener.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/listener/CompositeContainerStateListener.java
@@ -27,7 +27,7 @@ public class CompositeContainerStateListener extends AbstractCompositeListener<C
 		implements ContainerStateListener {
 
 	@Override
-	public void state(ContainerState state, int exit) {
+	public void state(ContainerState state, Object exit) {
 		for (Iterator<ContainerStateListener> iterator = getListeners().reverse(); iterator.hasNext();) {
 			ContainerStateListener listener = iterator.next();
 			listener.state(state, exit);

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/listener/ContainerStateListener.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/listener/ContainerStateListener.java
@@ -29,7 +29,7 @@ public interface ContainerStateListener {
 	 * @param state the {@link ContainerState}
 	 * @param exit the requested exit status
 	 */
-	void state(ContainerState state, int exit);
+	void state(ContainerState state, Object exit);
 
 	/**
 	 * Enum for container states


### PR DESCRIPTION
- Add better handling for return value
  of pojo method run from boot model.
- Pojo return value as String can now
  map back to generic launcher exit codes.
- Added DefaultYarnContainer to instruct
  ContainerLauncherRunner to wait state.
- ContainerStateListener changed to use Object
  as exit status instead of int. This way we
  can do better mapping.
