### PR TITLE
SHDP-296 Rename include-system-env property

### DIFF
--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/YarnAppmasterAutoConfiguration.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/YarnAppmasterAutoConfiguration.java
@@ -213,7 +213,7 @@ public class YarnAppmasterAutoConfiguration {
 		@Override
 		public void configure(YarnEnvironmentConfigurer environment) throws Exception {
 			environment
-				.includeSystemEnv(syalcp.isIncludeSystemEnv())
+				.includeLocalSystemEnv(syalcp.isIncludeLocalSystemEnv())
 				.withClasspath()
 					.includeBaseDirectory(syalcp.isIncludeBaseDirectory())
 					.useDefaultYarnClasspath(syalcp.isUseDefaultYarnClasspath())

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/YarnClientAutoConfiguration.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/YarnClientAutoConfiguration.java
@@ -140,7 +140,7 @@ public class YarnClientAutoConfiguration {
 		@Override
 		public void configure(YarnEnvironmentConfigurer environment) throws Exception {
 			environment
-				.includeSystemEnv(syclcp.isIncludeSystemEnv())
+				.includeLocalSystemEnv(syclcp.isIncludeLocalSystemEnv())
 				.withClasspath()
 					.includeBaseDirectory(syclcp.isIncludeBaseDirectory())
 					.useDefaultYarnClasspath(syclcp.isUseDefaultYarnClasspath())

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/AbstractLaunchContextProperties.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/AbstractLaunchContextProperties.java
@@ -28,7 +28,7 @@ public abstract class AbstractLaunchContextProperties {
 	private String pathSeparator;
 	private boolean includeBaseDirectory = true;
 	private boolean useDefaultYarnClasspath = true;
-	private boolean includeSystemEnv = true;
+	private boolean includeLocalSystemEnv = false;
 
 	public String getArchiveFile() {
 		return archiveFile;
@@ -94,12 +94,12 @@ public abstract class AbstractLaunchContextProperties {
 		this.useDefaultYarnClasspath = useDefaultYarnClasspath;
 	}
 
-	public boolean isIncludeSystemEnv() {
-		return includeSystemEnv;
+	public boolean isIncludeLocalSystemEnv() {
+		return includeLocalSystemEnv;
 	}
 
-	public void setIncludeSystemEnv(boolean includeSystemEnv) {
-		this.includeSystemEnv = includeSystemEnv;
+	public void setIncludeLocalSystemEnv(boolean includeLocalSystemEnv) {
+		this.includeLocalSystemEnv = includeLocalSystemEnv;
 	}
 
 }

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/support/AppmasterLauncherRunner.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/support/AppmasterLauncherRunner.java
@@ -64,6 +64,7 @@ public class AppmasterLauncherRunner extends CommandLineRunnerSupport implements
 			properties.put(AppmasterConstants.CONTAINER_COUNT, Integer.toString(containerCount));
 		}
 		appmaster.setParameters(properties);
+		appmaster.setEnvironment(System.getenv());
 
 
 		log.info("Running YarnAppmaster with parameters [" + StringUtils.arrayToCommaDelimitedString(parameters) + "]");

--- a/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringYarnAppmasterLaunchContextPropertiesTests.java
+++ b/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringYarnAppmasterLaunchContextPropertiesTests.java
@@ -61,7 +61,7 @@ public class SpringYarnAppmasterLaunchContextPropertiesTests {
 
 		assertThat(properties.isUseDefaultYarnClasspath(), is(false));
 		assertThat(properties.isIncludeBaseDirectory(), is(false));
-		assertThat(properties.isIncludeSystemEnv(), is(false));
+		assertThat(properties.isIncludeLocalSystemEnv(), is(true));
 		assertThat(properties.getPathSeparator(), is(":"));
 
 		context.close();

--- a/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringYarnClientLaunchContextPropertiesTests.java
+++ b/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringYarnClientLaunchContextPropertiesTests.java
@@ -61,7 +61,7 @@ public class SpringYarnClientLaunchContextPropertiesTests {
 
 		assertThat(properties.isUseDefaultYarnClasspath(), is(false));
 		assertThat(properties.isIncludeBaseDirectory(), is(false));
-		assertThat(properties.isIncludeSystemEnv(), is(false));
+		assertThat(properties.isIncludeLocalSystemEnv(), is(true));
 		assertThat(properties.getPathSeparator(), is(":"));
 
 		context.close();

--- a/spring-yarn/spring-yarn-boot/src/test/resources/SpringYarnAppmasterLaunchContextPropertiesTests.yml
+++ b/spring-yarn/spring-yarn-boot/src/test/resources/SpringYarnAppmasterLaunchContextPropertiesTests.yml
@@ -15,7 +15,7 @@ spring:
                 options:
                   - "options1Foo"
                   - "options2Foo"
-                includeSystemEnv: false
+                includeLocalSystemEnv: true
                 useDefaultYarnClasspath: false
                 includeBaseDirectory: false
                 pathSeparator: ":"

--- a/spring-yarn/spring-yarn-boot/src/test/resources/SpringYarnClientLaunchContextPropertiesTests.yml
+++ b/spring-yarn/spring-yarn-boot/src/test/resources/SpringYarnClientLaunchContextPropertiesTests.yml
@@ -15,7 +15,7 @@ spring:
                 options:
                   - "options1Foo"
                   - "options2Foo"
-                includeSystemEnv: false
+                includeLocalSystemEnv: true
                 useDefaultYarnClasspath: false
                 includeBaseDirectory: false
                 pathSeparator: ":"

--- a/spring-yarn/spring-yarn-build-tests/src/test/resources/YarnClusterTests-appmaster-context.xml
+++ b/spring-yarn/spring-yarn-build-tests/src/test/resources/YarnClusterTests-appmaster-context.xml
@@ -22,7 +22,7 @@
 	</yarn:localresources>
 
 	<!-- do not rely on default classpath, instead use all dependencies -->
-	<yarn:environment>
+	<yarn:environment include-local-system-env="true">
 		<yarn:classpath use-default-yarn-classpath="false"/>
 	</yarn:environment>
 

--- a/spring-yarn/spring-yarn-build-tests/src/test/resources/org/springframework/yarn/test/YarnClusterTests-context.xml
+++ b/spring-yarn/spring-yarn-build-tests/src/test/resources/org/springframework/yarn/test/YarnClusterTests-context.xml
@@ -27,7 +27,7 @@
 	</yarn:localresources>
 
 	<!-- do not rely on default classpath, instead use all dependencies -->
-	<yarn:environment include-system-env="false">
+	<yarn:environment include-local-system-env="false">
 		<yarn:classpath use-default-yarn-classpath="false" delimiter=":">
 			./*
 		</yarn:classpath>

--- a/spring-yarn/spring-yarn-build-tests/src/test/resources/org/springframework/yarn/test/junit/ClusterBaseTestClassSubmitTests-context.xml
+++ b/spring-yarn/spring-yarn-build-tests/src/test/resources/org/springframework/yarn/test/junit/ClusterBaseTestClassSubmitTests-context.xml
@@ -16,7 +16,7 @@
 	</yarn:localresources>
 
 	<!-- do not rely on default classpath, instead use all dependencies -->
-	<yarn:environment include-system-env="false">
+	<yarn:environment include-local-system-env="false">
 		<yarn:classpath use-default-yarn-classpath="false"/>
 	</yarn:environment>
 

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/AbstractAppmaster.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/AbstractAppmaster.java
@@ -103,7 +103,6 @@ public abstract class AbstractAppmaster extends LifecycleObjectSupport {
 	@Override
 	protected void onInit() throws Exception {
 		super.onInit();
-		applicationAttemptId = YarnUtils.getApplicationAttemptId(environment);
 		AppmasterRmTemplate armt = new AppmasterRmTemplate(getConfiguration());
 		armt.afterPropertiesSet();
 		rmTemplate = armt;
@@ -328,6 +327,7 @@ public abstract class AbstractAppmaster extends LifecycleObjectSupport {
 	 * @return the register application master response
 	 */
 	protected RegisterApplicationMasterResponse registerAppmaster() {
+		applicationAttemptId = YarnUtils.getApplicationAttemptId(getEnvironment());
 		Assert.notNull(applicationAttemptId, "applicationAttemptId must be set");
 		if(applicationRegistered) {
 			log.warn("Not sending register request because we are already registered");

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/CommandLineAppmasterRunner.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/CommandLineAppmasterRunner.java
@@ -45,6 +45,7 @@ public class CommandLineAppmasterRunner extends AbstractCommandLineRunner<YarnAp
 	protected ExitStatus handleBeanRun(YarnAppmaster bean, String[] parameters, Set<String> opts) {
 		Properties properties = StringUtils.splitArrayElementsIntoProperties(parameters, "=");
 		bean.setParameters(properties != null ? properties : new Properties());
+		bean.setEnvironment(System.getenv());
 		if(log.isDebugEnabled()) {
 			log.debug("Starting YarnAppmaster bean: " + StringUtils.arrayToCommaDelimitedString(parameters));
 		}

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/YarnAppmaster.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/YarnAppmaster.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.yarn.am;
 
+import java.util.Map;
 import java.util.Properties;
 
 import org.springframework.yarn.listener.AppmasterStateListener;
@@ -34,7 +35,16 @@ public interface YarnAppmaster {
 	void submitApplication();
 
 	/**
-	 * Sets parameters for the application.
+	 * Sets the environment variables. This method should be
+	 * used by a launcher or any other party handling
+	 * creation of an appmaster.
+	 *
+	 * @param environment the environment variables
+	 */
+	public void setEnvironment(Map<String, String> environment);
+
+	/**
+	 * Sets parameters for the appmaster.
 	 *
 	 * @param parameters the parameters to set
 	 */

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/EnvironmentParser.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/EnvironmentParser.java
@@ -43,7 +43,7 @@ class EnvironmentParser extends AbstractPropertiesConfiguredBeanDefinitionParser
 	protected void doParse(Element element, ParserContext parserContext, BeanDefinitionBuilder builder) {
 		super.doParse(element, parserContext, builder);
 
-		builder.addPropertyValue("includeSystemEnv", element.getAttribute("include-system-env"));
+		builder.addPropertyValue("includeLocalSystemEnv", element.getAttribute("include-local-system-env"));
 
 		List<Element> entries = DomUtils.getChildElementsByTagName(element, "classpath");
 		if(entries.size() == 1) {

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/MasterParser.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/MasterParser.java
@@ -135,7 +135,6 @@ public class MasterParser extends AbstractBeanDefinitionParser {
 		// for appmaster bean
 		YarnNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "resource-localizer", YarnSystemConstants.DEFAULT_ID_LOCAL_RESOURCES);
 		YarnNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "configuration", YarnSystemConstants.DEFAULT_ID_CONFIGURATION);
-		YarnNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "environment", YarnSystemConstants.DEFAULT_ID_ENVIRONMENT);
 
 		return builder.getBeanDefinition();
 	}

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/builders/YarnAppmasterBuilder.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/builders/YarnAppmasterBuilder.java
@@ -76,7 +76,6 @@ public final class YarnAppmasterBuilder extends AbstractConfiguredAnnotationBuil
 			}
 
 			abstractAppmaster.setConfiguration(configuration);
-			abstractAppmaster.setEnvironment(environment);
 			abstractAppmaster.setResourceLocalizer(resourceLocalizer);
 			if (appmaster instanceof AbstractServicesAppmaster) {
 				AbstractServicesAppmaster abstractServicesAppmaster = (AbstractServicesAppmaster)appmaster;

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/builders/YarnEnvironmentBuilder.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/builders/YarnEnvironmentBuilder.java
@@ -44,7 +44,7 @@ public final class YarnEnvironmentBuilder
 
 	private boolean useDefaultYarnClasspath = true;
 	private boolean includeBaseDirectory = true;
-	private boolean includeSystemEnv = true;
+	private boolean includeLocalSystemEnv = false;
 	private String defaultYarnAppClasspath;
 	private String delimiter = ":";
 	private Properties properties = new Properties();
@@ -63,7 +63,7 @@ public final class YarnEnvironmentBuilder
 		fb.setDelimiter(delimiter);
 		fb.setDefaultYarnAppClasspath(defaultYarnAppClasspath);
 		fb.setUseDefaultYarnClasspath(useDefaultYarnClasspath);
-		fb.setIncludeSystemEnv(includeSystemEnv);
+		fb.setIncludeLocalSystemEnv(includeLocalSystemEnv);
 		fb.setIncludeBaseDirectory(includeBaseDirectory);
 		fb.afterPropertiesSet();
 		return fb.getObject();
@@ -97,8 +97,8 @@ public final class YarnEnvironmentBuilder
 	}
 
 	@Override
-	public YarnEnvironmentConfigurer includeSystemEnv(boolean includeSystemEnv) {
-		this.includeSystemEnv = includeSystemEnv;
+	public YarnEnvironmentConfigurer includeLocalSystemEnv(boolean includeLocalSystemEnv) {
+		this.includeLocalSystemEnv = includeLocalSystemEnv;
 		return this;
 	}
 

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/builders/YarnEnvironmentConfigurer.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/builders/YarnEnvironmentConfigurer.java
@@ -142,19 +142,19 @@ public interface YarnEnvironmentConfigurer {
 	 * <pre>
 	 * public void configure(YarnEnvironmentConfigure environment) throws Exception {
 	 *   environment
-	 *     .includeSystemEnv(false);
+	 *     .includeLocalSystemEnv(false);
 	 * }
 	 * </pre>
 	 *
 	 * <p>XML:
 	 * <pre>
-	 * &lt;yarn:environment include-system-env="false"/>
+	 * &lt;yarn:environment include-local-system-env="false"/>
 	 * </pre>
 	 *
-	 * @param includeSystemEnv if system env variables should be included
+	 * @param includeLocalSystemEnv if system env variables should be included
 	 * @return {@link YarnEnvironmentConfigurer} for chaining
 	 */
-	YarnEnvironmentConfigurer includeSystemEnv(boolean includeSystemEnv);
+	YarnEnvironmentConfigurer includeLocalSystemEnv(boolean includeLocalSystemEnv);
 
 	/**
 	 * Specify properties with a {@link org.springframework.data.hadoop.config.common.annotation.configurers.PropertiesConfigurer}.

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/configuration/EnvironmentFactoryBean.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/configuration/EnvironmentFactoryBean.java
@@ -49,7 +49,7 @@ public class EnvironmentFactoryBean implements InitializingBean, FactoryBean<Map
 	private String defaultYarnAppClasspath;
 
 	/** Flag indicating if system env properties should be included */
-	private boolean includeSystemEnv = true;
+	private boolean includeLocalSystemEnv = false;
 
 	/**
 	 * Flag indicating if a default yarn entries should be added
@@ -157,10 +157,10 @@ public class EnvironmentFactoryBean implements InitializingBean, FactoryBean<Map
 	 * If set to true properties from a {@link System#getenv()} will
 	 * be included to environment settings. Default value is true.
 	 *
-	 * @param includeSystemEnv flag to set
+	 * @param includeLocalSystemEnv flag to set
 	 */
-	public void setIncludeSystemEnv(boolean includeSystemEnv) {
-		this.includeSystemEnv = includeSystemEnv;
+	public void setIncludeLocalSystemEnv(boolean includeLocalSystemEnv) {
+		this.includeLocalSystemEnv = includeLocalSystemEnv;
 	}
 
 	/**
@@ -169,7 +169,7 @@ public class EnvironmentFactoryBean implements InitializingBean, FactoryBean<Map
 	 * @return map of environment variables
 	 */
 	protected Map<String, String> createEnvironment() {
-		if(includeSystemEnv) {
+		if(includeLocalSystemEnv) {
 			return new HashMap<String, String>(System.getenv());
 		} else {
 			return new HashMap<String, String>();

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/YarnUtils.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/YarnUtils.java
@@ -88,8 +88,13 @@ public class YarnUtils {
 	 * @return the {@link ApplicationAttemptId}
 	 */
 	public static ApplicationAttemptId getApplicationAttemptId(Map<String, String> environment) {
+		if (environment == null) {
+			return null;
+		}
 		String amContainerId = environment.get(ApplicationConstants.Environment.CONTAINER_ID.name());
-		Assert.notNull(amContainerId, "CONTAINER_ID env variable has to exist to build appAttemptId");
+		if (amContainerId == null) {
+			return null;
+		}
 		ContainerId containerId = ConverterUtils.toContainerId(amContainerId);
 		return containerId.getApplicationAttemptId();
 	}

--- a/spring-yarn/spring-yarn-core/src/main/resources/org/springframework/yarn/config/spring-yarn-2.0.xsd
+++ b/spring-yarn/spring-yarn-core/src/main/resources/org/springframework/yarn/config/spring-yarn-2.0.xsd
@@ -136,7 +136,7 @@
 			</xsd:attribute>
 			<xsd:attribute name="resources">
 			</xsd:attribute>
-			<xsd:attribute name="include-system-env" type="xsd:boolean" default="true">
+			<xsd:attribute name="include-local-system-env" type="xsd:boolean" default="false">
 			</xsd:attribute>
 		</xsd:extension>
 		</xsd:complexContent>

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/AppmasterTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/AppmasterTests.java
@@ -20,6 +20,9 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -46,6 +49,16 @@ public class AppmasterTests {
         assertThat(service, notNullValue());
 
         ReflectionTestUtils.invokeMethod(master, "getAppmasterService", new Object[0]);
+	}
+
+	public static class TestAppmaster extends StaticAppmaster {
+		@Override
+		protected void onInit() throws Exception {
+			Map<String, String> environment = new HashMap<String, String>();
+			environment.put("CONTAINER_ID", "container_1360089121174_0011_01_000001");
+			setEnvironment(environment);
+			super.onInit();
+		}
 	}
 
 	public static class StubAppmasterService implements AppmasterService {

--- a/spring-yarn/spring-yarn-core/src/test/resources/org/springframework/yarn/am/AppmasterTests-context.xml
+++ b/spring-yarn/spring-yarn-core/src/test/resources/org/springframework/yarn/am/AppmasterTests-context.xml
@@ -13,13 +13,11 @@
 
 	<yarn:localresources/>
 
-	<yarn:environment>
-		CONTAINER_ID=container_1360089121174_0011_01_000001
-	</yarn:environment>
+	<yarn:environment/>
 
 	<bean id="yarnAmservice" class="org.springframework.yarn.am.AppmasterTests$StubAppmasterService"/>
 
-	<yarn:master>
+	<yarn:master appmaster-class="org.springframework.yarn.am.AppmasterTests$TestAppmaster">
 		<yarn:container-command>
 			<![CDATA[
 			fakecommand


### PR DESCRIPTION
- Renamed to include-local-system-env
- Environment was wrongly used in appmaster
  which had a dependency to this setting.
- Appmaster now follows same logic as container
  in terms of usage of beans handling launch
  contexts.
