### PR TITLE
SHDP-287 Better app install/submit model

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1005,6 +1005,34 @@ if (gradle.ext.mr2) {
 		}
 	}
 
+	project('spring-yarn:spring-yarn-boot-build-tests') {
+
+		apply plugin: 'spring-boot'
+
+		description = 'Spring Yarn Boot'
+		dependencies {
+			compile project(":spring-yarn:spring-yarn-boot")
+			testCompile project(":spring-yarn:spring-yarn-boot")
+			testCompile project(":spring-yarn:spring-yarn-test")
+		}
+
+		// create a boot jar which we can use in tests
+		// disable main bootRepackage task so that it
+		// doesn't mess with main artifact
+		// test needs to depend on these tasks
+		task appmasterJar(type: Jar) {
+			archiveName = 'test-archive-appmaster.jar'
+			from sourceSets.test.output
+		}
+		task appmasterBootJar(type: BootRepackage, dependsOn: appmasterJar) {
+			withJarTask = appmasterJar
+			mainClass = 'org.springframework.yarn.boot.app.SpringYarnBootApplication'
+		}
+		bootRepackage.enabled = false
+		test.dependsOn(appmasterBootJar)
+
+	}
+
 	project('spring-yarn:spring-yarn-test') {
 		description = 'Spring Yarn Test Core'
 		configurations {

--- a/settings.gradle
+++ b/settings.gradle
@@ -51,5 +51,5 @@ include 'spring-hadoop-build-tests'
 rootProject.children.find{ it.name == 'spring-hadoop-build-tests' }.name = 'spring-data-hadoop-build-tests'
 if (mr2) {
   print "Based on selected distro (${hadoopDistro}) we are including spring-yarn\n"
-  include 'spring-yarn:spring-yarn-core','spring-yarn:spring-yarn-integration','spring-yarn:spring-yarn-batch','spring-yarn:spring-yarn-test','spring-yarn:spring-yarn-build-tests','spring-yarn:spring-yarn-boot','spring-yarn:spring-yarn-boot-test'
+  include 'spring-yarn:spring-yarn-core','spring-yarn:spring-yarn-integration','spring-yarn:spring-yarn-batch','spring-yarn:spring-yarn-test','spring-yarn:spring-yarn-build-tests','spring-yarn:spring-yarn-boot','spring-yarn:spring-yarn-boot-test','spring-yarn:spring-yarn-boot-build-tests'
 }

--- a/spring-yarn/spring-yarn-boot-build-tests/src/test/java/org/springframework/yarn/boot/app/AbstractApplicationTests.java
+++ b/spring-yarn/spring-yarn-boot-build-tests/src/test/java/org/springframework/yarn/boot/app/AbstractApplicationTests.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.yarn.boot.app;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.hadoop.yarn.api.records.ApplicationReport;
+import org.apache.hadoop.yarn.api.records.YarnApplicationState;
+import org.junit.After;
+import org.junit.Before;
+import org.springframework.data.hadoop.fs.FsShell;
+import org.springframework.yarn.client.YarnClient;
+import org.springframework.yarn.client.YarnClientFactoryBean;
+import org.springframework.yarn.test.context.YarnCluster;
+import org.springframework.yarn.test.support.ClusterInfo;
+import org.springframework.yarn.test.support.YarnClusterManager;
+
+/**
+ * Common shared stuff handling for application tests. For example we use rather
+ * low level minicluster handling here to have hdfs/yarn system setup for tests.
+ * In tests we want to be as close as possible for real use case so we don't
+ * even try to use any magic from rest of the testing support.
+ * <p>
+ * Tests derived from this class will assume existence of
+ * build/libs/test-archive-appmaster.jar which is a custom boot packaged jar
+ * having a dummy StartExitAppmaster class.
+ * <p>
+ * We don't run any containers because focus on these tests is to test app
+ * install/submit/info/query classes.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public abstract class AbstractApplicationTests {
+
+	private final static Log log = LogFactory.getLog(AbstractApplicationTests.class);
+
+	protected final static String APPMASTER_ARCHIVE = "test-archive-appmaster.jar";
+	protected final static String APPMASTER_ARCHIVE_PATH = "file:build/libs/" + APPMASTER_ARCHIVE;
+
+	protected YarnCluster cluster;
+	protected Configuration configuration;
+
+	@Before
+	public void setup() throws Exception {
+		YarnClusterManager manager = YarnClusterManager.getInstance();
+		cluster = manager.getCluster(new ClusterInfo());
+		cluster.start();
+		configuration = cluster.getConfiguration();
+	}
+
+	@After
+	public void clean() {
+		if (cluster != null) {
+			YarnClusterManager manager = YarnClusterManager.getInstance();
+			manager.close();
+			cluster = null;
+		}
+		configuration = null;
+	}
+
+	protected void listFiles(Configuration configuration) {
+		@SuppressWarnings("resource")
+		FsShell shell = new FsShell(configuration);
+		for (FileStatus s : shell.ls(true, "/")) {
+			log.info("XXX " + s);
+		}
+	}
+
+	protected void catFile(String path) {
+		@SuppressWarnings("resource")
+		FsShell shell = new FsShell(configuration);
+		Collection<String> text = shell.text(path);
+		if (text.size() == 1) {
+			log.info("XXX content path");
+			log.info(text.iterator().next());
+		}
+	}
+
+	protected Properties readApplicationProperties(Path path) throws IOException {
+		FileSystem fs = null;
+		FSDataInputStream in = null;
+		Properties properties = null;
+		IOException ioe = null;
+		try {
+			fs = path.getFileSystem(configuration);
+			if (fs.exists(path)) {
+				in = fs.open(path);
+				properties = new Properties();
+				properties.load(in);
+			}
+		}
+		catch (IOException e) {
+			ioe = e;
+		}
+		finally {
+			if (in != null) {
+				try {
+					in.close();
+					in = null;
+				}
+				catch (IOException e) {
+				}
+			}
+			fs = null;
+		}
+		if (ioe != null) {
+			throw ioe;
+		}
+		return properties;
+	}
+
+	protected YarnApplicationState waitState(ApplicationId applicationId, long timeout, TimeUnit unit,
+			YarnApplicationState... applicationStates) throws Exception {
+		YarnApplicationState state = null;
+		long end = System.currentTimeMillis() + unit.toMillis(timeout);
+
+		// break label for inner loop
+		done: do {
+			state = findState(getYarnClient(), applicationId);
+			if (state == null) {
+				break;
+			}
+			for (YarnApplicationState stateCheck : applicationStates) {
+				if (state.equals(stateCheck)) {
+					break done;
+				}
+			}
+			Thread.sleep(1000);
+		} while (System.currentTimeMillis() < end);
+		return state;
+	}
+
+	protected YarnApplicationState findState(YarnClient client, ApplicationId applicationId) {
+		YarnApplicationState state = null;
+		for (ApplicationReport report : client.listApplications()) {
+			if (report.getApplicationId().equals(applicationId)) {
+				state = report.getYarnApplicationState();
+				break;
+			}
+		}
+		return state;
+	}
+
+	protected YarnClient getYarnClient() throws Exception {
+		YarnClientFactoryBean factory = new YarnClientFactoryBean();
+		factory.setConfiguration(configuration);
+		factory.afterPropertiesSet();
+		return factory.getObject();
+	}
+
+	protected ApplicationReport findApplicationReport(ApplicationId applicationId) throws Exception {
+		YarnClient client = getYarnClient();
+		for (ApplicationReport report : client.listApplications()) {
+			if (report.getApplicationId().equals(applicationId)) {
+				client = null;
+				return report;
+			}
+		}
+		client = null;
+		return null;
+	}
+
+}

--- a/spring-yarn/spring-yarn-boot-build-tests/src/test/java/org/springframework/yarn/boot/app/StartExitAppmaster.java
+++ b/spring-yarn/spring-yarn-boot-build-tests/src/test/java/org/springframework/yarn/boot/app/StartExitAppmaster.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.yarn.boot.app;
+
+import org.springframework.yarn.am.StaticAppmaster;
+
+/**
+ * Dummy appmaster for testing which simple starts,
+ * register itself and exit.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class StartExitAppmaster extends StaticAppmaster {
+
+	@Override
+	public void submitApplication() {
+		registerAppmaster();
+		notifyCompleted();
+	}
+
+}

--- a/spring-yarn/spring-yarn-boot-build-tests/src/test/java/org/springframework/yarn/boot/app/StartSleepAppmaster.java
+++ b/spring-yarn/spring-yarn-boot-build-tests/src/test/java/org/springframework/yarn/boot/app/StartSleepAppmaster.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.yarn.boot.app;
+
+import org.springframework.yarn.am.StaticAppmaster;
+
+/**
+ * Dummy appmaster for testing which simple starts,
+ * register itself, sleeps, and exit.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class StartSleepAppmaster extends StaticAppmaster {
+
+	@Override
+	public void submitApplication() {
+		registerAppmaster();
+		try {
+			Thread.sleep(60000);
+		} catch (InterruptedException e) {
+		}
+		notifyCompleted();
+	}
+
+}

--- a/spring-yarn/spring-yarn-boot-build-tests/src/test/java/org/springframework/yarn/boot/app/YarnInfoApplicationTests.java
+++ b/spring-yarn/spring-yarn-boot-build-tests/src/test/java/org/springframework/yarn/boot/app/YarnInfoApplicationTests.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.yarn.boot.app;
+
+import java.util.Properties;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.junit.Test;
+import org.springframework.yarn.boot.support.SpringYarnBootUtils;
+
+public class YarnInfoApplicationTests extends AbstractApplicationTests {
+
+	private final String BASE = "/tmp/YarnBootClientInfoApplicationTests/";
+
+	private final static Log log = LogFactory.getLog(YarnInfoApplicationTests.class);
+
+	@Test
+	public void testListSubmitted() throws Exception {
+
+		// minicluster, need to pass host/ports
+		Properties appProperties = new Properties();
+		SpringYarnBootUtils.mergeHadoopPropertyIntoMap(configuration, "fs.defaultFS", "spring.hadoop.fsUri",
+				appProperties);
+		SpringYarnBootUtils.mergeHadoopPropertyIntoMap(configuration, "yarn.resourcemanager.address",
+				"spring.hadoop.resourceManagerAddress", appProperties);
+		SpringYarnBootUtils.mergeHadoopPropertyIntoMap(configuration, "yarn.resourcemanager.scheduler.address",
+				"spring.hadoop.resourceManagerSchedulerAddress", appProperties);
+
+		String[] args = new String[]{
+				"--spring.yarn.internal.YarnInfoApplication.operation=SUBMITTED"
+		};
+
+		YarnInfoApplication app = new YarnInfoApplication();
+		app.appProperties(appProperties);
+		String info = app.run(args);
+		log.info("XXX info:\n" + info);
+	}
+
+	@Test
+	public void testListInstalled() throws Exception {
+		String ID = "testListInstalled";
+
+		Path path = new Path(BASE + ID);
+		FileSystem fs = path.getFileSystem(configuration);
+		fs.mkdirs(path);
+
+		// minicluster, need to pass host/ports
+		Properties appProperties = new Properties();
+		SpringYarnBootUtils.mergeHadoopPropertyIntoMap(configuration, "fs.defaultFS", "spring.hadoop.fsUri",
+				appProperties);
+		SpringYarnBootUtils.mergeHadoopPropertyIntoMap(configuration, "yarn.resourcemanager.address",
+				"spring.hadoop.resourceManagerAddress", appProperties);
+		SpringYarnBootUtils.mergeHadoopPropertyIntoMap(configuration, "yarn.resourcemanager.scheduler.address",
+				"spring.hadoop.resourceManagerSchedulerAddress", appProperties);
+
+		String[] args = new String[]{
+				"--spring.yarn.applicationBaseDir=" + BASE,
+				"--spring.yarn.internal.YarnInfoApplication.operation=INSTALLED"
+		};
+
+		YarnInfoApplication app = new YarnInfoApplication();
+		app.appProperties(appProperties);
+		app.applicationBaseDir(BASE);
+		String info = app.run(args);
+		log.info("XXX info:\n" + info);
+	}
+
+}

--- a/spring-yarn/spring-yarn-boot-build-tests/src/test/java/org/springframework/yarn/boot/app/YarnInstallApplicationTests.java
+++ b/spring-yarn/spring-yarn-boot-build-tests/src/test/java/org/springframework/yarn/boot/app/YarnInstallApplicationTests.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.yarn.boot.app;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Properties;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.junit.Test;
+import org.springframework.yarn.boot.SpringApplicationException;
+import org.springframework.yarn.boot.support.SpringYarnBootUtils;
+
+/**
+ * Tests for {@link YarnInstallApplication}.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class YarnInstallApplicationTests extends AbstractApplicationTests {
+
+	private final String BASE = "/tmp/YarnBootClientInstallApplicationTests/";
+
+	@Test
+	public void testEmptyInstall() throws Exception {
+		String ID = "testEmptyInstall";
+
+		YarnInstallApplication app = new YarnInstallApplication();
+		app.instanceId(ID);
+		app.applicationBaseDir(BASE);
+
+		// minicluster, need to pass host/ports
+		Properties appProperties = new Properties();
+		SpringYarnBootUtils.mergeHadoopPropertyIntoMap(configuration, "fs.defaultFS", "spring.hadoop.fsUri",
+				appProperties);
+		SpringYarnBootUtils.mergeHadoopPropertyIntoMap(configuration, "yarn.resourcemanager.address",
+				"spring.hadoop.resourceManagerAddress", appProperties);
+		SpringYarnBootUtils.mergeHadoopPropertyIntoMap(configuration, "yarn.resourcemanager.scheduler.address",
+				"spring.hadoop.resourceManagerSchedulerAddress", appProperties);
+		app.appProperties(appProperties);
+
+		String[] args = new String[]{
+				"--spring.yarn.client.clientClass=org.springframework.yarn.client.DefaultApplicationYarnClient",
+		};
+
+		app.run(args);
+
+		listFiles(configuration);
+
+	}
+
+	@Test
+	public void testInstall() throws Exception {
+		String ID = "testInstall";
+
+		YarnInstallApplication app = new YarnInstallApplication();
+		app.instanceId(ID);
+		app.applicationBaseDir(BASE);
+
+		Properties appProperties = new Properties();
+		SpringYarnBootUtils.mergeHadoopPropertyIntoMap(configuration, "fs.defaultFS", "spring.hadoop.fsUri",
+				appProperties);
+		SpringYarnBootUtils.mergeHadoopPropertyIntoMap(configuration, "yarn.resourcemanager.address",
+				"spring.hadoop.resourceManagerAddress", appProperties);
+		SpringYarnBootUtils.mergeHadoopPropertyIntoMap(configuration, "yarn.resourcemanager.scheduler.address",
+				"spring.hadoop.resourceManagerSchedulerAddress", appProperties);
+
+		app.configFile("application.properties", appProperties);
+		app.appProperties(appProperties);
+
+		String[] args = new String[]{
+				"--spring.yarn.client.clientClass=org.springframework.yarn.client.DefaultApplicationYarnClient",
+				"--spring.yarn.client.files[0]=" + APPMASTER_ARCHIVE_PATH
+		};
+
+		app.run(args);
+
+		listFiles(configuration);
+		catFile(BASE + ID + "/application.properties");
+
+		Path archive = new Path(BASE + ID + "/" + APPMASTER_ARCHIVE);
+		FileSystem fs = archive.getFileSystem(configuration);
+		assertThat(fs.exists(archive), is(true));
+
+		Properties applicationProperties = readApplicationProperties(new Path(BASE + ID + "/application.properties"));
+		assertThat(applicationProperties.size(), is(3));
+		assertThat(applicationProperties.get("spring.hadoop.fsUri"), notNullValue());
+		assertThat(applicationProperties.get("spring.hadoop.resourceManagerSchedulerAddress"), notNullValue());
+		assertThat(applicationProperties.get("spring.hadoop.resourceManagerAddress"), notNullValue());
+	}
+
+	@Test(expected=SpringApplicationException.class)
+	public void testInstallFailureIdMissing() throws Exception {
+		YarnInstallApplication app = new YarnInstallApplication();
+		String[] args = new String[]{
+				"--spring.yarn.client.files[0]=" + APPMASTER_ARCHIVE_PATH
+		};
+		app.run(args);
+	}
+
+	@Test(expected=SpringApplicationException.class)
+	public void testInstallFailureAppAlreadyInstalled() throws Exception {
+		String ID = "testInstallFailureAppAlreadyInstalled";
+
+		Path path = new Path(BASE + ID);
+		FileSystem fs = path.getFileSystem(configuration);
+		fs.mkdirs(path);
+
+		YarnInstallApplication app = new YarnInstallApplication();
+		app.instanceId(ID);
+		app.applicationBaseDir(BASE);
+
+		Properties properties = new Properties();
+		SpringYarnBootUtils
+				.mergeHadoopPropertyIntoMap(configuration, "fs.defaultFS", "spring.hadoop.fsUri", properties);
+		SpringYarnBootUtils.mergeHadoopPropertyIntoMap(configuration, "yarn.resourcemanager.address",
+				"spring.hadoop.resourceManagerAddress", properties);
+		SpringYarnBootUtils.mergeHadoopPropertyIntoMap(configuration, "yarn.resourcemanager.scheduler.address",
+				"spring.hadoop.resourceManagerSchedulerAddress", properties);
+
+		app.configFile("application.properties", properties);
+		app.appProperties(properties);
+
+		String[] args = new String[]{
+				"--spring.yarn.client.clientClass=org.springframework.yarn.client.DefaultApplicationYarnClient",
+				"--spring.yarn.client.files[0]=" + APPMASTER_ARCHIVE_PATH
+		};
+
+		app.run(args);
+	}
+
+}

--- a/spring-yarn/spring-yarn-boot-build-tests/src/test/java/org/springframework/yarn/boot/app/YarnKillApplicationTests.java
+++ b/spring-yarn/spring-yarn-boot-build-tests/src/test/java/org/springframework/yarn/boot/app/YarnKillApplicationTests.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.yarn.boot.app;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.hadoop.yarn.api.records.YarnApplicationState;
+import org.junit.Test;
+import org.springframework.yarn.boot.support.SpringYarnBootUtils;
+
+/**
+ * Tests for {@link YarnKillApplication}.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class YarnKillApplicationTests extends AbstractApplicationTests {
+
+	@Test
+	public void testKill() throws Exception {
+		String ID = "testKill";
+		String BASE = "/tmp/YarnKillApplicationTests/";
+
+		// install
+		YarnInstallApplication installApp = new YarnInstallApplication();
+		installApp.instanceId(ID);
+		installApp.applicationBaseDir(BASE);
+
+		Properties appProperties = new Properties();
+		SpringYarnBootUtils.mergeHadoopPropertyIntoMap(configuration, "fs.defaultFS", "spring.hadoop.fsUri",
+				appProperties);
+		SpringYarnBootUtils.mergeHadoopPropertyIntoMap(configuration, "yarn.resourcemanager.address",
+				"spring.hadoop.resourceManagerAddress", appProperties);
+		SpringYarnBootUtils.mergeHadoopPropertyIntoMap(configuration, "yarn.resourcemanager.scheduler.address",
+				"spring.hadoop.resourceManagerSchedulerAddress", appProperties);
+
+		installApp.configFile("application.properties", appProperties);
+		installApp.appProperties(appProperties);
+
+		String[] installArgs = new String[]{
+				"--spring.yarn.appmaster.appmasterClass=org.springframework.yarn.boot.app.StartSleepAppmaster",
+				"--spring.yarn.client.clientClass=org.springframework.yarn.client.DefaultApplicationYarnClient",
+				"--spring.yarn.client.files[0]=" + APPMASTER_ARCHIVE_PATH
+		};
+		installApp.run(installArgs);
+
+		// submit
+		YarnSubmitApplication submitApp = new YarnSubmitApplication();
+		submitApp.instanceId(ID);
+		submitApp.applicationBaseDir(BASE);
+		submitApp.appProperties(appProperties);
+
+		String[] submitArgs = new String[]{
+				"--spring.yarn.client.clientClass=org.springframework.yarn.client.DefaultApplicationYarnClient",
+				"--spring.yarn.client.launchcontext.archiveFile=" + APPMASTER_ARCHIVE
+		};
+
+		ApplicationId applicationId = submitApp.run(submitArgs);
+
+		YarnApplicationState state = waitState(applicationId, 60, TimeUnit.SECONDS, YarnApplicationState.FINISHED,
+				YarnApplicationState.FAILED, YarnApplicationState.RUNNING);
+		assertThat(state, is(YarnApplicationState.RUNNING));
+
+		// kill
+		YarnKillApplication killApp = new YarnKillApplication();
+		killApp.appProperties(appProperties);
+
+		String[] killArgs = new String[]{
+				"--spring.yarn.internal.YarnKillApplication.applicationId=" + applicationId.toString()
+		};
+
+		String info = killApp.run(killArgs);
+		assertThat(info, containsString("Kill request for"));
+	}
+
+}

--- a/spring-yarn/spring-yarn-boot-build-tests/src/test/java/org/springframework/yarn/boot/app/YarnSubmitApplicationTests.java
+++ b/spring-yarn/spring-yarn-boot-build-tests/src/test/java/org/springframework/yarn/boot/app/YarnSubmitApplicationTests.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.yarn.boot.app;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.hadoop.yarn.api.records.YarnApplicationState;
+import org.junit.Test;
+import org.springframework.yarn.boot.support.SpringYarnBootUtils;
+
+/**
+ * Tests for {@link YarnSubmitApplication}.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class YarnSubmitApplicationTests extends AbstractApplicationTests {
+
+	@Test
+	public void testInstallSubmit() throws Exception {
+		String ID = "testInstallSubmit";
+		String BASE = "/tmp/YarnSubmitApplicationTests/";
+
+		// instal
+		YarnInstallApplication installApp = new YarnInstallApplication();
+		installApp.instanceId(ID);
+		installApp.applicationBaseDir(BASE);
+
+		Properties appProperties = new Properties();
+		SpringYarnBootUtils.mergeHadoopPropertyIntoMap(configuration, "fs.defaultFS", "spring.hadoop.fsUri",
+				appProperties);
+		SpringYarnBootUtils.mergeHadoopPropertyIntoMap(configuration, "yarn.resourcemanager.address",
+				"spring.hadoop.resourceManagerAddress", appProperties);
+		SpringYarnBootUtils.mergeHadoopPropertyIntoMap(configuration, "yarn.resourcemanager.scheduler.address",
+				"spring.hadoop.resourceManagerSchedulerAddress", appProperties);
+
+		installApp.configFile("application.properties", appProperties);
+		installApp.appProperties(appProperties);
+
+		String[] args = new String[]{
+				"--spring.yarn.appmaster.appmasterClass=org.springframework.yarn.boot.app.StartExitAppmaster",
+				"--spring.yarn.client.clientClass=org.springframework.yarn.client.DefaultApplicationYarnClient",
+				"--spring.yarn.client.files[0]=" + APPMASTER_ARCHIVE_PATH
+		};
+		installApp.run(args);
+
+		// submit
+		YarnSubmitApplication submitApp = new YarnSubmitApplication();
+		submitApp.instanceId(ID);
+		submitApp.applicationBaseDir(BASE);
+		submitApp.appProperties(appProperties);
+
+		args = new String[]{
+				"--spring.yarn.client.clientClass=org.springframework.yarn.client.DefaultApplicationYarnClient",
+				"--spring.yarn.client.launchcontext.archiveFile=" + APPMASTER_ARCHIVE
+		};
+
+		ApplicationId applicationId = submitApp.run(args);
+
+		YarnApplicationState state = waitState(applicationId, 60, TimeUnit.SECONDS, YarnApplicationState.FINISHED, YarnApplicationState.FAILED);
+		assertThat(state, is(YarnApplicationState.FINISHED));
+	}
+
+}

--- a/spring-yarn/spring-yarn-boot-build-tests/src/test/resources/log4j.properties
+++ b/spring-yarn/spring-yarn-boot-build-tests/src/test/resources/log4j.properties
@@ -1,0 +1,10 @@
+log4j.rootCategory=INFO, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} %5p %t %c{2} - %m%n
+
+log4j.category.org.springframework.hadoop.test=DEBUG
+log4j.category.org.springframework.batch=TRACE
+log4j.category.org.springframework.yarn=DEBUG
+

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/SpringApplicationException.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/SpringApplicationException.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.yarn.boot;
+
+import org.springframework.dao.UncategorizedDataAccessException;
+
+/**
+ * Generic exception thrown from a
+ * {@link SpringApplicationTemplate#execute(SpringApplicationCallback, String...)}
+ * to be able to wrap a possible exception.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class SpringApplicationException extends UncategorizedDataAccessException {
+
+	private static final long serialVersionUID = 6791172815454960337L;
+
+	/**
+	 * Instantiates a new spring application exception.
+	 *
+	 * @param msg the message
+	 * @param cause the cause
+	 */
+	public SpringApplicationException(String msg, Throwable cause) {
+		super(msg, cause);
+	}
+
+}

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/SpringApplicationTemplate.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/SpringApplicationTemplate.java
@@ -30,15 +30,16 @@ import org.springframework.context.ConfigurableApplicationContext;
  */
 public class SpringApplicationTemplate {
 
-	private SpringApplicationBuilder builder;
+	private final SpringApplicationBuilder builder;
 
+	/**
+	 * Instantiates a new spring application template.
+	 *
+	 * @param builder the spring application builder
+	 */
 	public SpringApplicationTemplate(SpringApplicationBuilder builder) {
 		this.builder = builder;
 	}
-
-	// TODO: when we get better internal support for executing
-	//       beans via reflection aka, container activator for pojos,
-	//       add support methods here not to have need to always use raw execute
 
 	/**
 	 * Execute spring application from a builder. This method will automatically
@@ -48,13 +49,13 @@ public class SpringApplicationTemplate {
 	 * @param args the boot application args
 	 * @return the value from an execution
 	 */
-	public <T> T execute(SpringApplicationCallback<T> action, String... args) {
+	public <T> T execute(SpringApplicationCallback<T> action, String... args) throws SpringApplicationException {
 		ConfigurableApplicationContext context = null;
 		try {
 			context = builder.run(args);
 			return action.runWithSpringApplication(context);
 		} catch (Exception e) {
-			throw new RuntimeException(e);
+			throw new SpringApplicationException("Error executing a spring application", e);
 		} finally {
 			if (context != null) {
 				try {

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/YarnAppmasterAutoConfiguration.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/YarnAppmasterAutoConfiguration.java
@@ -48,6 +48,7 @@ import org.springframework.yarn.boot.support.AppmasterLauncherRunner;
 import org.springframework.yarn.boot.support.BootApplicationEventTransformer;
 import org.springframework.yarn.boot.support.BootLocalResourcesSelector;
 import org.springframework.yarn.boot.support.BootLocalResourcesSelector.Mode;
+import org.springframework.yarn.boot.support.SpringYarnBootUtils;
 import org.springframework.yarn.boot.support.YarnJobLauncherCommandLineRunner;
 import org.springframework.yarn.config.annotation.EnableYarn;
 import org.springframework.yarn.config.annotation.EnableYarn.Enable;
@@ -202,11 +203,12 @@ public class YarnAppmasterAutoConfiguration {
 
 		@Override
 		public void configure(YarnResourceLocalizerConfigurer localizer) throws Exception {
+			String applicationDir = SpringYarnBootUtils.resolveApplicationdir(syp);
 			localizer
 				.stagingDirectory(syp.getStagingDir());
 			LocalResourcesHdfsConfigurer withHdfs = localizer.withHdfs();
-			for (Entry e : localResourcesSelector.select(syp.getApplicationDir() != null ? syp.getApplicationDir() : "/")) {
-				withHdfs.hdfs(e.getPath(), e.getType(), syp.getApplicationDir() == null);
+			for (Entry e : localResourcesSelector.select(applicationDir != null ? applicationDir : "/")) {
+				withHdfs.hdfs(e.getPath(), e.getType(), applicationDir == null);
 			}
 		}
 

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/YarnClientAutoConfiguration.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/YarnClientAutoConfiguration.java
@@ -35,6 +35,7 @@ import org.springframework.yarn.boot.properties.SpringYarnEnvProperties;
 import org.springframework.yarn.boot.properties.SpringYarnProperties;
 import org.springframework.yarn.boot.support.BootLocalResourcesSelector;
 import org.springframework.yarn.boot.support.BootLocalResourcesSelector.Mode;
+import org.springframework.yarn.boot.support.SpringYarnBootUtils;
 import org.springframework.yarn.client.YarnClient;
 import org.springframework.yarn.config.annotation.EnableYarn;
 import org.springframework.yarn.config.annotation.EnableYarn.Enable;
@@ -125,15 +126,16 @@ public class YarnClientAutoConfiguration {
 
 		@Override
 		public void configure(YarnResourceLocalizerConfigurer localizer) throws Exception {
+			String applicationDir = SpringYarnBootUtils.resolveApplicationdir(syp);
 			localizer
 				.stagingDirectory(syp.getStagingDir())
 				.withCopy()
-					.copy(StringUtils.toStringArray(sycp.getFiles()), syp.getApplicationDir(), syp.getApplicationDir() == null)
-					.raw(syclp.getRawFileContents(), syp.getApplicationDir());
+					.copy(StringUtils.toStringArray(sycp.getFiles()), applicationDir, applicationDir == null)
+					.raw(syclp.getRawFileContents(), applicationDir);
 
 			LocalResourcesHdfsConfigurer withHdfs = localizer.withHdfs();
-			for (Entry e : localResourcesSelector.select(syp.getApplicationDir() != null ? syp.getApplicationDir() : "/")) {
-				withHdfs.hdfs(e.getPath(), e.getType(), syp.getApplicationDir() == null);
+			for (Entry e : localResourcesSelector.select(applicationDir != null ? applicationDir : "/")) {
+				withHdfs.hdfs(e.getPath(), e.getType(), applicationDir == null);
 			}
 		}
 
@@ -153,6 +155,7 @@ public class YarnClientAutoConfiguration {
 		@Override
 		public void configure(YarnClientConfigurer client) throws Exception {
 			client
+				.clientClass(sycp.getClientClass())
 				.appName(syp.getAppName())
 				.appType(syp.getAppType())
 				.priority(sycp.getPriority())

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/AbstractClientApplication.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/AbstractClientApplication.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.yarn.boot.app;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+
+/**
+ * Base class for client applications.
+ *
+ * @author Janne Valkealahti
+ *
+ * @param <T> the type of a sub-class
+ */
+public abstract class AbstractClientApplication<T extends AbstractClientApplication<T>> {
+
+	protected String instanceId;
+	protected String applicationBaseDir;
+	protected List<Object> sources = new ArrayList<Object>();
+	protected List<String> profiles = new ArrayList<String>();
+	protected Properties appProperties = new Properties();
+
+	/**
+	 * Sets an instance id to be used by a builder.
+	 *
+	 * @param instanceId the appid
+	 * @return the T for chaining
+	 */
+	public T instanceId(String instanceId) {
+		Assert.state(StringUtils.hasText(instanceId), "Instance id must not be empty");
+		this.instanceId = instanceId;
+		return getThis();
+	}
+
+	/**
+	 * Sets an Applications base directory to be used by a builder.
+	 *
+	 * @param applicationBaseDir the applications base directory
+	 * @return the T for chaining
+	 */
+	public T applicationBaseDir(String applicationBaseDir) {
+		// can be empty because value may come from an existing properties
+		this.applicationBaseDir = applicationBaseDir;
+		return getThis();
+	}
+
+	/**
+	 * Sets an additional sources to by used when running
+	 * an {@link SpringApplication}.
+	 *
+	 * @param sources the additional sources for Spring Application
+	 * @return the T for chaining
+	 */
+	public T sources(Object... sources) {
+		if (!ObjectUtils.isEmpty(sources)) {
+			this.sources.addAll(Arrays.asList(sources));
+		}
+		return getThis();
+	}
+
+	/**
+	 * Sets an additional profiles to be used when running
+	 * an {@link SpringApplication}.
+	 *
+	 * @param profiles the additional profiles for Spring Application
+	 * @return the T for chaining
+	 */
+	public T profiles(String ... profiles) {
+		if (!ObjectUtils.isEmpty(profiles)) {
+			this.profiles.addAll(Arrays.asList(profiles));
+		}
+		return getThis();
+	}
+
+	/**
+	 * Sets application properties which will be passed into a Spring Boot
+	 * environment. Properties are placed with a priority which is just below
+	 * command line arguments put above all other properties.
+	 * <p>
+	 * Effectively this means that these properties allow to override all
+	 * existing properties but still doesn't override properties based on
+	 * command-line arguments. Command-line arguments in this context are the
+	 * ones passed to {@link #run(String...)} method.
+	 *
+	 * @param appProperties the app properties
+	 * @return the T for chaining
+	 */
+	public T appProperties(Properties appProperties) {
+		this.appProperties = appProperties;
+		return getThis();
+	}
+
+	/**
+	 * Gets the instance of this defined by a sub-class. Needed for methods in
+	 * this abstract class to be able to return correct type for method
+	 * chaining.
+	 *
+	 * @return the this instance
+	 */
+	protected abstract T getThis();
+
+}

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/YarnSubmitApplication.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/YarnSubmitApplication.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.yarn.boot.app;
+
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
+import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.EmbeddedServletContainerAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.WebMvcAutoConfiguration;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+import org.springframework.yarn.boot.SpringApplicationCallback;
+import org.springframework.yarn.boot.SpringApplicationTemplate;
+import org.springframework.yarn.boot.properties.SpringYarnProperties;
+import org.springframework.yarn.boot.support.SpringYarnBootUtils;
+import org.springframework.yarn.client.ApplicationDescriptor;
+import org.springframework.yarn.client.ApplicationYarnClient;
+import org.springframework.yarn.client.YarnClient;
+
+/**
+ * Generic Spring Boot client application used to submit Spring Yarn Boot based apps into Yarn.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@Configuration
+@EnableAutoConfiguration(exclude = { EmbeddedServletContainerAutoConfiguration.class, WebMvcAutoConfiguration.class,
+		JmxAutoConfiguration.class, BatchAutoConfiguration.class })
+public class YarnSubmitApplication extends AbstractClientApplication<YarnSubmitApplication> {
+
+	/**
+	 * Run a {@link SpringApplication} build by a
+	 * {@link SpringApplicationBuilder} using an empty args.
+	 *
+	 * @return the application id
+	 * @see #run(String...)
+	 */
+	public ApplicationId run() {
+		return run(new String[0]);
+	}
+
+	/**
+	 * Run a {@link SpringApplication} build by a
+	 * {@link SpringApplicationBuilder} using an empty args.
+	 *
+	 * @param args the args
+	 * @return the application id
+	 */
+	public ApplicationId run(String... args) {
+		Assert.state(StringUtils.hasText(instanceId), "Instance id must be set");
+		SpringApplicationBuilder builder = new SpringApplicationBuilder();
+		builder.web(false);
+		builder.sources(YarnSubmitApplication.class);
+		SpringYarnBootUtils.addSources(builder, sources.toArray(new Object[0]));
+		SpringYarnBootUtils.addProfiles(builder, profiles.toArray(new String[0]));
+
+		if (StringUtils.hasText(applicationBaseDir)) {
+			appProperties.setProperty("spring.yarn.applicationDir", applicationBaseDir + instanceId + "/");
+		}
+
+		appProperties.setProperty("spring.yarn.applicationId", instanceId);
+		SpringYarnBootUtils.addApplicationListener(builder, appProperties);
+
+		SpringApplicationTemplate template = new SpringApplicationTemplate(builder);
+		return template.execute(new SpringApplicationCallback<ApplicationId>() {
+
+			@Override
+			public ApplicationId runWithSpringApplication(ApplicationContext context) throws Exception {
+				YarnClient client = context.getBean(YarnClient.class);
+				SpringYarnProperties syp = context.getBean(SpringYarnProperties.class);
+				String applicationdir = SpringYarnBootUtils.resolveApplicationdir(syp);
+				if (client instanceof ApplicationYarnClient) {
+					return ((ApplicationYarnClient)client).submitApplication(new ApplicationDescriptor(applicationdir));
+				} else {
+					return client.submitApplication(false);
+				}
+			}
+
+		}, args);
+	}
+
+	@Override
+	protected YarnSubmitApplication getThis() {
+		return this;
+	}
+
+}

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/SpringYarnClientProperties.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/SpringYarnClientProperties.java
@@ -32,6 +32,7 @@ public class SpringYarnClientProperties {
 	private List<String> files;
 	private Integer priority;
 	private String queue;
+	private String clientClass;
 
 	public List<String> getFiles() {
 		return files;
@@ -55,6 +56,14 @@ public class SpringYarnClientProperties {
 
 	public void setQueue(String queue) {
 		this.queue = queue;
+	}
+
+	public String getClientClass() {
+		return clientClass;
+	}
+
+	public void setClientClass(String clientClass) {
+		this.clientClass = clientClass;
 	}
 
 }

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/SpringYarnProperties.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/SpringYarnProperties.java
@@ -29,6 +29,7 @@ public class SpringYarnProperties {
 
 	private String applicationDir;
 	private String applicationBaseDir;
+	private String applicationId;
 	private String stagingDir;
 	private String appName;
 	private String appType;
@@ -51,6 +52,14 @@ public class SpringYarnProperties {
 
 	public void setApplicationBaseDir(String applicationBaseDir) {
 		this.applicationBaseDir = applicationBaseDir;
+	}
+
+	public String getApplicationId() {
+		return applicationId;
+	}
+
+	public void setApplicationId(String applicationId) {
+		this.applicationId = applicationId;
 	}
 
 	public String getStagingDir() {

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/support/SpringYarnBootUtils.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/support/SpringYarnBootUtils.java
@@ -27,6 +27,7 @@ import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
+import org.springframework.yarn.boot.properties.SpringYarnProperties;
 
 /**
  * Utilities for Spring Yarn Boot.
@@ -130,6 +131,16 @@ public final class SpringYarnBootUtils {
 			Properties p = new Properties();
 			p.put("spring.yarn.client.localizer.rawFileContents", content);
 			builder.properties(p);
+		}
+	}
+
+	public static String resolveApplicationdir(SpringYarnProperties syp) {
+		if (StringUtils.hasText(syp.getApplicationBaseDir()) && StringUtils.hasText(syp.getApplicationId())) {
+			return (syp.getApplicationBaseDir().endsWith("/") ? syp.getApplicationBaseDir() : syp
+					.getApplicationBaseDir() + "/")
+					+ syp.getApplicationId() + "/";
+		} else {
+			return syp.getApplicationDir();
 		}
 	}
 

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/support/YarnBootClientApplicationListener.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/support/YarnBootClientApplicationListener.java
@@ -17,6 +17,8 @@ package org.springframework.yarn.boot.support;
 
 import java.util.Map;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.core.env.CommandLinePropertySource;
@@ -32,6 +34,8 @@ import org.springframework.util.Assert;
  *
  */
 public class YarnBootClientApplicationListener implements ApplicationListener<ApplicationEnvironmentPreparedEvent> {
+
+	private final static Log log = LogFactory.getLog(YarnBootClientApplicationListener.class);
 
 	private final Map<String, Object> propertySourceMap;
 
@@ -49,9 +53,16 @@ public class YarnBootClientApplicationListener implements ApplicationListener<Ap
 	public void onApplicationEvent(ApplicationEnvironmentPreparedEvent event) {
 		MutablePropertySources propertySources = event.getEnvironment().getPropertySources();
 		if (propertySources.contains(CommandLinePropertySource.COMMAND_LINE_PROPERTY_SOURCE_NAME)) {
+			if(log.isDebugEnabled()) {
+				log.debug("Adding afterCommandLineArgs property source after "
+						+ CommandLinePropertySource.COMMAND_LINE_PROPERTY_SOURCE_NAME);
+			}
 			propertySources.addAfter(CommandLinePropertySource.COMMAND_LINE_PROPERTY_SOURCE_NAME,
 					new MapPropertySource("afterCommandLineArgs", propertySourceMap));
 		} else {
+			if(log.isDebugEnabled()) {
+				log.debug("Adding afterCommandLineArgs property source as first");
+			}
 			propertySources.addFirst(new MapPropertySource("afterCommandLineArgs", propertySourceMap));
 		}
 	}

--- a/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringYarnClientPropertiesTests.java
+++ b/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringYarnClientPropertiesTests.java
@@ -52,6 +52,8 @@ public class SpringYarnClientPropertiesTests {
 		assertThat(properties.getPriority(), is(234));
 		assertThat(properties.getQueue(), is("queueFoo"));
 
+		assertThat(properties.getClientClass(), is("clientClassFoo"));
+
 		context.close();
 	}
 

--- a/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringYarnPropertiesTests.java
+++ b/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringYarnPropertiesTests.java
@@ -42,6 +42,7 @@ public class SpringYarnPropertiesTests {
 		assertThat(properties, notNullValue());
 		assertThat(properties.getApplicationDir(), is("applicationDirFoo"));
 		assertThat(properties.getApplicationBaseDir(), is("applicationBaseDirFoo"));
+		assertThat(properties.getApplicationId(), is("applicationIdFoo"));
 		assertThat(properties.getAppName(), is("appNameFoo"));
 		assertThat(properties.getAppType(), is("appTypeFoo"));
 		assertThat(properties.getStagingDir(), is("stagingDirFoo"));

--- a/spring-yarn/spring-yarn-boot/src/test/resources/SpringYarnClientPropertiesTests.yml
+++ b/spring-yarn/spring-yarn-boot/src/test/resources/SpringYarnClientPropertiesTests.yml
@@ -6,3 +6,4 @@ spring:
               - "files2Foo"
             priority: 234
             queue: queueFoo
+            clientClass: clientClassFoo

--- a/spring-yarn/spring-yarn-boot/src/test/resources/SpringYarnPropertiesTests.yml
+++ b/spring-yarn/spring-yarn-boot/src/test/resources/SpringYarnPropertiesTests.yml
@@ -5,4 +5,5 @@ spring:
         stagingDir: stagingDirFoo
         applicationDir: applicationDirFoo
         applicationBaseDir: applicationBaseDirFoo
+        applicationId: applicationIdFoo
         defaultYarnAppClasspath: defaultYarnAppClasspathFoo

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/YarnSystemException.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/YarnSystemException.java
@@ -60,9 +60,6 @@ public class YarnSystemException extends UncategorizedDataAccessException {
 	public YarnSystemException(IOException e) {
 		super(e.getMessage(), e);
 	}
-//	public YarnSystemException(RemoteException e) {
-//		super(e.getMessage(), e);
-//	}
 
 	/**
 	 * Constructs a general YarnSystemException.

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/client/ApplicationDescriptor.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/client/ApplicationDescriptor.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.yarn.client;
+
+/**
+ * An {@code ApplicationDescriptor} is a descriptor for an application meant to
+ * be installed into HDFS and later run from there.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class ApplicationDescriptor {
+
+	// for now we only keep directory to guard
+	// against installation and launch errors.
+	// we should add more functionality into this
+	// descriptor to be able to check before we
+	// launch anything that all application files
+	// are in place.
+
+	private String directory;
+
+	/**
+	 * Instantiates a new application descriptor.
+	 */
+	public ApplicationDescriptor() {
+	}
+
+	/**
+	 * Instantiates a new application descriptor.
+	 *
+	 * @param directory the application directory
+	 */
+	public ApplicationDescriptor(String directory) {
+		this.directory = directory;
+	}
+
+	/**
+	 * Gets the application directory.
+	 *
+	 * @return the application directory
+	 */
+	public String getDirectory() {
+		return directory;
+	}
+
+	/**
+	 * Sets the application directory.
+	 *
+	 * @param directory the new application directory
+	 */
+	public void setDirectory(String directory) {
+		this.directory = directory;
+	}
+
+}

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/client/ApplicationYarnClient.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/client/ApplicationYarnClient.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.yarn.client;
+
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+
+/**
+ * A {@code ApplicationYarnClient} is an extension of {@link YarnClient}
+ * introducing more direct semantics of an application. Core yarn and generally
+ * when something is executed on yarn, there are no hard dependencies of
+ * existing application files.
+ * <p>
+ * This interface adds these semantics by using an {@link ApplicationDescriptor}
+ * which an implementation can for example use to guard against various
+ * application problems like not overwriting existing application instance or
+ * trying to launch an application which doesn't exist.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public interface ApplicationYarnClient extends YarnClient {
+
+	/**
+	 * Install application based on {@link ApplicationDescriptor}.
+	 *
+	 * @param descriptor the application descriptor
+	 */
+	void installApplication(ApplicationDescriptor descriptor);
+
+	/**
+	 * Submit application based on {@link ApplicationDescriptor}.
+	 *
+	 * @param descriptor the application descriptor
+	 * @return the application id
+	 */
+	ApplicationId submitApplication(ApplicationDescriptor descriptor);
+
+}

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/client/DefaultApplicationYarnClient.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/client/DefaultApplicationYarnClient.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.yarn.client;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.springframework.yarn.YarnSystemException;
+
+/**
+ * An implementation of {@link ApplicationYarnClient} verifying application
+ * install and submit statuses.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class DefaultApplicationYarnClient extends CommandYarnClient implements ApplicationYarnClient {
+
+	/**
+	 * Instantiates a new default application yarn client.
+	 *
+	 * @param clientRmOperations the client rm operations
+	 */
+	public DefaultApplicationYarnClient(ClientRmOperations clientRmOperations) {
+		super(clientRmOperations);
+	}
+
+	@Override
+	public void installApplication(ApplicationDescriptor descriptor) {
+		preInstallVerify(descriptor);
+		installApplication();
+		postInstallVerify(descriptor);
+	}
+
+	@Override
+	public ApplicationId submitApplication(ApplicationDescriptor descriptor) {
+		preSubmitVerify(descriptor);
+		ApplicationId applicationId = submitApplication(false);
+		postSubmitVerify(applicationId, descriptor);
+		return applicationId;
+	}
+
+	/**
+	 * Pre install verify.
+	 *
+	 * @param descriptor the application descriptor
+	 */
+	protected void preInstallVerify(ApplicationDescriptor descriptor) {
+		try {
+			Path path = new Path(descriptor.getDirectory());
+			FileSystem fs = path.getFileSystem(getConfiguration());
+			if (fs.exists(path)) {
+				throw new IllegalArgumentException("Application directory " + descriptor.getDirectory() + " already exists");
+			}
+		} catch (Exception e) {
+			throw new YarnSystemException("Error", e);
+		}
+	}
+
+	/**
+	 * Post install verify.
+	 *
+	 * @param descriptor the application descriptor
+	 */
+	protected void postInstallVerify(ApplicationDescriptor descriptor) {
+	}
+
+	/**
+	 * Pre submit verify.
+	 *
+	 * @param descriptor the application descriptor
+	 */
+	protected void preSubmitVerify(ApplicationDescriptor descriptor) {
+		try {
+			Path path = new Path(descriptor.getDirectory());
+			FileSystem fs = path.getFileSystem(getConfiguration());
+			if (!fs.exists(path)) {
+				throw new IllegalArgumentException("Application directory " + descriptor.getDirectory() + " doesn't exist");
+			}
+		} catch (Exception e) {
+			throw new YarnSystemException("Error", e);
+		}
+	}
+
+	/**
+	 * Post submit verify.
+	 *
+	 * @param applicationId the application id
+	 * @param descriptor the application descriptor
+	 */
+	protected void postSubmitVerify(ApplicationId applicationId, ApplicationDescriptor descriptor) {
+	}
+
+}

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/builders/YarnClientConfigurer.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/builders/YarnClientConfigurer.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.yarn.config.annotation.builders;
 
+import org.springframework.yarn.client.YarnClient;
 import org.springframework.yarn.config.annotation.SpringYarnConfigurerAdapter;
 import org.springframework.yarn.config.annotation.configurers.ClientMasterRunnerConfigurer;
 import org.springframework.yarn.config.annotation.configurers.DefaultClientMasterRunnerConfigurer;
@@ -304,5 +305,49 @@ public interface YarnClientConfigurer {
 	 * @return {@link YarnClientConfigurer} for chaining
 	 */
 	YarnClientConfigurer queue(String queue);
+
+	/**
+	 * Specify a {@code YarnClient} class.
+	 *
+	 * <p>
+	 * <p>JavaConfig:
+	 * <p>
+	 * <pre>
+	 * public void configure(YarnClientConfigure client) throws Exception {
+	 *   client
+	 *     .clientClass(MyYarnClient.class);
+	 * }
+	 * </pre>
+	 *
+	 * <p>XML:
+	 * <p>
+	 * No equivalent
+	 *
+	 * @param clazz The Yarn client class
+	 * @return {@link YarnClientConfigurer} for chaining
+	 */
+	YarnClientConfigurer clientClass(Class<? extends YarnClient> clazz);
+
+	/**
+	 * Specify a {@code YarnClient} as a fully qualified class name.
+	 *
+	 * <p>
+	 * <p>JavaConfig:
+	 * <p>
+	 * <pre>
+	 * public void configure(YarnClientConfigure client) throws Exception {
+	 *   client
+	 *     .clientClass("com.example.MyYarnClient");
+	 * }
+	 * </pre>
+	 *
+	 * <p>XML:
+	 * <p>
+	 * No equivalent
+	 *
+	 * @param clazz The Yarn client class
+	 * @return {@link YarnClientConfigurer} for chaining
+	 */
+	YarnClientConfigurer clientClass(String clazz);
 
 }


### PR DESCRIPTION
- Refactored built-in apps in spring-yarn-core handling
  app lifecycles.
- New DefaultApplicationYarnClient which does a better job
  installing and running apps by guarding against errors
  by having a knowledge where app is installed and from
  where app is started.
- New spring.yarn.applicationId which together with
  applicationBaseDir can overwrite applicationDir. This
  concept allows to install apps on a different hdfs
  directories so that actual app dir can be resolved at runtime.
- YarnClientFactoryBean can know instantiate a yarn client based
  on a given client class. Related changes in YarnClientConfigurer
  and YarnClientBuilder.
