### PR TITLE
SHDP-272 Change default yarn classpath handling

### DIFF
--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/EnvironmentParser.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/EnvironmentParser.java
@@ -44,6 +44,7 @@ class EnvironmentParser extends AbstractPropertiesConfiguredBeanDefinitionParser
 		super.doParse(element, parserContext, builder);
 
 		builder.addPropertyValue("includeLocalSystemEnv", element.getAttribute("include-local-system-env"));
+		YarnNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "configuration");
 
 		List<Element> entries = DomUtils.getChildElementsByTagName(element, "classpath");
 		if(entries.size() == 1) {

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/builders/SpringYarnConfigBuilder.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/builders/SpringYarnConfigBuilder.java
@@ -75,7 +75,9 @@ public class SpringYarnConfigBuilder
 		ResourceLocalizer localizer = yarnResourceLocalizerBuilder.build();
 		config.setLocalizer(localizer);
 
-		Map<String, String> env = getSharedObject(YarnEnvironmentBuilder.class).build();
+		YarnEnvironmentBuilder yarnEnvironmentBuilder = getSharedObject(YarnEnvironmentBuilder.class);
+		yarnEnvironmentBuilder.configuration(configuration);
+		Map<String, String> env = yarnEnvironmentBuilder.build();
 		config.setEnvironment(env);
 
 		YarnClientBuilder yarnClientBuilder = getSharedObject(YarnClientBuilder.class);

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/builders/YarnEnvironmentBuilder.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/builders/YarnEnvironmentBuilder.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Map;
 import java.util.Properties;
 
+import org.apache.hadoop.conf.Configuration;
 import org.springframework.beans.factory.config.PropertiesFactoryBean;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.data.hadoop.config.common.annotation.AbstractConfiguredAnnotationBuilder;
@@ -42,6 +43,7 @@ public final class YarnEnvironmentBuilder
 		extends AbstractConfiguredAnnotationBuilder<Map<String, String>, YarnEnvironmentConfigurer, YarnEnvironmentBuilder>
 		implements PropertiesConfigurerAware, YarnEnvironmentConfigurer {
 
+	private Configuration configuration;
 	private boolean useDefaultYarnClasspath = true;
 	private boolean includeBaseDirectory = true;
 	private boolean includeLocalSystemEnv = false;
@@ -58,6 +60,7 @@ public final class YarnEnvironmentBuilder
 	@Override
 	protected Map<String, String> performBuild() throws Exception {
 		EnvironmentFactoryBean fb = new EnvironmentFactoryBean();
+		fb.setConfiguration(configuration);
 		fb.setProperties(properties);
 		fb.setClasspath(StringUtils.collectionToDelimitedString(classpathEntries, delimiter));
 		fb.setDelimiter(delimiter);
@@ -114,6 +117,15 @@ public final class YarnEnvironmentBuilder
 	 */
 	public void addClasspathEntries(ArrayList<String> classpathEntries) {
 		this.classpathEntries.addAll(classpathEntries);
+	}
+
+	/**
+	 * Sets the yarn configuration.
+	 *
+	 * @param configuration the yarn configuration
+	 */
+	public void configuration(Configuration configuration) {
+		this.configuration = configuration;
 	}
 
 	/**

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/configurers/DefaultEnvironmentClasspathConfigurer.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/configurers/DefaultEnvironmentClasspathConfigurer.java
@@ -91,6 +91,12 @@ public class DefaultEnvironmentClasspathConfigurer
 	}
 
 	@Override
+	public EnvironmentClasspathConfigurer defaultYarnAppClasspath(String... defaultClasspath) {
+		this.defaultYarnAppClasspath = StringUtils.arrayToCommaDelimitedString(defaultClasspath);
+		return this;
+	}
+
+	@Override
 	public EnvironmentClasspathConfigurer includeBaseDirectory(boolean includeBaseDirectory) {
 		this.includeBaseDirectory = includeBaseDirectory;
 		return this;

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/configurers/EnvironmentClasspathConfigurer.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/configurers/EnvironmentClasspathConfigurer.java
@@ -84,12 +84,21 @@ public interface EnvironmentClasspathConfigurer extends AnnotationConfigurerBuil
 	EnvironmentClasspathConfigurer useDefaultYarnClasspath(boolean useDefaultClasspath);
 
 	/**
-	 * Specify a default yarn application classpath
+	 * Specify a default yarn application classpath. Given classpath
+	 * entry can be a comma delimited list.
 	 *
 	 * @param defaultClasspath the default classpath
 	 * @return {@link EnvironmentClasspathConfigurer} for chaining
 	 */
 	EnvironmentClasspathConfigurer defaultYarnAppClasspath(String defaultClasspath);
+
+	/**
+	 * Specify a default yarn application classpath entries.
+	 *
+	 * @param defaultClasspath the default classpath entries.
+	 * @return {@link EnvironmentClasspathConfigurer} for chaining
+	 */
+	EnvironmentClasspathConfigurer defaultYarnAppClasspath(String... defaultClasspath);
 
 	/**
 	 * Specify if base directory should be added in classpath.

--- a/spring-yarn/spring-yarn-core/src/main/resources/org/springframework/yarn/config/spring-yarn-2.0.xsd
+++ b/spring-yarn/spring-yarn-core/src/main/resources/org/springframework/yarn/config/spring-yarn-2.0.xsd
@@ -134,6 +134,7 @@
 			</xsd:sequence>
 			<xsd:attribute name="id" type="xsd:ID" use="optional">
 			</xsd:attribute>
+			<xsd:attribute name="configuration" default="yarnConfiguration"/>
 			<xsd:attribute name="resources">
 			</xsd:attribute>
 			<xsd:attribute name="include-local-system-env" type="xsd:boolean" default="false">

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/annotation/ClasspathEnvironmentDefaultsTweakedAnnotationTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/annotation/ClasspathEnvironmentDefaultsTweakedAnnotationTests.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.yarn.config.annotation;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Properties;
+
+import javax.annotation.Resource;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.PropertiesFactoryBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+import org.springframework.yarn.YarnSystemConstants;
+import org.springframework.yarn.config.annotation.EnableYarn.Enable;
+import org.springframework.yarn.config.annotation.builders.YarnEnvironmentConfigurer;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(loader=AnnotationConfigContextLoader.class)
+public class ClasspathEnvironmentDefaultsTweakedAnnotationTests {
+
+	@Autowired
+	private ApplicationContext ctx;
+
+	@Resource(name = YarnSystemConstants.DEFAULT_ID_ENVIRONMENT)
+	private Map<String, String> defaultEnvironment;
+
+	@Test
+	public void testClasspathMixedEnvironment() throws Exception {
+		assertThat(defaultEnvironment, notNullValue());
+
+		assertThat(defaultEnvironment.get("foo"), is("jee"));
+		assertThat(defaultEnvironment.get("test.foo.2"), nullValue());
+		assertThat(defaultEnvironment.get("myvar1"), is("myvalue1"));
+
+		String classpath = defaultEnvironment.get("CLASSPATH");
+		assertThat(classpath, notNullValue());
+		assertThat(classpath, containsString("/tmp/fake1"));
+		assertThat(classpath, containsString("/tmp/fake2"));
+
+		// check that there's no extra or empty elements
+		assertThat(false, is(classpath.contains("::")));
+		assertThat(true, is(classpath.charAt(0) != ':'));
+		assertThat(true, is(classpath.charAt(classpath.length()-1) != ':'));
+	}
+
+	@Configuration
+	@EnableYarn(enable=Enable.BASE)
+	static class Config extends SpringYarnConfigurerAdapter {
+
+		@Bean(name="props")
+		public Properties getProperties() throws IOException {
+			PropertiesFactoryBean fb = new PropertiesFactoryBean();
+			fb.setLocation(new ClassPathResource("props.properties"));
+			fb.afterPropertiesSet();
+			return fb.getObject();
+		}
+
+		@Override
+		public void configure(YarnEnvironmentConfigurer environment) throws Exception {
+				environment
+					.withProperties()
+						.and()
+					.withClasspath()
+						.useDefaultYarnClasspath(true)
+						.defaultYarnAppClasspath("/tmp/fake1", "/tmp/fake2")
+						.and()
+					.entry("myvar1", "myvalue1")
+					.entry("foo", "jee");
+		}
+
+	}
+
+}

--- a/spring-yarn/spring-yarn-core/src/test/resources/org/springframework/yarn/config/environment-ns.xml
+++ b/spring-yarn/spring-yarn-core/src/test/resources/org/springframework/yarn/config/environment-ns.xml
@@ -13,6 +13,8 @@
 
 	<util:properties id="props" location="props.properties"/>
 
+	<yarn:configuration/>
+
 	<yarn:environment>
 		foo=jee
 		test-myvar1=${myvar1}
@@ -29,7 +31,11 @@
 	</yarn:environment>
 
 	<yarn:environment id="defClasspathEnvCustomDefaultClasspath">
-		<yarn:classpath use-default-yarn-classpath="true" default-yarn-app-classpath="/tmp/fake1:/tmp/fake2"/>
+		<yarn:classpath use-default-yarn-classpath="true" default-yarn-app-classpath="/tmp/fake1,/tmp/fake2"/>
+	</yarn:environment>
+
+	<yarn:environment id="defClasspathEnvCustomDefaultClasspathFromYarn">
+		<yarn:classpath use-default-yarn-classpath="true"/>
 	</yarn:environment>
 
 	<yarn:environment id="defClasspathEnvMixed">


### PR DESCRIPTION
- EnvironmentFactoryBean changed use yarn configuration
  if set and get the default cp from there unless
  overriden by user.
- Removes all the hard coded env variables from
  EnvironmentFactoryBean which was a bit dangerous.
- Related changes to xml and java configs.
