### PR TITLE
SHDP-303 Disable distZip and buildScripts in tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1030,7 +1030,12 @@ if (gradle.ext.mr2) {
 		}
 		bootRepackage.enabled = false
 		test.dependsOn(appmasterBootJar)
-
+		// boot plugin imports gradle application plugin
+		// which creates distZip task which fails
+		// because we don't need mainClassname, so
+		// disabling startScripts and distZip tasks
+		startScripts.enabled = false
+		distZip.enabled = false
 	}
 
 	project('spring-yarn:spring-yarn-test') {


### PR DESCRIPTION
- We already have distZip task to package stuff and this collides
  with application plugin imported by boot gradle plugin. Application
  plugin creates a distZip task which calls startScripts task
  which then fails because we don't define mainClassName.
- Just need to disable startScripts and distZip tasks for spring-yarn-boot-build-tests.
