### PR TITLE
Update build to use Gradle 1.11 and remain compatible with Guava 16

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -319,6 +319,12 @@ configure(javaProjects()) {
 		testRuntime "com.google.guava:guava:$guavaVersion"
 	}
 
+	configurations.all {
+		resolutionStrategy {
+			force "com.google.guava:guava:$guavaVersion"
+		}
+	}
+
 	task sourcesJar(type: Jar) {
 		classifier = 'sources'
 		from sourceSets.main.allJava
@@ -1136,6 +1142,6 @@ if (gradle.ext.mr2) {
 
 task wrapper(type: Wrapper) {
 	description = "Generates gradlew[.bat] scripts"
-	gradleVersion = "1.8"
+	gradleVersion = "1.11"
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Mar 19 07:32:52 EDT 2014
+#Mon Mar 24 13:01:15 GMT 2014
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.8-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.11-bin.zip


### PR DESCRIPTION
I have built this PR to the extent that I know the NoClassDefFoundError that was being seen with Guava 16.0.1 and Gradle 1.11 no longer occurs. However, I haven't built it fully as I see a number of connection refused problems (presumably as I don't have Hadoop set up).
