### PR TITLE
SHDP-318 Fix composed annotations for tests

### DIFF
--- a/spring-yarn/spring-yarn-test/src/main/java/org/springframework/yarn/test/context/MiniYarnClusterTest.java
+++ b/spring-yarn/spring-yarn-test/src/main/java/org/springframework/yarn/test/context/MiniYarnClusterTest.java
@@ -20,8 +20,11 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.yarn.test.YarnTestSystemConstants;
 
 /**
  * Composed annotation having &#064;{@link MiniYarnCluster},
@@ -43,14 +46,31 @@ import org.springframework.test.context.ContextConfiguration;
  * </pre>
  *
  * <p>
- * Drawback of using a composed annotation like this is that the
- * &#064;{@link Configuration} is then applied from an annotation
- * class itself and user can't no longer add a static &#064;{@link Configuration}
- * class in a test class itself and expect Spring to pick it up from
- * there which is a normal behaviour in Spring testing support.
- * <p>
  * If user wants to use a simple composed annotation and use a
- * custom &#064;{@link Configuration}, one can simply duplicate
+ * custom &#064;{@link Configuration}, there are two options.
+ * <p>
+ * Use classes attribute with &#064;{@link MiniYarnCluster} to override
+ * default context configuration class.
+ * <p>
+ * <pre>
+ * &#064;MiniYarnClusterTest(classes = AppTests.Config.class)
+ * public class AppTests extends AbstractBootYarnClusterTests {
+ *
+ *   &#064;Test
+ *   public void testApp() {
+ *     // test methods
+ *   }
+ *
+ *   &#064;Configuration
+ *   public static class Config {
+ *     // custom config
+ *   }
+ *
+ * }
+ * </pre>
+ *
+ * <p>
+ * If more functionality is needed for composed annotation, one can simply duplicate
  * functionality of this &#064;{@code MiniYarnClusterTest} annotation.
  * <p>
  * <pre>
@@ -59,6 +79,8 @@ import org.springframework.test.context.ContextConfiguration;
  * &#064;ContextConfiguration(loader=YarnDelegatingSmartContextLoader.class)
  * &#064;MiniYarnCluster
  * public &#064;interface CustomMiniYarnClusterTest {
+ *
+ *   Class<?>[] classes() default { CustomMiniYarnClusterTest.Config.class };
  *
  *   &#064;Configuration
  *   public static class Config {
@@ -85,5 +107,57 @@ public @interface MiniYarnClusterTest {
 	@Configuration
 	public static class Config {
 	}
+
+	/**
+	 * @see MiniYarnCluster#configName()
+	 */
+	String configName() default YarnTestSystemConstants.DEFAULT_ID_MINIYARNCLUSTER_CONFIG;
+
+	/**
+	 * @see MiniYarnCluster#clusterName()
+	 */
+	String clusterName() default YarnTestSystemConstants.DEFAULT_ID_MINIYARNCLUSTER;
+
+	/**
+	 * @see MiniYarnCluster#id()
+	 */
+	String id() default YarnTestSystemConstants.DEFAULT_ID_CLUSTER;
+
+	/**
+	 * @see MiniYarnCluster#nodes()
+	 */
+	int nodes() default 1;
+
+	/**
+	 * @see ContextConfiguration#locations()
+	 */
+	String[] locations() default {};
+
+	/**
+	 * Defaults to empty configuration.
+	 *
+	 * @see ContextConfiguration#classes()
+	 */
+	Class<?>[] classes() default { MiniYarnClusterTest.Config.class };
+
+	/**
+	 * @see ContextConfiguration#initializers()
+	 */
+	Class<? extends ApplicationContextInitializer<? extends ConfigurableApplicationContext>>[] initializers() default {};
+
+	/**
+	 * @see ContextConfiguration#inheritLocations()
+	 */
+	boolean inheritLocations() default true;
+
+	/**
+	 * @see ContextConfiguration#inheritInitializers()
+	 */
+	boolean inheritInitializers() default true;
+
+	/**
+	 * @see ContextConfiguration#name()
+	 */
+	String name() default "";
 
 }

--- a/spring-yarn/spring-yarn-test/src/main/java/org/springframework/yarn/test/context/YarnClusterInjectUtils.java
+++ b/spring-yarn/spring-yarn-test/src/main/java/org/springframework/yarn/test/context/YarnClusterInjectUtils.java
@@ -43,11 +43,10 @@ abstract class YarnClusterInjectUtils {
 				testClass, MiniYarnCluster.class);
 
 		if (annotationDescriptor != null && annotationDescriptor.getAnnotation() != null) {
-			MiniYarnCluster annotation = annotationDescriptor.getAnnotation();
-			String clusterName = annotation.clusterName();
-			String configName = annotation.configName();
-			String id = annotation.id();
-			int nodeCount = annotation.nodes();
+			String clusterName = annotationDescriptor.getAnnotationAttributes().getString("clusterName");
+			String configName = annotationDescriptor.getAnnotationAttributes().getString("configName");
+			String id = annotationDescriptor.getAnnotationAttributes().getString("id");
+			int nodeCount = annotationDescriptor.getAnnotationAttributes().getNumber("nodes");
 
 			BeanDefinitionBuilder builder = BeanDefinitionBuilder
 					.genericBeanDefinition(ClusterDelegatingFactoryBean.class);

--- a/spring-yarn/spring-yarn-test/src/test/java/org/springframework/yarn/test/context/ComposedAnnotationCustomizeTests.java
+++ b/spring-yarn/spring-yarn-test/src/test/java/org/springframework/yarn/test/context/ComposedAnnotationCustomizeTests.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.yarn.test.context;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import javax.annotation.Resource;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * Tests for custom composed annotations.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@CustomMiniYarnClusterTest(classes=ComposedAnnotationCustomizeTests.Config.class)
+public class ComposedAnnotationCustomizeTests {
+
+	@Autowired
+	private ApplicationContext ctx;
+
+	@Resource(name = "yarnConfiguration")
+	Configuration configuration;
+
+	@Test
+	public void testLoaderAndConfig() {
+		assertNotNull(ctx);
+		assertTrue(ctx.containsBean("yarnCluster"));
+		assertTrue(ctx.containsBean("yarnConfiguration"));
+		// bean from CustomMiniYarnClusterTest should not get created
+		assertFalse(ctx.containsBean("myCustomBean"));
+		assertTrue(ctx.containsBean("myCustomLocalBean"));
+		Configuration config = (Configuration) ctx.getBean("yarnConfiguration");
+		assertNotNull(config);
+	}
+
+	@org.springframework.context.annotation.Configuration
+	public static class Config {
+		@Bean
+		public String myCustomLocalBean() {
+			return "myCustomLocalBean";
+		}
+	}
+
+}

--- a/spring-yarn/spring-yarn-test/src/test/java/org/springframework/yarn/test/context/CustomMiniYarnClusterTest.java
+++ b/spring-yarn/spring-yarn-test/src/test/java/org/springframework/yarn/test/context/CustomMiniYarnClusterTest.java
@@ -37,6 +37,8 @@ import org.springframework.test.context.ContextConfiguration;
 @MiniYarnCluster
 public @interface CustomMiniYarnClusterTest {
 
+	Class<?>[] classes() default { CustomMiniYarnClusterTest.Config.class };
+
 	@Configuration
 	public static class Config {
 		@Bean

--- a/spring-yarn/spring-yarn-test/src/test/java/org/springframework/yarn/test/context/MiniYarnClusterTestOverrideTests.java
+++ b/spring-yarn/spring-yarn-test/src/test/java/org/springframework/yarn/test/context/MiniYarnClusterTestOverrideTests.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.yarn.test.context;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * Tests using {@link MiniYarnClusterTest}.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@MiniYarnClusterTest(
+		classes = MiniYarnClusterTestOverrideTests.Config.class,
+		configName = "yarnCustomConfiguration",
+		clusterName = "yarnCustomCluster",
+		id = "custom")
+public class MiniYarnClusterTestOverrideTests {
+
+	@Autowired
+	private ApplicationContext ctx;
+
+	@Test
+	public void testLoaderAndConfig() {
+		assertNotNull(ctx);
+		assertTrue(ctx.containsBean("yarnCustomCluster"));
+		assertTrue(ctx.containsBean("yarnCustomConfiguration"));
+		Configuration config = (Configuration) ctx.getBean("yarnCustomConfiguration");
+		assertNotNull(config);
+	}
+
+	@org.springframework.context.annotation.Configuration
+	public static class Config {
+		// we're testing custom name so need to change config
+		// so that spring-test doesn't cache our context and
+		// we don't want to dirty context for all tests.
+	}
+
+}


### PR DESCRIPTION
- MiniYarnClusterTest breaks with Spring 4.0.3 is now fixed
  per discussion in SPR-11641.
- Composed annotation and a way a custom extended annotation
  should be created is refactored to follow Spring 4.x logic.
- More tests to verify this behaviour.
- YarnClusterInjectUtils now using annotationAttributes instead
  of annotation itself. This will automatically handle
  cases where attribute is re-defined in a custom annotation
  or generally defined in a composed annotation.
