### PR TITLE
SHDP-317 Better allocation localization

### DIFF
--- a/docs/src/reference/docbook/reference/yarn.xml
+++ b/docs/src/reference/docbook/reference/yarn.xml
@@ -1026,7 +1026,7 @@ public class ClientConfiguration extends SpringYarnConfigurerAdapter {
     launching and monitoring.</para>
 
     <programlisting language="xml"><![CDATA[<yarn:master>
-  <yarn:container-allocator hosts="host1,host2" racks="rack1,rack2" virtualcores="1" memory="64" priority="0"/>    
+  <yarn:container-allocator virtualcores="1" memory="64" priority="0"/>    
   <yarn:container-launcher username="whoami"/>    
   <yarn:container-command>
     <![CDATA[
@@ -1129,16 +1129,6 @@ public class ClientConfiguration extends SpringYarnConfigurerAdapter {
             </thead>
             <tbody>
                 <row>
-                    <entry><literal>hosts</literal></entry>
-                    <entry>List of hosts</entry>
-                    <entry>Preferred hostname of nodes for allocation.</entry>
-                </row>
-                <row>
-                    <entry><literal>racks</literal></entry>
-                    <entry>List of racks</entry>
-                    <entry>Preferred name of racks for allocation.</entry>
-                </row>
-                <row>
                     <entry><literal>virtualcores</literal></entry>
                     <entry>Integer</entry>
                     <entry><emphasis>number of virtual cpu cores</emphasis> of the resource.</entry>
@@ -1153,8 +1143,14 @@ public class ClientConfiguration extends SpringYarnConfigurerAdapter {
                     <entry>Integer</entry>
                     <entry>Assigned priority of a request.</entry>
                 </row>
+                <row>
+                    <entry><literal>locality</literal></entry>
+                    <entry>Boolean</entry>
+                    <entry>If set to true indicates that resources are not relaxed.
+                    Default is <emphasis>FALSE</emphasis>.</entry>
+                </row>
             </tbody>
-        </tgroup>  
+        </tgroup>
     </table>
 
     <table id="yarn:master:containerlauncherflags" pgwide="1" align="center">
@@ -2858,6 +2854,12 @@ public void publicVoidNoArgsMethod(@YarnParameter("key") String value) {
                       <entry>Boolean</entry>
                       <entry>true</entry>
                   </row>
+                  <row>
+                      <entry><literal>spring.yarn.appmaster.launchcontext.locality</literal></entry>
+                      <entry>No</entry>
+                      <entry>Boolean</entry>
+                      <entry>false</entry>
+                </row>
               </tbody>
           </tgroup>
       </table>
@@ -2906,6 +2908,11 @@ public void publicVoidNoArgsMethod(@YarnParameter("key") String value) {
           <varlistentry><term><filename>spring.yarn.appmaster.launchcontext.includeSystemEnv</filename></term>
               <listitem><para>
               If system environment variables are added to a container environment.
+              </para></listitem>
+          </varlistentry>
+          <varlistentry><term><filename>spring.yarn.appmaster.launchcontext.locality</filename></term>
+              <listitem><para>
+              If set to true indicates that resources are not relaxed.
               </para></listitem>
           </varlistentry>
       </variablelist>

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/am/AbstractBatchAppmaster.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/am/AbstractBatchAppmaster.java
@@ -23,7 +23,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.NoSuchElementException;
 import java.util.Set;
 
 import org.apache.commons.logging.Log;
@@ -147,15 +146,17 @@ public abstract class AbstractBatchAppmaster extends AbstractEventingAppmaster i
 
 		log.debug("stepExecution after racks match: " + stepExecution);
 
-		try {
-			if (stepExecution == null) {
-				stepExecution = requestData.entrySet().iterator().next().getKey();
-			}
+		iterator = requestData.entrySet().iterator();
+		if (stepExecution == null && iterator.hasNext()) {
+			stepExecution = iterator.next().getKey();
+		}
+
+		if (stepExecution != null) {
 			requestData.remove(stepExecution);
 			containerToStepMap.put(container.getId(), stepExecution);
 			getLauncher().launchContainer(container, getCommands());
-		} catch (NoSuchElementException e) {
-			log.error("We didn't have step execution in request map.", e);
+		} else {
+			getAllocator().releaseContainer(container.getId());
 		}
 	}
 

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/YarnAppmasterAutoConfiguration.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/YarnAppmasterAutoConfiguration.java
@@ -247,6 +247,7 @@ public class YarnAppmasterAutoConfiguration {
 				.appmasterClass(syap.getAppmasterClass() != null ? syap.getAppmasterClass() : appmasterClass)
 				.containerCommands(createContainerCommands(syalcp))
 				.withContainerAllocator()
+					.locality(syalcp.isLocality())
 					.memory(syarp.getMemory())
 					.priority(syarp.getPriority())
 					.virtualCores(syarp.getVirtualCores());

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/SpringYarnAppmasterLaunchContextProperties.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/SpringYarnAppmasterLaunchContextProperties.java
@@ -20,5 +20,14 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(value = "spring.yarn.appmaster.launchcontext")
 public class SpringYarnAppmasterLaunchContextProperties extends AbstractLaunchContextProperties {
 
+	private boolean locality = false;
+
+	public boolean isLocality() {
+		return locality;
+	}
+
+	public void setLocality(boolean locality) {
+		this.locality = locality;
+	}
 
 }

--- a/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringYarnAppmasterLaunchContextPropertiesTests.java
+++ b/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringYarnAppmasterLaunchContextPropertiesTests.java
@@ -60,6 +60,7 @@ public class SpringYarnAppmasterLaunchContextPropertiesTests {
 		assertThat(options.get(0), is("options1Foo"));
 		assertThat(options.get(1), is("options2Foo"));
 
+		assertThat(properties.isLocality(), is(true));
 		assertThat(properties.isUseDefaultYarnClasspath(), is(false));
 		assertThat(properties.isIncludeBaseDirectory(), is(false));
 		assertThat(properties.isIncludeLocalSystemEnv(), is(true));

--- a/spring-yarn/spring-yarn-boot/src/test/resources/SpringYarnAppmasterLaunchContextPropertiesTests.yml
+++ b/spring-yarn/spring-yarn-boot/src/test/resources/SpringYarnAppmasterLaunchContextPropertiesTests.yml
@@ -15,6 +15,7 @@ spring:
                 options:
                   - "options1Foo"
                   - "options2Foo"
+                locality: true
                 includeLocalSystemEnv: true
                 useDefaultYarnClasspath: false
                 includeBaseDirectory: false

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/allocate/DefaultAllocateCountTracker.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/allocate/DefaultAllocateCountTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.api.records.Container;
+import org.apache.hadoop.yarn.util.RackResolver;
+import org.springframework.util.StringUtils;
 
 /**
  * Helper class tracking allocation counts. This separates counts
@@ -58,6 +61,17 @@ public class DefaultAllocateCountTracker {
 	/** Counts for anys requested and not yet received */
 	private AtomicInteger requestedAny = new AtomicInteger();
 
+	private final Configuration configuration;
+
+	/**
+	 * Instantiates a new default allocate count tracker.
+	 *
+	 * @param configuration the hadoop configuration
+	 */
+	public DefaultAllocateCountTracker(Configuration configuration) {
+		this.configuration = configuration;
+	}
+
 	/**
 	 * Adds new count of containers into 'any'
 	 * pending requests.
@@ -81,6 +95,7 @@ public class DefaultAllocateCountTracker {
 	 */
 	public void addContainers(ContainerAllocateData containerAllocateData) {
 		// Adding incoming host counts to internal map
+		Map<String, Integer> rackCountsAdded = new HashMap<String, Integer>();
 		Iterator<Entry<String, Integer>> iterator = containerAllocateData.getHosts().entrySet().iterator();
 		while (iterator.hasNext()) {
 			Entry<String, Integer> entry = iterator.next();
@@ -90,6 +105,18 @@ public class DefaultAllocateCountTracker {
 				pendingHosts.put(entry.getKey(), atomicInteger);
 			}
 			atomicInteger.addAndGet(entry.getValue());
+
+			String resolvedRack = resolveRack(configuration, entry.getKey());
+			if (StringUtils.hasText(resolvedRack)) {
+				AtomicInteger atomicInteger2 = pendingRacks.get(resolvedRack);
+				if (atomicInteger2 == null) {
+					atomicInteger2 = new AtomicInteger();
+					pendingRacks.put(resolvedRack, atomicInteger2);
+				}
+				atomicInteger2.addAndGet(entry.getValue());
+				rackCountsAdded.put(resolvedRack, entry.getValue());
+			}
+
 		}
 
 		// Adding incoming rack counts to internal map
@@ -101,7 +128,9 @@ public class DefaultAllocateCountTracker {
 				atomicInteger = new AtomicInteger();
 				pendingRacks.put(entry.getKey(), atomicInteger);
 			}
-			atomicInteger.addAndGet(entry.getValue());
+			Integer rackCountAlreadyAdded = rackCountsAdded.get(entry.getKey());
+			Integer toAdd = rackCountAlreadyAdded != null ? entry.getValue() - rackCountAlreadyAdded : entry.getValue();
+			atomicInteger.addAndGet(Math.max(toAdd, 0));
 		}
 
 		// Adding incoming any count
@@ -114,7 +143,8 @@ public class DefaultAllocateCountTracker {
 	 *
 	 * @return the allocate counts
 	 */
-	public Map<String, Integer> getAllocateCounts() {
+	public AllocateCountInfo getAllocateCounts() {
+		AllocateCountInfo info = new AllocateCountInfo();
 		HashMap<String, Integer> allocateCountMap = new HashMap<String, Integer>();
 
 		int total = 0;
@@ -134,7 +164,9 @@ public class DefaultAllocateCountTracker {
 			}
 			total += out.get();
 		}
+		info.hostsInfo = allocateCountMap;
 
+		allocateCountMap = new HashMap<String, Integer>();
 		// flush pending racks from incoming to outgoing
 		iterator = pendingRacks.entrySet().iterator();
 		while (iterator.hasNext()) {
@@ -150,7 +182,9 @@ public class DefaultAllocateCountTracker {
 			}
 			total += out.get();
 		}
+		info.racksInfo = allocateCountMap;
 
+		allocateCountMap = new HashMap<String, Integer>();
 		// this is a point where allocation request gets tricky. Allocation will not happen
 		// until "*" is sent as a hostname. Also count for "*" has to match total of hosts and
 		// racks to be requested. Also count need to include any general "*" requests.
@@ -159,8 +193,9 @@ public class DefaultAllocateCountTracker {
 		int value = requestedAny.addAndGet(pendingAny.getAndSet(0));
 		total += value;
 		allocateCountMap.put("*", total);
+		info.anysInfo = allocateCountMap;
 
-		return allocateCountMap;
+		return info;
 	}
 
 	public Container processAllocatedContainer(Container container) {
@@ -313,6 +348,36 @@ public class DefaultAllocateCountTracker {
 		}
 		buf.append('}');
 		return buf.toString();
+	}
+
+	/**
+	 * Resolve rack for host.
+	 *
+	 * @param configuration the hadoop configuration
+	 * @param node the node
+	 * @return the resolved rack, null if failure
+	 */
+	private static String resolveRack(Configuration configuration, String node) {
+		try {
+			if (node != null) {
+				String rack = RackResolver.resolve(configuration, node).getNetworkLocation();
+				if (rack == null) {
+					log.warn("Failed to resolve rack for node " + node + ".");
+					return null;
+				} else {
+					return rack;
+				}
+			}
+		} catch (Exception e) {
+			log.warn("Failure in RackResolver", e);
+		}
+		return null;
+	}
+
+	public static class AllocateCountInfo {
+		public Map<String, Integer> racksInfo;
+		public Map<String, Integer> hostsInfo;
+		public Map<String, Integer> anysInfo;
 	}
 
 }

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/allocate/DefaultContainerAllocator.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/allocate/DefaultContainerAllocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,11 +18,11 @@ package org.springframework.yarn.am.allocate;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.logging.Log;
@@ -36,7 +36,7 @@ import org.apache.hadoop.yarn.api.records.Priority;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.api.records.ResourceRequest;
 import org.apache.hadoop.yarn.util.Records;
-import org.springframework.util.Assert;
+import org.springframework.yarn.am.allocate.DefaultAllocateCountTracker.AllocateCountInfo;
 import org.springframework.yarn.listener.CompositeContainerAllocatorListener;
 import org.springframework.yarn.listener.ContainerAllocatorListener;
 import org.springframework.yarn.support.compat.ResourceCompat;
@@ -50,297 +50,302 @@ import org.springframework.yarn.support.compat.ResourceCompat;
  */
 public class DefaultContainerAllocator extends AbstractPollingAllocator implements ContainerAllocator {
 
-	private static final Log log = LogFactory.getLog(DefaultContainerAllocator.class);
+    private static final Log log = LogFactory.getLog(DefaultContainerAllocator.class);
 
-	/** Listener dispatcher for events */
-	private CompositeContainerAllocatorListener allocatorListener = new CompositeContainerAllocatorListener();
+    /** Listener dispatcher for events */
+    private CompositeContainerAllocatorListener allocatorListener = new CompositeContainerAllocatorListener();
 
-	/** Container request priority */
-	private int priority = 0;
+    /** Container request priority */
+    private int priority = 0;
 
-	/** Default hosts to schedule */
-	private String[] hosts = new String[0];
+    /** Resource capability as of cores */
+    private int virtualcores = 1;
 
-	/** Default racks to schedule */
-	private String[] racks = new String[0];
+    /** Resource capability as of memory */
+    private int memory = 64;
 
-	/** Resource capability as of cores */
-	private int virtualcores = 1;
+    /** Locality relaxing */
+    private boolean locality = false;
 
-	/** Resource capability as of memory */
-	private int memory = 64;
+    /** Increasing counter for rpc request id*/
+    private AtomicInteger requestId = new AtomicInteger();
 
-	/** Increasing counter for rpc request id*/
-	private AtomicInteger requestId = new AtomicInteger();
+    /** Current progress reported during allocate requests */
+    private float applicationProgress = 0;
 
-	/** Current progress reported during allocate requests */
-	private float applicationProgress = 0;
+    /** Queued container id's to be released */
+    private Queue<ContainerId> releaseContainers = new ConcurrentLinkedQueue<ContainerId>();
 
-	/** Queued container id's to be released */
-	private Queue<ContainerId> releaseContainers = new ConcurrentLinkedQueue<ContainerId>();
+    /** Internal set of containers marked as garbage by allocate tracker */
+    private Set<ContainerId> garbageContainers = new HashSet<ContainerId>();
 
-	/** Internal set of containers marked as garbage by allocate tracker */
-	private Set<ContainerId> garbageContainers = new HashSet<ContainerId>();
+    /** Tracker for request counts */
+    private DefaultAllocateCountTracker allocateCountTracker;
 
-	/** Tracker for request counts */
-	private DefaultAllocateCountTracker allocateCountTracker = new DefaultAllocateCountTracker();
+    /** Flag helping to avoid allocation garbage */
+    private AtomicBoolean allocationDirty = new AtomicBoolean();
 
-	@Override
-	public void allocateContainers(int count) {
-		if (log.isDebugEnabled()) {
-			log.debug("Incoming count: " + count);
-		}
-		allocateCountTracker.addContainers(count);
-	}
+    /** Empty list for requests without container asks */
+    private final List<ResourceRequest> EMPTY = new ArrayList<ResourceRequest>();
 
-	@Override
-	public void addListener(ContainerAllocatorListener listener) {
-		allocatorListener.register(listener);
-	}
+    @Override
+    protected void onInit() throws Exception {
+        super.onInit();
+        allocateCountTracker = new DefaultAllocateCountTracker(getConfiguration());
+    }
 
-	@Override
-	public void allocateContainers(ContainerAllocateData containerAllocateData) {
-		if (log.isDebugEnabled()) {
-			log.debug("Incoming containerAllocateData: " + containerAllocateData);
-		}
+    @Override
+    public void allocateContainers(int count) {
+        if (log.isDebugEnabled()) {
+            log.debug("Incoming count: " + count);
+        }
+        allocateCountTracker.addContainers(count);
+        allocationDirty.set(true);
+    }
 
-		if (log.isDebugEnabled()) {
-			log.debug("State allocateCountTracker before adding allocation data: " + allocateCountTracker);
-		}
+    @Override
+    public void addListener(ContainerAllocatorListener listener) {
+        allocatorListener.register(listener);
+    }
 
-		allocateCountTracker.addContainers(containerAllocateData);
+    @Override
+    public void allocateContainers(ContainerAllocateData containerAllocateData) {
+        log.info("Incoming containerAllocateData: " + containerAllocateData);
+        log.info("State allocateCountTracker before adding allocation data: " + allocateCountTracker);
+        allocateCountTracker.addContainers(containerAllocateData);
+        allocationDirty.set(true);
+        log.info("State allocateCountTracker after adding allocation data: " + allocateCountTracker);
+    }
 
-		if (log.isDebugEnabled()) {
-			log.debug("State allocateCountTracker after adding allocation data: " + allocateCountTracker);
-		}
-	}
+    @Override
+    public void releaseContainers(List<Container> containers) {
+        for (Container container : containers) {
+            releaseContainer(container.getId());
+        }
+    }
 
-	@Override
-	public void releaseContainers(List<Container> containers) {
-		for (Container container : containers) {
-			releaseContainer(container.getId());
-		}
-	}
+    @Override
+    public void releaseContainer(ContainerId containerId) {
+        log.info("Adding new container to be released containerId=" + containerId);
+        releaseContainers.add(containerId);
+    }
 
-	@Override
-	public void releaseContainer(ContainerId containerId) {
-		if (log.isDebugEnabled()) {
-			log.debug("Adding new container to be released containerId=" + containerId);
-		}
-		releaseContainers.add(containerId);
-	}
+    private List<ResourceRequest> createRequests() {
+        List<ResourceRequest> requestedContainers = new ArrayList<ResourceRequest>();
+        AllocateCountInfo allocateCounts = allocateCountTracker.getAllocateCounts();
 
-	@Override
-	protected AllocateResponse doContainerRequest() {
-		List<ResourceRequest> requestedContainers = new ArrayList<ResourceRequest>();
-		Map<String, Integer> allocateCounts = allocateCountTracker.getAllocateCounts();
+        boolean hostsAdded = false;
+        for (Entry<String, Integer> entry : allocateCounts.hostsInfo.entrySet()) {
+            requestedContainers.add(getContainerResourceRequest(entry.getValue(), entry.getKey(), true));
+            hostsAdded = true;
+        }
 
-		for (Entry<String, Integer> entry : allocateCounts.entrySet()) {
-			requestedContainers.add(getContainerResourceRequest(entry.getValue(), entry.getKey()));
-		}
+        for (Entry<String, Integer> entry : allocateCounts.racksInfo.entrySet()) {
+            requestedContainers.add(getContainerResourceRequest(entry.getValue(), entry.getKey(), (hostsAdded && locality) ? false : true));
+        }
 
-		// add pending containers to be released
-		List<ContainerId> release = new ArrayList<ContainerId>();
-		ContainerId element = null;
-		while ((element = releaseContainers.poll()) != null) {
-			release.add(element);
-		}
+        for (Entry<String, Integer> entry : allocateCounts.anysInfo.entrySet()) {
+            requestedContainers.add(getContainerResourceRequest(entry.getValue(), entry.getKey(), !locality));
+        }
+        return requestedContainers;
+    }
 
-		if (log.isDebugEnabled()) {
-			log.debug("Requesting containers using " + requestedContainers.size() + " requests.");
-			for (ResourceRequest resourceRequest : requestedContainers) {
-				log.debug("ResourceRequest: " + resourceRequest + " with count=" +
-						resourceRequest.getNumContainers() + " with hostName=" + resourceRequest.getResourceName());
-			}
-			log.debug("Releasing containers " + release.size());
-			for (ContainerId cid : release) {
-				log.debug("Release container=" + cid);
-			}
-			log.debug("Request id will be: " + requestId.get());
-		}
+    @Override
+    protected AllocateResponse doContainerRequest() {
+    	List<ResourceRequest> requestedContainers = null;
 
-		// build the allocation request
-		AllocateRequest request = Records.newRecord(AllocateRequest.class);
-		request.setResponseId(requestId.get());
-		request.setAskList(requestedContainers);
-		request.setReleaseList(release);
-		request.setProgress(applicationProgress);
+    	if (allocationDirty.getAndSet(false)) {
+    		requestedContainers = createRequests();
+    	} else {
+    		requestedContainers = EMPTY;
+    	}
 
-		// do request and return response
-		AllocateResponse allocate = getRmTemplate().allocate(request);
-		requestId.set(allocate.getResponseId());
-		return allocate;
-	}
+        // add pending containers to be released
+        List<ContainerId> release = new ArrayList<ContainerId>();
+        ContainerId element = null;
+        while ((element = releaseContainers.poll()) != null) {
+            release.add(element);
+        }
 
-	@Override
-	protected List<Container> preProcessAllocatedContainers(List<Container> containers) {
-		// checking if we have standing allocation counts,
-		// if not assume as garbage and send to release queue.
-		// what's left will be out of our hand and expected to be
-		// processed by the listener and eventually send back
-		// to us as a released container.
+        if (log.isDebugEnabled()) {
+            log.debug("Requesting containers using " + requestedContainers.size() + " requests.");
+            for (ResourceRequest resourceRequest : requestedContainers) {
+                log.debug("ResourceRequest: " + resourceRequest + " with count=" +
+                        resourceRequest.getNumContainers() + " with hostName=" + resourceRequest.getResourceName());
+            }
+            log.debug("Releasing containers " + release.size());
+            for (ContainerId cid : release) {
+                log.debug("Release container=" + cid);
+            }
+            log.debug("Request id will be: " + requestId.get());
+        }
 
-		if (log.isDebugEnabled()) {
-			log.debug("State allocateCountTracker before handling allocated container: " + allocateCountTracker);
-		}
+        // build the allocation request
+        AllocateRequest request = Records.newRecord(AllocateRequest.class);
+        request.setResponseId(requestId.get());
+        request.setAskList(requestedContainers);
+        request.setReleaseList(release);
+        request.setProgress(applicationProgress);
 
-		List<Container> preProcessed = new ArrayList<Container>();
-		for (Container container : containers) {
-			Container processed = allocateCountTracker.processAllocatedContainer(container);
-			if (processed != null) {
-				preProcessed.add(processed);
-			} else {
-				garbageContainers.add(container.getId());
-				releaseContainers.add(container.getId());
-			}
-		}
+        // do request and return response
+        AllocateResponse allocate = getRmTemplate().allocate(request);
+        requestId.set(allocate.getResponseId());
+        return allocate;
+    }
 
-		if (log.isDebugEnabled()) {
-			log.debug("State allocateCountTracker after handling allocated container: " + allocateCountTracker);
-		}
+    @Override
+    protected List<Container> preProcessAllocatedContainers(List<Container> containers) {
+        // checking if we have standing allocation counts,
+        // if not assume as garbage and send to release queue.
+        // what's left will be out of our hand and expected to be
+        // processed by the listener and eventually send back
+        // to us as a released container.
 
-		return preProcessed;
-	}
+        if (log.isDebugEnabled()) {
+            log.debug("State allocateCountTracker before handling allocated container: " + allocateCountTracker);
+        }
 
-	@Override
-	protected void handleAllocatedContainers(List<Container> containers) {
-		allocatorListener.allocated(containers);
-	}
+        List<Container> preProcessed = new ArrayList<Container>();
+        for (Container container : containers) {
+            Container processed = allocateCountTracker.processAllocatedContainer(container);
+            if (processed != null) {
+                preProcessed.add(processed);
+            } else {
+                garbageContainers.add(container.getId());
+                releaseContainers.add(container.getId());
+            }
+        }
 
-	@Override
-	protected void handleCompletedContainers(List<ContainerStatus> containerStatuses) {
-		// strip away containers which were already marked
-		// garbage by allocate tracker. system
-		// never knew those even exist and might create mess
-		// with monitor component. monitor only sees
-		// complete status which is also the case for garbage
-		// when it's released.
-		List<ContainerStatus> garbageFree = new ArrayList<ContainerStatus>();
-		for (ContainerStatus status : containerStatuses) {
-			if (!garbageContainers.contains(status.getContainerId())) {
-				garbageFree.add(status);
-			}
-		}
-		allocatorListener.completed(garbageFree);
-	}
+        if (log.isDebugEnabled()) {
+            log.debug("State allocateCountTracker after handling allocated container: " + allocateCountTracker);
+        }
 
-	@Override
-	public void setProgress(float progress) {
-		applicationProgress = progress;
-	}
+        return preProcessed;
+    }
 
-	/**
-	 * Gets the priority for container request.
-	 *
-	 * @return the priority
-	 */
-	public int getPriority() {
-		return priority;
-	}
+    @Override
+    protected void handleAllocatedContainers(List<Container> containers) {
+        allocatorListener.allocated(containers);
+    }
 
-	/**
-	 * Sets the priority for container request.
-	 *
-	 * @param priority the new priority
-	 */
-	public void setPriority(int priority) {
-		this.priority = priority;
-	}
+    @Override
+    protected void handleCompletedContainers(List<ContainerStatus> containerStatuses) {
+        // strip away containers which were already marked
+        // garbage by allocate tracker. system
+        // never knew those even exist and might create mess
+        // with monitor component. monitor only sees
+        // complete status which is also the case for garbage
+        // when it's released.
+        List<ContainerStatus> garbageFree = new ArrayList<ContainerStatus>();
+        for (ContainerStatus status : containerStatuses) {
+            if (!garbageContainers.contains(status.getContainerId())) {
+                garbageFree.add(status);
+            }
+        }
+        allocatorListener.completed(garbageFree);
+    }
 
-	/**
-	 * Gets the hosts.
-	 *
-	 * @return the hosts
-	 */
-	public String[] getHosts() {
-		return hosts;
-	}
+    @Override
+    public void setProgress(float progress) {
+        applicationProgress = progress;
+    }
 
-	/**
-	 * Sets the hosts.
-	 *
-	 * @param hosts the new hosts
-	 */
-	public void setHosts(String[] hosts) {
-		Assert.notNull(hosts, "Hosts array must not be null");
-		this.hosts = hosts;
-	}
+    /**
+     * Gets the priority for container request.
+     *
+     * @return the priority
+     */
+    public int getPriority() {
+        return priority;
+    }
 
-	/**
-	 * Gets the racks.
-	 *
-	 * @return the racks
-	 */
-	public String[] getRacks() {
-		return racks;
-	}
+    /**
+     * Sets the priority for container request.
+     *
+     * @param priority the new priority
+     */
+    public void setPriority(int priority) {
+        this.priority = priority;
+    }
 
-	/**
-	 * Sets the racks.
-	 *
-	 * @param racks the new racks
-	 */
-	public void setRacks(String[] racks) {
-		Assert.notNull(racks, "Racks array must not be null");
-		this.racks = racks;
-	}
+    /**
+     * Gets the virtualcores for container request.
+     *
+     * @return the virtualcores
+     */
+    public int getVirtualcores() {
+        return virtualcores;
+    }
 
-	/**
-	 * Gets the virtualcores for container request.
-	 *
-	 * @return the virtualcores
-	 */
-	public int getVirtualcores() {
-		return virtualcores;
-	}
+    /**
+     * Sets the virtualcores for container request defining
+     * <em>number of virtual cpu cores</em> of the resource.
+     *
+     * @param virtualcores the new virtualcores
+     */
+    public void setVirtualcores(int virtualcores) {
+        this.virtualcores = virtualcores;
+    }
 
-	/**
-	 * Sets the virtualcores for container request defining
-	 * <em>number of virtual cpu cores</em> of the resource.
-	 *
-	 * @param virtualcores the new virtualcores
-	 */
-	public void setVirtualcores(int virtualcores) {
-		this.virtualcores = virtualcores;
-	}
+    /**
+     * Gets the memory for container request.
+     *
+     * @return the memory
+     */
+    public int getMemory() {
+        return memory;
+    }
 
-	/**
-	 * Gets the memory for container request.
-	 *
-	 * @return the memory
-	 */
-	public int getMemory() {
-		return memory;
-	}
+    /**
+     * Sets the memory for container request defining
+     * <em>memory</em> of the resource.
+     *
+     * @param memory the new memory
+     */
+    public void setMemory(int memory) {
+        this.memory = memory;
+    }
 
-	/**
-	 * Sets the memory for container request defining
-	 * <em>memory</em> of the resource.
-	 *
-	 * @param memory the new memory
-	 */
-	public void setMemory(int memory) {
-		this.memory = memory;
-	}
+    /**
+     * Checks if is locality relax flag is enabled.
+     *
+     * @return true, if is locality is enabled.
+     */
+    public boolean isLocality() {
+        return locality;
+    }
 
-	/**
-	 * Utility method creating a {@link ResourceRequest}.
-	 *
-	 * @param numContainers number of containers to request
-	 * @return request to be sent to resource manager
-	 */
-	private ResourceRequest getContainerResourceRequest(int numContainers, String hostName) {
-		ResourceRequest request = Records.newRecord(ResourceRequest.class);
-		request.setResourceName(hostName);
-		request.setNumContainers(numContainers);
-		Priority pri = Records.newRecord(Priority.class);
-		pri.setPriority(priority);
-		request.setPriority(pri);
-		Resource capability = Records.newRecord(Resource.class);
-		capability.setMemory(memory);
-		ResourceCompat.setVirtualCores(capability, virtualcores);
-		request.setCapability(capability);
-		return request;
-	}
+    /**
+     * Sets the flag telling if resource allocation
+     * should not be relaxed. Setting this to true
+     * means that relaxing is not used. Default value
+     * is false.
+     *
+     * @param locality the new locality relax flag
+     */
+    public void setLocality(boolean locality) {
+        this.locality = locality;
+    }
+
+    /**
+     * Utility method creating a {@link ResourceRequest}.
+     *
+     * @param numContainers number of containers to request
+     * @return request to be sent to resource manager
+     */
+    private ResourceRequest getContainerResourceRequest(int numContainers, String hostName, boolean relaxLocality) {
+        ResourceRequest request = Records.newRecord(ResourceRequest.class);
+        request.setRelaxLocality(relaxLocality);
+        request.setResourceName(hostName);
+        request.setNumContainers(numContainers);
+        Priority pri = Records.newRecord(Priority.class);
+        pri.setPriority(priority);
+        request.setPriority(pri);
+        Resource capability = Records.newRecord(Resource.class);
+        capability.setMemory(memory);
+        ResourceCompat.setVirtualCores(capability, virtualcores);
+        request.setCapability(capability);
+        return request;
+    }
 
 }

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/MasterParser.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/MasterParser.java
@@ -100,11 +100,10 @@ public class MasterParser extends AbstractBeanDefinitionParser {
 		Element allocElement = DomUtils.getChildElementByTagName(element, "container-allocator");
 		YarnNamespaceUtils.setReferenceIfAttributeDefined(defBuilder, element, "environment", YarnSystemConstants.DEFAULT_ID_ENVIRONMENT);
 		if(allocElement != null) {
-			YarnNamespaceUtils.setValueIfAttributeDefined(defBuilder, allocElement, "hosts");
-			YarnNamespaceUtils.setValueIfAttributeDefined(defBuilder, allocElement, "racks");
 			YarnNamespaceUtils.setValueIfAttributeDefined(defBuilder, allocElement, "virtualcores");
 			YarnNamespaceUtils.setValueIfAttributeDefined(defBuilder, allocElement, "memory");
 			YarnNamespaceUtils.setValueIfAttributeDefined(defBuilder, allocElement, "priority");
+			YarnNamespaceUtils.setValueIfAttributeDefined(defBuilder, allocElement, "locality");
 		}
 		AbstractBeanDefinition beanDef = defBuilder.getBeanDefinition();
 		String beanName = BeanDefinitionReaderUtils.generateBeanName(beanDef, parserContext.getRegistry());

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/configurers/DefaultMasterContainerAllocatorConfigurer.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/configurers/DefaultMasterContainerAllocatorConfigurer.java
@@ -29,6 +29,7 @@ public class DefaultMasterContainerAllocatorConfigurer
 	private Integer priority;
 	private String memory;
 	private Integer virtualCores;
+	private boolean locality;
 
 	@Override
 	public void configure(YarnAppmasterBuilder builder) throws Exception {
@@ -42,6 +43,7 @@ public class DefaultMasterContainerAllocatorConfigurer
 		if (memory != null) {
 			containerAllocator.setMemory(ParsingUtils.parseBytesAsMegs(memory));
 		}
+		containerAllocator.setLocality(locality);
 		builder.setContainerAllocator(containerAllocator);
 	}
 
@@ -66,6 +68,11 @@ public class DefaultMasterContainerAllocatorConfigurer
 	@Override
 	public MasterContainerAllocatorConfigurer memory(int memory) {
 		this.memory = Integer.toString(memory);
+		return this;
+	}
+
+	public MasterContainerAllocatorConfigurer locality(boolean locality) {
+		this.locality = locality;
 		return this;
 	}
 

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/configurers/MasterContainerAllocatorConfigurer.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/configurers/MasterContainerAllocatorConfigurer.java
@@ -169,4 +169,34 @@ public interface MasterContainerAllocatorConfigurer extends AnnotationConfigurer
 	 */
 	MasterContainerAllocatorConfigurer memory(int memory);
 
+	/**
+	 * Specify a locality relaxing for {@link ContainerAllocator}. Setting
+	 * this flag <code>true</code> means that resource requests will
+	 * not use locality relaxing. Default for this flag is <code>false</code>.
+	 *
+	 * <p>
+	 * <p>JavaConfig:
+	 * <p>
+	 * <pre>
+	 *
+	 * public void configure(YarnAppmasterConfigure master) throws Exception {
+	 *   master
+	 *     .withContainerAllocator()
+	 *       .locality(false);
+	 * }
+	 * </pre>
+	 *
+	 * <p>XML:
+	 * <p>
+	 * <pre>
+	 * &lt;yarn:master>
+	 *   &lt;yarn:container-allocator locality="false"/>
+	 * &lt;/yarn:master>
+	 * </pre>
+	 *
+	 * @param locality the locality flag for resource relaxing
+	 * @return {@link MasterContainerAllocatorConfigurer} for chaining
+	 */
+	MasterContainerAllocatorConfigurer locality(boolean locality);
+
 }

--- a/spring-yarn/spring-yarn-core/src/main/resources/org/springframework/yarn/config/spring-yarn-2.0.xsd
+++ b/spring-yarn/spring-yarn-core/src/main/resources/org/springframework/yarn/config/spring-yarn-2.0.xsd
@@ -407,22 +407,6 @@
 	</xsd:complexType>
 
 	<xsd:complexType name="containerAllocatorType" mixed="true">
-		<xsd:attribute name="hosts" type="xsd:string" use="optional">
-			<xsd:annotation>
-				<xsd:documentation><![CDATA[
-				Preferred hostname of nodes for allocation.
-				]]>
-				</xsd:documentation>
-			</xsd:annotation>
-		</xsd:attribute>
-		<xsd:attribute name="racks" type="xsd:string" use="optional">
-			<xsd:annotation>
-				<xsd:documentation><![CDATA[
-				Preferred name of racks for allocation.
-				]]>
-				</xsd:documentation>
-			</xsd:annotation>
-		</xsd:attribute>
 		<xsd:attribute name="virtualcores" type="xsd:string" use="optional">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
@@ -443,6 +427,14 @@
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
 				Assigned priority of a request.
+				]]>
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="locality" type="xsd:boolean" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+				If set to true indicates that resources are not relaxed.
 				]]>
 				</xsd:documentation>
 			</xsd:annotation>

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/TestUtils.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/TestUtils.java
@@ -16,6 +16,9 @@
 package org.springframework.yarn;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import org.springframework.util.ReflectionUtils;
 
 /**
  * Testing utilities.
@@ -43,6 +46,37 @@ public abstract class TestUtils {
 					+ target.getClass());
 		field.setAccessible(true);
 		return (T) field.get(target);
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T> T callMethod(String name, Object target) throws Exception {
+		Class<?> clazz = target.getClass();
+		Method method = ReflectionUtils.findMethod(clazz, name);
+
+		if (method == null)
+			throw new IllegalArgumentException("Cannot find method '" + method + "' in the class hierarchy of "
+					+ target.getClass());
+		method.setAccessible(true);
+		return (T) ReflectionUtils.invokeMethod(method, target);
+	}
+
+	public static void setField(String name, Object target, Object value) throws Exception {
+		Field field = null;
+		Class<?> clazz = target.getClass();
+		do {
+			try {
+				field = clazz.getDeclaredField(name);
+			} catch (Exception ex) {
+			}
+
+			clazz = clazz.getSuperclass();
+		} while (field == null && !clazz.equals(Object.class));
+
+		if (field == null)
+			throw new IllegalArgumentException("Cannot find field '" + name + "' in the class hierarchy of "
+					+ target.getClass());
+		field.setAccessible(true);
+		field.set(target, value);
 	}
 
 }

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/allocate/DefaultAllocateCountTrackerTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/allocate/DefaultAllocateCountTrackerTests.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.yarn.am.allocate;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Test;
+import org.springframework.yarn.am.allocate.DefaultAllocateCountTracker.AllocateCountInfo;
+
+/**
+ * Tests for {@link DefaultAllocateCountTracker}.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class DefaultAllocateCountTrackerTests {
+
+	@Test
+	public void testOneAny() {
+		DefaultAllocateCountTracker tracker = new DefaultAllocateCountTracker(new Configuration());
+		ContainerAllocateData containerAllocateData = new ContainerAllocateData();
+		containerAllocateData.addAny(1);
+		tracker.addContainers(containerAllocateData);
+		AllocateCountInfo allocateCounts = tracker.getAllocateCounts();
+		assertThat(allocateCounts, notNullValue());
+		assertThat(allocateCounts.anysInfo.size(), is(1));
+		assertThat(allocateCounts.anysInfo.get("*"), is(1));
+		assertThat(allocateCounts.hostsInfo.size(), is(0));
+		assertThat(allocateCounts.racksInfo.size(), is(0));
+	}
+
+	@Test
+	public void testOneHost() {
+		DefaultAllocateCountTracker tracker = new DefaultAllocateCountTracker(new Configuration());
+		ContainerAllocateData containerAllocateData = new ContainerAllocateData();
+		containerAllocateData.addHosts("host1", 1);
+		tracker.addContainers(containerAllocateData);
+		AllocateCountInfo allocateCounts = tracker.getAllocateCounts();
+		assertThat(allocateCounts, notNullValue());
+		assertThat(allocateCounts.anysInfo.size(), is(1));
+		assertThat(allocateCounts.anysInfo.get("*"), is(2));
+		assertThat(allocateCounts.hostsInfo.size(), is(1));
+		assertThat(allocateCounts.hostsInfo.get("host1"), is(1));
+		assertThat(allocateCounts.racksInfo.size(), is(1));
+		assertThat(allocateCounts.racksInfo.get("/default-rack"), is(1));
+	}
+
+	@Test
+	public void testOneRack() {
+		DefaultAllocateCountTracker tracker = new DefaultAllocateCountTracker(new Configuration());
+		ContainerAllocateData containerAllocateData = new ContainerAllocateData();
+		containerAllocateData.addRacks("/default-rack", 1);
+		tracker.addContainers(containerAllocateData);
+		AllocateCountInfo allocateCounts = tracker.getAllocateCounts();
+		assertThat(allocateCounts, notNullValue());
+		assertThat(allocateCounts.anysInfo.size(), is(1));
+		assertThat(allocateCounts.anysInfo.get("*"), is(1));
+		assertThat(allocateCounts.hostsInfo.size(), is(0));
+		assertThat(allocateCounts.racksInfo.size(), is(1));
+		assertThat(allocateCounts.racksInfo.get("/default-rack"), is(1));
+	}
+
+	@Test
+	public void testOneHostOneRack() {
+		DefaultAllocateCountTracker tracker = new DefaultAllocateCountTracker(new Configuration());
+		ContainerAllocateData containerAllocateData = new ContainerAllocateData();
+		containerAllocateData.addHosts("host1", 1);
+		containerAllocateData.addRacks("/default-rack", 1);
+		tracker.addContainers(containerAllocateData);
+		AllocateCountInfo allocateCounts = tracker.getAllocateCounts();
+		assertThat(allocateCounts, notNullValue());
+		assertThat(allocateCounts.anysInfo.size(), is(1));
+		assertThat(allocateCounts.anysInfo.get("*"), is(2));
+		assertThat(allocateCounts.hostsInfo.size(), is(1));
+		assertThat(allocateCounts.hostsInfo.get("host1"), is(1));
+		assertThat(allocateCounts.racksInfo.size(), is(1));
+		assertThat(allocateCounts.racksInfo.get("/default-rack"), is(1));
+	}
+
+}

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/allocate/DefaultContainerAllocatorTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/allocate/DefaultContainerAllocatorTests.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.yarn.am.allocate;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.List;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.yarn.api.records.ResourceRequest;
+import org.junit.Test;
+import org.springframework.yarn.TestUtils;
+
+/**
+ * Tests for {@link DefaultContainerAllocator}.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class DefaultContainerAllocatorTests {
+
+	@Test
+	public void testDefaultNoRequests() throws Exception {
+		DefaultAllocateCountTracker allocateCountTracker = new DefaultAllocateCountTracker(new Configuration());
+		DefaultContainerAllocator allocator = new DefaultContainerAllocator();
+		TestUtils.setField("allocateCountTracker", allocator, allocateCountTracker);
+
+		List<ResourceRequest> createRequests = TestUtils.callMethod("createRequests", allocator);
+		assertThat(createRequests, notNullValue());
+		assertThat(createRequests.size(), is(1));
+		ResourceRequest req = createRequests.get(0);
+		assertThat(req.getPriority().getPriority(), is(0));
+		assertThat(req.getNumContainers(), is(0));
+		assertThat(req.getRelaxLocality(), is(true));
+	}
+
+	@Test
+	public void testAnyHostNoLocalityRequests() throws Exception {
+		DefaultAllocateCountTracker allocateCountTracker = new DefaultAllocateCountTracker(new Configuration());
+		DefaultContainerAllocator allocator = new DefaultContainerAllocator();
+		allocator.setLocality(false);
+		TestUtils.setField("allocateCountTracker", allocator, allocateCountTracker);
+
+		ContainerAllocateData data = new ContainerAllocateData();
+		data.addAny(2);
+		allocator.allocateContainers(data);
+
+		List<ResourceRequest> createRequests = TestUtils.callMethod("createRequests", allocator);
+		assertThat(createRequests, notNullValue());
+		assertThat(createRequests.size(), is(1));
+
+		ResourceRequest req0 = createRequests.get(0);
+		assertThat(req0.getResourceName(), is("*"));
+		assertThat(req0.getPriority().getPriority(), is(0));
+		assertThat(req0.getNumContainers(), is(2));
+		assertThat(req0.getRelaxLocality(), is(true));
+	}
+
+	@Test
+	public void testOneHostLocalityRequests() throws Exception {
+		DefaultAllocateCountTracker allocateCountTracker = new DefaultAllocateCountTracker(new Configuration());
+		DefaultContainerAllocator allocator = new DefaultContainerAllocator();
+		allocator.setLocality(true);
+		TestUtils.setField("allocateCountTracker", allocator, allocateCountTracker);
+
+		ContainerAllocateData data = new ContainerAllocateData();
+		data.addHosts("host1", 1);
+		allocator.allocateContainers(data);
+
+		List<ResourceRequest> createRequests = TestUtils.callMethod("createRequests", allocator);
+		assertThat(createRequests, notNullValue());
+		assertThat(createRequests.size(), is(3));
+
+		ResourceRequest req0 = createRequests.get(0);
+		assertThat(req0.getResourceName(), is("host1"));
+		assertThat(req0.getPriority().getPriority(), is(0));
+		assertThat(req0.getNumContainers(), is(1));
+		assertThat(req0.getRelaxLocality(), is(true));
+
+		ResourceRequest req1 = createRequests.get(1);
+		assertThat(req1.getResourceName(), is("/default-rack"));
+		assertThat(req1.getPriority().getPriority(), is(0));
+		assertThat(req1.getNumContainers(), is(1));
+		assertThat(req1.getRelaxLocality(), is(false));
+
+		ResourceRequest req2 = createRequests.get(2);
+		assertThat(req2.getResourceName(), is("*"));
+		assertThat(req2.getPriority().getPriority(), is(0));
+		assertThat(req2.getNumContainers(), is(2));
+		assertThat(req2.getRelaxLocality(), is(false));
+	}
+
+	@Test
+	public void testOneRackLocalityRequests() throws Exception {
+		DefaultAllocateCountTracker allocateCountTracker = new DefaultAllocateCountTracker(new Configuration());
+		DefaultContainerAllocator allocator = new DefaultContainerAllocator();
+		allocator.setLocality(true);
+		TestUtils.setField("allocateCountTracker", allocator, allocateCountTracker);
+
+		ContainerAllocateData data = new ContainerAllocateData();
+		data.addRacks("/default-rack", 1);
+		allocator.allocateContainers(data);
+
+		List<ResourceRequest> createRequests = TestUtils.callMethod("createRequests", allocator);
+		assertThat(createRequests, notNullValue());
+		assertThat(createRequests.size(), is(2));
+
+		ResourceRequest req0 = createRequests.get(0);
+		assertThat(req0.getResourceName(), is("/default-rack"));
+		assertThat(req0.getPriority().getPriority(), is(0));
+		assertThat(req0.getNumContainers(), is(1));
+		assertThat(req0.getRelaxLocality(), is(true));
+
+		ResourceRequest req1 = createRequests.get(1);
+		assertThat(req1.getResourceName(), is("*"));
+		assertThat(req1.getPriority().getPriority(), is(0));
+		assertThat(req1.getNumContainers(), is(1));
+		assertThat(req1.getRelaxLocality(), is(false));
+	}
+
+	@Test
+	public void testOneHostNoLocalityRequests() throws Exception {
+		DefaultAllocateCountTracker allocateCountTracker = new DefaultAllocateCountTracker(new Configuration());
+		DefaultContainerAllocator allocator = new DefaultContainerAllocator();
+		allocator.setLocality(false);
+		TestUtils.setField("allocateCountTracker", allocator, allocateCountTracker);
+
+		ContainerAllocateData data = new ContainerAllocateData();
+		data.addHosts("host1", 1);
+		allocator.allocateContainers(data);
+
+		List<ResourceRequest> createRequests = TestUtils.callMethod("createRequests", allocator);
+		assertThat(createRequests, notNullValue());
+		assertThat(createRequests.size(), is(3));
+
+		ResourceRequest req0 = createRequests.get(0);
+		assertThat(req0.getResourceName(), is("host1"));
+		assertThat(req0.getPriority().getPriority(), is(0));
+		assertThat(req0.getNumContainers(), is(1));
+		assertThat(req0.getRelaxLocality(), is(true));
+
+		ResourceRequest req1 = createRequests.get(1);
+		assertThat(req1.getResourceName(), is("/default-rack"));
+		assertThat(req1.getPriority().getPriority(), is(0));
+		assertThat(req1.getNumContainers(), is(1));
+		assertThat(req1.getRelaxLocality(), is(true));
+
+		ResourceRequest req2 = createRequests.get(2);
+		assertThat(req2.getResourceName(), is("*"));
+		assertThat(req2.getPriority().getPriority(), is(0));
+		assertThat(req2.getNumContainers(), is(2));
+		assertThat(req2.getRelaxLocality(), is(true));
+	}
+
+}


### PR DESCRIPTION
- Can now use relax localization flag
- Some obsolete settings removed from
  DefaultContainerAllocator, namely default
  hosts/racks properties.
- Adding some tests for allocation logic and
  request count tracking.
- new locality flag for launch context for
  containers, flag used in appmaster.
- AbstractBatchAppmaster now returns allocation
  garbage back to allocator. Using strict locality
  now creates garbage which we can't avoid in
  some cases.
