### PR TITLE
Ensure exclusions on compile dependencies appear in generated poms

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -979,19 +979,19 @@ if (gradle.ext.mr2) {
 	}
 
 	project('spring-yarn') {
-		description = 'Spring for Apache Hadoop YARN'	
+		description = 'Spring for Apache Hadoop YARN'
 		dependencies {
 			compile project("spring-yarn-batch")
 		}
 	}
-	
+
 	project('spring-yarn:spring-yarn-core') {
 		description = 'Spring Yarn Core'
 		dependencies {
 			compile project(":spring-data-hadoop")
 			compile "org.apache.hadoop:hadoop-yarn-client:$hadoopVersion"
 			compile("org.apache.hadoop:hadoop-common:$hadoopVersion") { dep ->
-				exclude module: "junit"
+				exclude group: "junit", module: "junit"
 			}
 			testCompile("org.mockito:mockito-core:$mockitoVersion") { dep ->
 				exclude group: "org.hamcrest"
@@ -1110,7 +1110,7 @@ if (gradle.ext.mr2) {
 			compile "junit:junit:$junitVersion"
 			compile "org.apache.hadoop:hadoop-yarn-client:$hadoopVersion"
 			compile("org.apache.hadoop:hadoop-common:$hadoopVersion") { dep ->
-				exclude module: "junit"
+				exclude group: "junit", module: "junit"
 			}
 			compile "org.apache.hadoop:hadoop-yarn-server-tests:$hadoopVersion"
 			compile "org.apache.hadoop:hadoop-yarn-server-tests:$hadoopVersion:tests"


### PR DESCRIPTION
Gradle will only produce an exclusion in a generated pom if the exclusion is declared with both a group and a module. This PR updates all the exclusions on compile dependencies so that they are declared with both a group and a module.
