### PR TITLE
SHDP-335 Fix npe race condition

### DIFF
--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/TextFileWriter.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/TextFileWriter.java
@@ -71,7 +71,7 @@ public class TextFileWriter extends AbstractDataStreamWriter implements DataStor
 
 	@Override
 	public synchronized  void flush() throws IOException {
-		if (streamsHolder == null) {
+		if (streamsHolder != null) {
 			streamsHolder.getStream().flush();
 		}
 	}


### PR DESCRIPTION
- By mistake access to streamsHolder was checked it to be null,
  when we need to check it to be not null.
