### PR TITLE
SHDP-348 Configurable YarnClient action

### DIFF
--- a/docs/src/reference/docbook/reference/yarn.xml
+++ b/docs/src/reference/docbook/reference/yarn.xml
@@ -3131,6 +3131,12 @@ public void publicVoidParameterArgsMethod(@YarnParameter("key") String value) {
                       <entry>Class</entry>
                       <entry>null</entry>
                   </row>
+                  <row>
+                      <entry><literal>spring.yarn.client.startup.action</literal></entry>
+                      <entry>No</entry>
+                      <entry>String</entry>
+                      <entry>null</entry>
+                  </row>
               </tbody>
           </tgroup>
       </table>
@@ -3155,6 +3161,14 @@ public void publicVoidParameterArgsMethod(@YarnParameter("key") String value) {
               <listitem><para>
               Fully qualified classname which auto-configuration can automatically
               instantiate as a custom client.
+              </para></listitem>
+          </varlistentry>
+          <varlistentry><term><filename>spring.yarn.client.startup.action</filename></term>
+              <listitem><para>
+              Default action to perform on <interfacename>YarnClient</interfacename>.
+              Currently only one action named <emphasis>submit</emphasis> is supported.
+              This action is simply calling <literal>submitApplication</literal> method
+              on <interfacename>YarnClient</interfacename>.
               </para></listitem>
           </varlistentry>
       </variablelist>

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/YarnClientAutoConfiguration.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/YarnClientAutoConfiguration.java
@@ -19,6 +19,7 @@ import java.util.Properties;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -35,6 +36,7 @@ import org.springframework.yarn.boot.properties.SpringYarnEnvProperties;
 import org.springframework.yarn.boot.properties.SpringYarnProperties;
 import org.springframework.yarn.boot.support.BootLocalResourcesSelector;
 import org.springframework.yarn.boot.support.BootLocalResourcesSelector.Mode;
+import org.springframework.yarn.boot.support.ClientLauncherRunner;
 import org.springframework.yarn.boot.support.SpringYarnBootUtils;
 import org.springframework.yarn.client.YarnClient;
 import org.springframework.yarn.config.annotation.EnableYarn;
@@ -61,6 +63,21 @@ import org.springframework.yarn.launch.LaunchCommandsFactoryBean;
 @ConditionalOnClass(EnableYarn.class)
 @ConditionalOnMissingBean(YarnClient.class)
 public class YarnClientAutoConfiguration {
+
+	@Configuration
+	@EnableConfigurationProperties({ SpringYarnClientProperties.class })
+	public static class RunnerConfig {
+
+		@Autowired
+		private SpringYarnClientProperties sycp;
+
+		@Bean
+		@ConditionalOnMissingBean(ClientLauncherRunner.class)
+		@ConditionalOnBean(YarnClient.class)
+		public ClientLauncherRunner clientLauncherRunner() {
+			return new ClientLauncherRunner(sycp.getStartup() != null ? sycp.getStartup().getAction() : null);
+		}
+	}
 
 	@Configuration
 	@EnableConfigurationProperties({ SpringYarnClientLocalizerProperties.class })

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/SpringYarnClientProperties.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/SpringYarnClientProperties.java
@@ -33,6 +33,7 @@ public class SpringYarnClientProperties {
 	private Integer priority;
 	private String queue;
 	private String clientClass;
+	private StartupProperties startup;
 
 	public List<String> getFiles() {
 		return files;
@@ -64,6 +65,28 @@ public class SpringYarnClientProperties {
 
 	public void setClientClass(String clientClass) {
 		this.clientClass = clientClass;
+	}
+
+	public StartupProperties getStartup() {
+		return startup;
+	}
+
+	public void setStartup(StartupProperties startup) {
+		this.startup = startup;
+	}
+
+	public static class StartupProperties {
+
+		private String action;
+
+		public String getAction() {
+			return action;
+		}
+
+		public void setAction(String action) {
+			this.action = action;
+		}
+
 	}
 
 }

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/support/ClientLauncherRunner.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/support/ClientLauncherRunner.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.yarn.boot.support;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.util.StringUtils;
+import org.springframework.yarn.client.YarnClient;
+
+/**
+ * A {@link CommandLineRunner} handling a default action for {@link YarnClient}.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class ClientLauncherRunner implements CommandLineRunner {
+
+	private static final Log log = LogFactory.getLog(ClientLauncherRunner.class);
+
+	public static final String ACTION_SUBMIT = "submit";
+
+	@Autowired(required=false)
+	private YarnClient yarnClient;
+
+	private String action;
+
+	/**
+	 * Instantiates a new client launcher runner.
+	 */
+	public ClientLauncherRunner() {
+	}
+
+	/**
+	 * Instantiates a new client launcher runner.
+	 *
+	 * @param action the action
+	 */
+	public ClientLauncherRunner(String action) {
+		this.action = action;
+	}
+
+	@Override
+	public void run(String... args) throws Exception {
+		if (!StringUtils.hasText(action)) {
+			// no action, silently bail out
+			return;
+		} else if (yarnClient == null) {
+			log.warn("We have action=" + action + " but no yarnClient");
+			return;
+		}
+		log.info("Running action=" + action);
+		if (ACTION_SUBMIT.equals(action)) {
+			log.info("Submitting application");
+			yarnClient.submitApplication();
+		} else {
+			log.warn("Unable to do startup with unknown action=" + action);
+		}
+	}
+
+	/**
+	 * Sets the action use by this launcher.
+	 *
+	 * @param action the new action
+	 */
+	public void setAction(String action) {
+		this.action = action;
+	}
+
+}

--- a/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringYarnClientPropertiesTests.java
+++ b/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringYarnClientPropertiesTests.java
@@ -55,6 +55,8 @@ public class SpringYarnClientPropertiesTests {
 
 		assertThat(properties.getClientClass(), is("clientClassFoo"));
 
+		assertThat(properties.getStartup().getAction(), is("submit"));
+
 		context.close();
 	}
 

--- a/spring-yarn/spring-yarn-boot/src/test/resources/SpringYarnClientPropertiesTests.yml
+++ b/spring-yarn/spring-yarn-boot/src/test/resources/SpringYarnClientPropertiesTests.yml
@@ -7,3 +7,5 @@ spring:
             priority: 234
             queue: queueFoo
             clientClass: clientClassFoo
+            startup:
+                action: submit


### PR DESCRIPTION
- New boot property spring.yarn.client.startup.action
  which can be used to define an action what a ClientLauncherRunner
  should do on startup. Only one action 'submit' is
  currently defined which would simply call submitApplication()
  with YarnClient.
