### PR TITLE
SHDP-350 Fix HashMethodExecutor negative values

### DIFF
--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/expression/HashMethodExecutor.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/expression/HashMethodExecutor.java
@@ -26,7 +26,8 @@ import org.springframework.expression.TypedValue;
  * be an Integer to calculate a simple bucket name.
  *
  * <p>Spel expression "hash(region,2)" would create either key
- * "0_hash" or "1_hash".
+ * "0_hash" or "1_hash". Using a bucketsize 0 results
+ * an {@link AccessException}.
  *
  * @author Janne Valkealahti
  *
@@ -38,7 +39,7 @@ public class HashMethodExecutor implements MethodExecutor {
 		if (arguments[1] instanceof Integer) {
 			try {
 				Integer buckets = ((Integer)arguments[1]);
-				return new TypedValue(arguments[0].hashCode() % buckets + "_hash");
+				return new TypedValue(Math.abs(arguments[0].hashCode()) % buckets + "_hash");
 			} catch (Exception e) {
 				throw new AccessException("Error creating hash", e);
 			}

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/expression/HashMethodExecutorTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/expression/HashMethodExecutorTests.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.hadoop.store.expression;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.springframework.expression.AccessException;
+import org.springframework.expression.TypedValue;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+/**
+ * Tests for {@link HashMethodExecutor} internal functionality.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class HashMethodExecutorTests {
+
+	@Test
+	public void testPositiveValues() throws Exception {
+		StandardEvaluationContext context = new StandardEvaluationContext();
+		HashMethodExecutor executor = new HashMethodExecutor();
+		TypedValue value = executor.execute(context, new Object(), 3, 2);
+		assertThat((String) value.getValue(), is("1_hash"));
+		value = executor.execute(context, new Object(), 4, 2);
+		assertThat((String) value.getValue(), is("0_hash"));
+		value = executor.execute(context, new Object(), 9, 27);
+		assertThat((String) value.getValue(), is("9_hash"));
+		value = executor.execute(context, new Object(), 9, 11);
+		assertThat((String) value.getValue(), is("9_hash"));
+		value = executor.execute(context, new Object(), 11, 22);
+		assertThat((String) value.getValue(), is("11_hash"));
+		value = executor.execute(context, new Object(), 30, 27);
+		assertThat((String) value.getValue(), is("3_hash"));
+		value = executor.execute(context, new Object(), 332, 27);
+		assertThat((String) value.getValue(), is("8_hash"));
+	}
+
+	@Test
+	public void testNegativeValues() throws Exception {
+		StandardEvaluationContext context = new StandardEvaluationContext();
+		HashMethodExecutor executor = new HashMethodExecutor();
+		TypedValue value = executor.execute(context, new Object(), -3, -2);
+		assertThat((String) value.getValue(), is("1_hash"));
+	}
+
+	@Test
+	public void testEqualValues() throws Exception {
+		StandardEvaluationContext context = new StandardEvaluationContext();
+		HashMethodExecutor executor = new HashMethodExecutor();
+		TypedValue value = executor.execute(context, new Object(), -3, -3);
+		assertThat((String) value.getValue(), is("0_hash"));
+		value = executor.execute(context, new Object(), -1, -1);
+		assertThat((String) value.getValue(), is("0_hash"));
+		value = executor.execute(context, new Object(), 1, 1);
+		assertThat((String) value.getValue(), is("0_hash"));
+	}
+
+	@Test(expected=AccessException.class)
+	public void testZeros() throws Exception {
+		StandardEvaluationContext context = new StandardEvaluationContext();
+		HashMethodExecutor executor = new HashMethodExecutor();
+		executor.execute(context, new Object(), 0, 0);
+	}
+
+	@Test
+	public void testNegativeBucketSize() throws Exception {
+		StandardEvaluationContext context = new StandardEvaluationContext();
+		HashMethodExecutor executor = new HashMethodExecutor();
+		TypedValue value = executor.execute(context, new Object(), 3, -2);
+		assertThat((String) value.getValue(), is("1_hash"));
+	}
+
+	@Test
+	public void testNegativeHashcode() throws Exception {
+		StandardEvaluationContext context = new StandardEvaluationContext();
+		HashMethodExecutor executor = new HashMethodExecutor();
+		TypedValue value = executor.execute(context, new Object(), -9, 2);
+		assertThat((String) value.getValue(), is("1_hash"));
+	}
+
+	@Test
+	public void testNegativeHashcodeBucketSizeBigger() throws Exception {
+		StandardEvaluationContext context = new StandardEvaluationContext();
+		HashMethodExecutor executor = new HashMethodExecutor();
+		TypedValue value = executor.execute(context, new Object(), -9, 12);
+		assertThat((String) value.getValue(), is("9_hash"));
+		value = executor.execute(context, new Object(), -9, 24);
+		assertThat((String) value.getValue(), is("9_hash"));
+		value = executor.execute(context, new Object(), -9, 27);
+		assertThat((String) value.getValue(), is("9_hash"));
+	}
+
+}


### PR DESCRIPTION
- Hashcode given to HashMethodExecutor doesn't
  result negative values, thus giving accurate
  bucket count.
- Added tests for internal functionality.
