### PR TITLE
SHDP-357 Change store tests to use minicluster

### DIFF
--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/AbstractStoreTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/AbstractStoreTests.java
@@ -17,18 +17,18 @@ package org.springframework.data.hadoop.store;
 
 import java.io.IOException;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.junit.After;
 import org.junit.Before;
+import org.springframework.data.hadoop.test.junit.AbstractHadoopClusterTests;
 
 /**
  * Base class for store tests.
  *
  * @author Janne Valkealahti
  */
-public abstract class AbstractStoreTests {
+public abstract class AbstractStoreTests extends AbstractHadoopClusterTests {
 
 	protected final static String DATA10 = "0123456789";
 
@@ -72,18 +72,16 @@ public abstract class AbstractStoreTests {
 	protected final static String[] DATA79ARRAY = new String[] {
 		DATA17, DATA18, DATA19 };
 
-	private static final String tmpDirName = System.getProperty("java.io.tmpdir");
+	private static final String tmpDirName = "/tmp/";
 
 	protected final Path testBasePath = new Path(tmpDirName + (tmpDirName.endsWith("/") ? "" : "/")
 			+ getClass().getSimpleName());
 
 	protected final Path testDefaultPath = new Path(testBasePath, "default");
 
-	protected final Configuration testConfig = new Configuration();
-
 	@Before
 	public void setup() throws IOException {
-		FileSystem fs = testBasePath.getFileSystem(testConfig);
+		FileSystem fs = testBasePath.getFileSystem(getConfiguration());
 		fs.delete(testBasePath, true);
 	}
 

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/DelimitedTextFileStoreTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/DelimitedTextFileStoreTests.java
@@ -27,8 +27,18 @@ import java.util.List;
 import org.junit.Test;
 import org.springframework.data.hadoop.store.input.DelimitedTextFileReader;
 import org.springframework.data.hadoop.store.output.DelimitedTextFileWriter;
+import org.springframework.data.hadoop.test.context.HadoopDelegatingSmartContextLoader;
+import org.springframework.data.hadoop.test.context.MiniHadoopCluster;
+import org.springframework.test.context.ContextConfiguration;
 
+@ContextConfiguration(loader=HadoopDelegatingSmartContextLoader.class)
+@MiniHadoopCluster
 public class DelimitedTextFileStoreTests extends AbstractStoreTests {
+
+	@org.springframework.context.annotation.Configuration
+	static class Config {
+		// just empty to survive without xml configs
+	}
 
 	@Test
 	public void testWriteReadTextOneDelimitedLine() throws IOException {
@@ -36,10 +46,10 @@ public class DelimitedTextFileStoreTests extends AbstractStoreTests {
 		List<List<String>> data = new ArrayList<List<String>>();
 		data.add(Arrays.asList(DATA09ARRAY));
 
-		DelimitedTextFileWriter writer = new DelimitedTextFileWriter(testConfig, testDefaultPath, null);
+		DelimitedTextFileWriter writer = new DelimitedTextFileWriter(getConfiguration(), testDefaultPath, null);
 		TestUtils.writeData(writer, data);
 
-		DelimitedTextFileReader reader = new DelimitedTextFileReader(testConfig, testDefaultPath, null);
+		DelimitedTextFileReader reader = new DelimitedTextFileReader(getConfiguration(), testDefaultPath, null);
 		List<List<String>> list = TestUtils.readDataList(reader);
 		assertThat(list, notNullValue());
 		assertThat(list.size(), is(1));
@@ -54,10 +64,10 @@ public class DelimitedTextFileStoreTests extends AbstractStoreTests {
 		data.add(Arrays.asList(DATA09ARRAY));
 		data.add(Arrays.asList(DATA09ARRAY));
 
-		DelimitedTextFileWriter writer = new DelimitedTextFileWriter(testConfig, testDefaultPath, null);
+		DelimitedTextFileWriter writer = new DelimitedTextFileWriter(getConfiguration(), testDefaultPath, null);
 		TestUtils.writeData(writer, data);
 
-		DelimitedTextFileReader reader = new DelimitedTextFileReader(testConfig, testDefaultPath, null);
+		DelimitedTextFileReader reader = new DelimitedTextFileReader(getConfiguration(), testDefaultPath, null);
 		List<List<String>> list = TestUtils.readDataList(reader);
 		assertThat(list, notNullValue());
 		assertThat(list.size(), is(3));

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/PartitionTextFileWriterTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/PartitionTextFileWriterTests.java
@@ -37,10 +37,20 @@ import org.springframework.data.hadoop.store.partition.PartitionStrategy;
 import org.springframework.data.hadoop.store.strategy.naming.RollingFileNamingStrategy;
 import org.springframework.data.hadoop.store.strategy.naming.StaticFileNamingStrategy;
 import org.springframework.data.hadoop.store.strategy.rollover.SizeRolloverStrategy;
+import org.springframework.data.hadoop.test.context.HadoopDelegatingSmartContextLoader;
+import org.springframework.data.hadoop.test.context.MiniHadoopCluster;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.test.context.ContextConfiguration;
 
+@ContextConfiguration(loader=HadoopDelegatingSmartContextLoader.class)
+@MiniHadoopCluster
 public class PartitionTextFileWriterTests extends AbstractStoreTests {
+
+	@org.springframework.context.annotation.Configuration
+	static class Config {
+		// just empty to survive without xml configs
+	}
 
 	@Test
 	public void testMapWriteReadTextOneLine() throws IOException {
@@ -55,14 +65,14 @@ public class PartitionTextFileWriterTests extends AbstractStoreTests {
 		String nowYYYYMM = new SimpleDateFormat("yyyy/MM").format(new Date());
 
 		PartitionTextFileWriter<Map<String, Object>> writer =
-				new PartitionTextFileWriter<Map<String, Object>>(testConfig, testDefaultPath, null, strategy);
+				new PartitionTextFileWriter<Map<String, Object>>(getConfiguration(), testDefaultPath, null, strategy);
 		writer.setFileNamingStrategyFactory(new StaticFileNamingStrategy("bar"));
 
 		writer.write(dataArray[0], headers);
 		writer.flush();
 		writer.close();
 
-		TextFileReader reader = new TextFileReader(testConfig, new Path(testDefaultPath, "foo/" + nowYYYYMM + "/0_hash/jee_list/10_range/bar"), null);
+		TextFileReader reader = new TextFileReader(getConfiguration(), new Path(testDefaultPath, "foo/" + nowYYYYMM + "/0_hash/jee_list/10_range/bar"), null);
 		TestUtils.readDataAndAssert(reader, dataArray);
 	}
 
@@ -78,14 +88,14 @@ public class PartitionTextFileWriterTests extends AbstractStoreTests {
 		String nowYYYYMM = new SimpleDateFormat("yyyy/MM").format(new Date());
 
 		PartitionTextFileWriter<Message<?>> writer =
-				new PartitionTextFileWriter<Message<?>>(testConfig, testDefaultPath, null, strategy);
+				new PartitionTextFileWriter<Message<?>>(getConfiguration(), testDefaultPath, null, strategy);
 		writer.setFileNamingStrategyFactory(new StaticFileNamingStrategy("bar"));
 
 		writer.write(dataArray[0], message);
 		writer.flush();
 		writer.close();
 
-		TextFileReader reader = new TextFileReader(testConfig, new Path(testDefaultPath, "foo/" + nowYYYYMM + "/bar"), null);
+		TextFileReader reader = new TextFileReader(getConfiguration(), new Path(testDefaultPath, "foo/" + nowYYYYMM + "/bar"), null);
 		TestUtils.readDataAndAssert(reader, dataArray);
 	}
 
@@ -99,14 +109,14 @@ public class PartitionTextFileWriterTests extends AbstractStoreTests {
 		headers.put("region", "foo");
 
 		PartitionTextFileWriter<Message<?>> writer =
-				new PartitionTextFileWriter<Message<?>>(testConfig, testDefaultPath, null, strategy);
+				new PartitionTextFileWriter<Message<?>>(getConfiguration(), testDefaultPath, null, strategy);
 		writer.setFileNamingStrategyFactory(new StaticFileNamingStrategy("bar"));
 
 		writer.write(dataArray[0], null);
 		writer.flush();
 		writer.close();
 
-		TextFileReader reader = new TextFileReader(testConfig, new Path(testDefaultPath, "bar"), null);
+		TextFileReader reader = new TextFileReader(getConfiguration(), new Path(testDefaultPath, "bar"), null);
 		TestUtils.readDataAndAssert(reader, dataArray);
 	}
 
@@ -117,7 +127,7 @@ public class PartitionTextFileWriterTests extends AbstractStoreTests {
 		MessagePartitionStrategy<String> strategy = new MessagePartitionStrategy<String>(expression);
 
 		PartitionTextFileWriter<Message<?>> writer =
-				new PartitionTextFileWriter<Message<?>>(testConfig, testDefaultPath, null, strategy);
+				new PartitionTextFileWriter<Message<?>>(getConfiguration(), testDefaultPath, null, strategy);
 
 		writer.setFileNamingStrategyFactory(new RollingFileNamingStrategy());
 		writer.setRolloverStrategyFactory(new SizeRolloverStrategy(40));
@@ -133,13 +143,13 @@ public class PartitionTextFileWriterTests extends AbstractStoreTests {
 
 		String nowYYYYMM = new SimpleDateFormat("yyyy/MM").format(new Date());
 
-		TextFileReader reader1 = new TextFileReader(testConfig, new Path(testDefaultPath, "foo/" + nowYYYYMM + "/0"), null);
+		TextFileReader reader1 = new TextFileReader(getConfiguration(), new Path(testDefaultPath, "foo/" + nowYYYYMM + "/0"), null);
 		List<String> splitData1 = TestUtils.readData(reader1);
 
-		TextFileReader reader2 = new TextFileReader(testConfig, new Path(testDefaultPath, "foo/" + nowYYYYMM + "/1"), null);
+		TextFileReader reader2 = new TextFileReader(getConfiguration(), new Path(testDefaultPath, "foo/" + nowYYYYMM + "/1"), null);
 		List<String> splitData2 = TestUtils.readData(reader2);
 
-		TextFileReader reader3 = new TextFileReader(testConfig, new Path(testDefaultPath, "foo/" + nowYYYYMM + "/2"), null);
+		TextFileReader reader3 = new TextFileReader(getConfiguration(), new Path(testDefaultPath, "foo/" + nowYYYYMM + "/2"), null);
 		List<String> splitData3 = TestUtils.readData(reader3);
 
 		assertThat(splitData1.size() + splitData2.size() + splitData3.size(), is(DATA09ARRAY.length));
@@ -152,7 +162,7 @@ public class PartitionTextFileWriterTests extends AbstractStoreTests {
 		String[] dataArray3 = new String[] { "customer3-1", "customer3-2", "customer3-3" };
 		CustomerPartitionStrategy strategy = new CustomerPartitionStrategy();
 		PartitionTextFileWriter<String> writer =
-				new PartitionTextFileWriter<String>(testConfig, testDefaultPath, null, strategy);
+				new PartitionTextFileWriter<String>(getConfiguration(), testDefaultPath, null, strategy);
 
 		writer.write(dataArray1[0], "customer1");
 		writer.write(dataArray1[1], "customer1");
@@ -167,15 +177,15 @@ public class PartitionTextFileWriterTests extends AbstractStoreTests {
 		writer.close();
 
 		// /tmp/TextFilePartitionedWriterTests/default/customer1
-		TextFileReader reader1 = new TextFileReader(testConfig, new Path(testDefaultPath, "customer1"), null);
+		TextFileReader reader1 = new TextFileReader(getConfiguration(), new Path(testDefaultPath, "customer1"), null);
 		TestUtils.readDataAndAssert(reader1, dataArray1);
 
 		// /tmp/TextFilePartitionedWriterTests/default/customer2
-		TextFileReader reader2 = new TextFileReader(testConfig, new Path(testDefaultPath, "customer2"), null);
+		TextFileReader reader2 = new TextFileReader(getConfiguration(), new Path(testDefaultPath, "customer2"), null);
 		TestUtils.readDataAndAssert(reader2, dataArray2);
 
 		// /tmp/TextFilePartitionedWriterTests/default/customer3
-		TextFileReader reader3 = new TextFileReader(testConfig, new Path(testDefaultPath, "customer3"), null);
+		TextFileReader reader3 = new TextFileReader(getConfiguration(), new Path(testDefaultPath, "customer3"), null);
 		TestUtils.readDataAndAssert(reader3, dataArray3);
 	}
 
@@ -186,7 +196,7 @@ public class PartitionTextFileWriterTests extends AbstractStoreTests {
 		String[] dataArray3 = new String[] { "customer3-1", "customer3-2", "customer3-3" };
 		CustomerPartitionStrategy strategy = new CustomerPartitionStrategy();
 		PartitionTextFileWriter<String> writer =
-				new PartitionTextFileWriter<String>(testConfig, testDefaultPath, null, strategy);
+				new PartitionTextFileWriter<String>(getConfiguration(), testDefaultPath, null, strategy);
 
 		writer.write(dataArray1[0]);
 		writer.write(dataArray1[1]);
@@ -201,15 +211,15 @@ public class PartitionTextFileWriterTests extends AbstractStoreTests {
 		writer.close();
 
 		// /tmp/TextFilePartitionedWriterTests/default/customer1
-		TextFileReader reader1 = new TextFileReader(testConfig, new Path(testDefaultPath, "customer1"), null);
+		TextFileReader reader1 = new TextFileReader(getConfiguration(), new Path(testDefaultPath, "customer1"), null);
 		TestUtils.readDataAndAssert(reader1, dataArray1);
 
 		// /tmp/TextFilePartitionedWriterTests/default/customer2
-		TextFileReader reader2 = new TextFileReader(testConfig, new Path(testDefaultPath, "customer2"), null);
+		TextFileReader reader2 = new TextFileReader(getConfiguration(), new Path(testDefaultPath, "customer2"), null);
 		TestUtils.readDataAndAssert(reader2, dataArray2);
 
 		// /tmp/TextFilePartitionedWriterTests/default/customer3
-		TextFileReader reader3 = new TextFileReader(testConfig, new Path(testDefaultPath, "customer3"), null);
+		TextFileReader reader3 = new TextFileReader(getConfiguration(), new Path(testDefaultPath, "customer3"), null);
 		TestUtils.readDataAndAssert(reader3, dataArray3);
 	}
 

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/RawStreamStoreTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/RawStreamStoreTests.java
@@ -32,6 +32,9 @@ import org.springframework.data.hadoop.store.strategy.naming.ChainedFileNamingSt
 import org.springframework.data.hadoop.store.strategy.naming.CodecFileNamingStrategy;
 import org.springframework.data.hadoop.store.strategy.naming.StaticFileNamingStrategy;
 import org.springframework.data.hadoop.store.support.StoreUtils;
+import org.springframework.data.hadoop.test.context.HadoopDelegatingSmartContextLoader;
+import org.springframework.data.hadoop.test.context.MiniHadoopCluster;
+import org.springframework.test.context.ContextConfiguration;
 
 /**
  * Tests for writing raw byte arrays.
@@ -39,7 +42,14 @@ import org.springframework.data.hadoop.store.support.StoreUtils;
  * @author Janne Valkealahti
  *
  */
+@ContextConfiguration(loader=HadoopDelegatingSmartContextLoader.class)
+@MiniHadoopCluster
 public class RawStreamStoreTests extends AbstractStoreTests {
+
+	@org.springframework.context.annotation.Configuration
+	static class Config {
+		// just empty to survive without xml configs
+	}
 
 	@Test
 	public void testWriteReadTextTwoLines() throws IOException {
@@ -51,22 +61,22 @@ public class RawStreamStoreTests extends AbstractStoreTests {
 		data[2] = DATA11.getBytes();
 		data[3] = "\n".getBytes();
 
-		OutputStreamWriter writer = new OutputStreamWriter(testConfig, testDefaultPath, null);
+		OutputStreamWriter writer = new OutputStreamWriter(getConfiguration(), testDefaultPath, null);
 		TestUtils.writeData(writer, data, true);
 
-		TextFileReader reader = new TextFileReader(testConfig, testDefaultPath, null);
+		TextFileReader reader = new TextFileReader(getConfiguration(), testDefaultPath, null);
 		TestUtils.readDataAndAssert(reader, dataArray);
 	}
 
 	@Test
 	public void testStreamSmall() throws IOException {
 		ByteArrayInputStream stream = new ByteArrayInputStream(DATA10.getBytes());
-		OutputStreamWriter writer = new OutputStreamWriter(testConfig, testDefaultPath, null);
+		OutputStreamWriter writer = new OutputStreamWriter(getConfiguration(), testDefaultPath, null);
 
 		doWithInputStream(stream, writer);
 
 		String[] dataArray = new String[] { DATA10 };
-		TextFileReader reader = new TextFileReader(testConfig, testDefaultPath, null);
+		TextFileReader reader = new TextFileReader(getConfiguration(), testDefaultPath, null);
 		TestUtils.readDataAndAssert(reader, dataArray);
 	}
 
@@ -78,11 +88,11 @@ public class RawStreamStoreTests extends AbstractStoreTests {
 			buf.append("\n");
 		}
 		ByteArrayInputStream stream = new ByteArrayInputStream(buf.toString().getBytes());
-		OutputStreamWriter writer = new OutputStreamWriter(testConfig, testDefaultPath, null);
+		OutputStreamWriter writer = new OutputStreamWriter(getConfiguration(), testDefaultPath, null);
 
 		doWithInputStream(stream, writer);
 
-		TextFileReader reader = new TextFileReader(testConfig, testDefaultPath, null);
+		TextFileReader reader = new TextFileReader(getConfiguration(), testDefaultPath, null);
 		List<String> data = TestUtils.readData(reader);
 		assertThat(data.size(), is(1000));
 	}
@@ -95,11 +105,11 @@ public class RawStreamStoreTests extends AbstractStoreTests {
 			buf.append("\n");
 		}
 		ByteArrayInputStream stream = new ByteArrayInputStream(buf.toString().getBytes());
-		OutputStreamWriter writer = new OutputStreamWriter(testConfig, testDefaultPath, Codecs.GZIP.getCodecInfo());
+		OutputStreamWriter writer = new OutputStreamWriter(getConfiguration(), testDefaultPath, Codecs.GZIP.getCodecInfo());
 
 		doWithInputStream(stream, writer);
 
-		TextFileReader reader = new TextFileReader(testConfig, testDefaultPath, Codecs.GZIP.getCodecInfo());
+		TextFileReader reader = new TextFileReader(getConfiguration(), testDefaultPath, Codecs.GZIP.getCodecInfo());
 		List<String> data = TestUtils.readData(reader);
 		assertThat(data.size(), is(1000));
 	}
@@ -112,7 +122,7 @@ public class RawStreamStoreTests extends AbstractStoreTests {
 			buf.append("\n");
 		}
 		ByteArrayInputStream stream = new ByteArrayInputStream(buf.toString().getBytes());
-		OutputStreamWriter writer = new OutputStreamWriter(testConfig, testDefaultPath, Codecs.GZIP.getCodecInfo());
+		OutputStreamWriter writer = new OutputStreamWriter(getConfiguration(), testDefaultPath, Codecs.GZIP.getCodecInfo());
 
 		ChainedFileNamingStrategy fileNamingStrategy = new ChainedFileNamingStrategy();
 		fileNamingStrategy.register(new StaticFileNamingStrategy("data"));
@@ -121,7 +131,7 @@ public class RawStreamStoreTests extends AbstractStoreTests {
 
 		doWithInputStream(stream, writer);
 
-		TextFileReader reader = new TextFileReader(testConfig, new Path(testDefaultPath, "data.gzip"), Codecs.GZIP.getCodecInfo());
+		TextFileReader reader = new TextFileReader(getConfiguration(), new Path(testDefaultPath, "data.gzip"), Codecs.GZIP.getCodecInfo());
 		List<String> data = TestUtils.readData(reader);
 		assertThat(data.size(), is(1000));
 	}

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/SequenceFileStoreCtxTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/SequenceFileStoreCtxTests.java
@@ -24,13 +24,13 @@ import java.util.List;
 
 import org.apache.hadoop.fs.Path;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.data.hadoop.store.input.TextSequenceFileReader;
 import org.springframework.data.hadoop.store.output.TextSequenceFileWriter;
+import org.springframework.data.hadoop.test.context.HadoopDelegatingSmartContextLoader;
+import org.springframework.data.hadoop.test.context.MiniHadoopCluster;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * Tests for reading and writing text using context configuration.
@@ -38,8 +38,8 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * @author Janne Valkealahti
  *
  */
-@ContextConfiguration
-@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(loader=HadoopDelegatingSmartContextLoader.class)
+@MiniHadoopCluster
 public class SequenceFileStoreCtxTests extends AbstractStoreTests {
 
 	@Autowired
@@ -57,13 +57,13 @@ public class SequenceFileStoreCtxTests extends AbstractStoreTests {
 		Thread.sleep(2000);
 		TestUtils.writeData(writer, new String[] { DATA12 }, true);
 
-		TextSequenceFileReader reader1 = new TextSequenceFileReader(testConfig, new Path(testDefaultPath, "0"), null);
+		TextSequenceFileReader reader1 = new TextSequenceFileReader(getConfiguration(), new Path(testDefaultPath, "0"), null);
 		List<String> splitData1 = TestUtils.readData(reader1);
 
-		TextSequenceFileReader reader2 = new TextSequenceFileReader(testConfig, new Path(testDefaultPath, "1"), null);
+		TextSequenceFileReader reader2 = new TextSequenceFileReader(getConfiguration(), new Path(testDefaultPath, "1"), null);
 		List<String> splitData2 = TestUtils.readData(reader2);
 
-		TextSequenceFileReader reader3 = new TextSequenceFileReader(testConfig, new Path(testDefaultPath, "2"), null);
+		TextSequenceFileReader reader3 = new TextSequenceFileReader(getConfiguration(), new Path(testDefaultPath, "2"), null);
 		List<String> splitData3 = TestUtils.readData(reader3);
 
 		assertThat(splitData1.size() + splitData2.size() + splitData3.size(), is(3));

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/SequenceFileStoreTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/SequenceFileStoreTests.java
@@ -28,6 +28,9 @@ import org.springframework.data.hadoop.store.input.TextSequenceFileReader;
 import org.springframework.data.hadoop.store.output.TextSequenceFileWriter;
 import org.springframework.data.hadoop.store.strategy.naming.RollingFileNamingStrategy;
 import org.springframework.data.hadoop.store.strategy.rollover.SizeRolloverStrategy;
+import org.springframework.data.hadoop.test.context.HadoopDelegatingSmartContextLoader;
+import org.springframework.data.hadoop.test.context.MiniHadoopCluster;
+import org.springframework.test.context.ContextConfiguration;
 
 /**
  * Tests for writing and reading text using sequence file.
@@ -35,25 +38,32 @@ import org.springframework.data.hadoop.store.strategy.rollover.SizeRolloverStrat
  * @author Janne Valkealahti
  *
  */
+@ContextConfiguration(loader=HadoopDelegatingSmartContextLoader.class)
+@MiniHadoopCluster
 public class SequenceFileStoreTests extends AbstractStoreTests {
+
+	@org.springframework.context.annotation.Configuration
+	static class Config {
+		// just empty to survive without xml configs
+	}
 
 	@Test
 	public void testWriteReadSequenceFileOneLine() throws IOException {
 		String[] dataArray = new String[] { DATA10 };
 
-		TextSequenceFileWriter writer = new TextSequenceFileWriter(testConfig, testDefaultPath, null);
+		TextSequenceFileWriter writer = new TextSequenceFileWriter(getConfiguration(), testDefaultPath, null);
 		TestUtils.writeData(writer, dataArray);
 
-		TextSequenceFileReader reader = new TextSequenceFileReader(testConfig, testDefaultPath, null);
+		TextSequenceFileReader reader = new TextSequenceFileReader(getConfiguration(), testDefaultPath, null);
 		TestUtils.readDataAndAssert(reader, dataArray);
 	}
 
 	@Test
 	public void testWriteReadSequenceFileManyLines() throws IOException {
-		TextSequenceFileWriter writer = new TextSequenceFileWriter(testConfig, testDefaultPath, null);
+		TextSequenceFileWriter writer = new TextSequenceFileWriter(getConfiguration(), testDefaultPath, null);
 		TestUtils.writeData(writer, DATA09ARRAY);
 
-		TextSequenceFileReader reader = new TextSequenceFileReader(testConfig, testDefaultPath, null);
+		TextSequenceFileReader reader = new TextSequenceFileReader(getConfiguration(), testDefaultPath, null);
 		TestUtils.readDataAndAssert(reader, DATA09ARRAY);
 	}
 
@@ -71,31 +81,31 @@ public class SequenceFileStoreTests extends AbstractStoreTests {
 
 	@Test
 	public void testWriteReadManyLinesWithBzip2() throws IOException {
-		TextSequenceFileWriter writer = new TextSequenceFileWriter(testConfig, testDefaultPath,
+		TextSequenceFileWriter writer = new TextSequenceFileWriter(getConfiguration(), testDefaultPath,
 				Codecs.BZIP2.getCodecInfo());
 		TestUtils.writeData(writer, DATA09ARRAY);
 
-		TextSequenceFileReader reader = new TextSequenceFileReader(testConfig, testDefaultPath,
+		TextSequenceFileReader reader = new TextSequenceFileReader(getConfiguration(), testDefaultPath,
 				Codecs.BZIP2.getCodecInfo());
 		TestUtils.readDataAndAssert(reader, DATA09ARRAY);
 	}
 
 	@Test
 	public void testWriteReadManyLinesWithNamingAndRollover() throws IOException {
-		TextSequenceFileWriter writer = new TextSequenceFileWriter(testConfig, testDefaultPath, null);
+		TextSequenceFileWriter writer = new TextSequenceFileWriter(getConfiguration(), testDefaultPath, null);
 		writer.setFileNamingStrategy(new RollingFileNamingStrategy());
 		writer.setRolloverStrategy(new SizeRolloverStrategy(150));
 		writer.setIdleTimeout(10000);
 
 		TestUtils.writeData(writer, DATA09ARRAY);
 
-		TextSequenceFileReader reader1 = new TextSequenceFileReader(testConfig, new Path(testDefaultPath, "0"), null);
+		TextSequenceFileReader reader1 = new TextSequenceFileReader(getConfiguration(), new Path(testDefaultPath, "0"), null);
 		List<String> splitData1 = TestUtils.readData(reader1);
 
-		TextSequenceFileReader reader2 = new TextSequenceFileReader(testConfig, new Path(testDefaultPath, "1"), null);
+		TextSequenceFileReader reader2 = new TextSequenceFileReader(getConfiguration(), new Path(testDefaultPath, "1"), null);
 		List<String> splitData2 = TestUtils.readData(reader2);
 
-		TextSequenceFileReader reader3 = new TextSequenceFileReader(testConfig, new Path(testDefaultPath, "2"), null);
+		TextSequenceFileReader reader3 = new TextSequenceFileReader(getConfiguration(), new Path(testDefaultPath, "2"), null);
 		List<String> splitData3 = TestUtils.readData(reader3);
 
 		assertThat(splitData1.size() + splitData2.size() + splitData3.size(), is(DATA09ARRAY.length));

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TextFileStoreCtxTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TextFileStoreCtxTests.java
@@ -24,13 +24,13 @@ import java.util.List;
 
 import org.apache.hadoop.fs.Path;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.data.hadoop.store.input.TextFileReader;
 import org.springframework.data.hadoop.store.output.TextFileWriter;
+import org.springframework.data.hadoop.test.context.HadoopDelegatingSmartContextLoader;
+import org.springframework.data.hadoop.test.context.MiniHadoopCluster;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * Tests for reading and writing text using context configuration.
@@ -38,8 +38,8 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * @author Janne Valkealahti
  *
  */
-@ContextConfiguration
-@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(loader=HadoopDelegatingSmartContextLoader.class)
+@MiniHadoopCluster
 public class TextFileStoreCtxTests extends AbstractStoreTests {
 
 	@Autowired
@@ -57,13 +57,13 @@ public class TextFileStoreCtxTests extends AbstractStoreTests {
 		Thread.sleep(2000);
 		TestUtils.writeData(writer, new String[] { DATA12 }, true);
 
-		TextFileReader reader1 = new TextFileReader(testConfig, new Path(testDefaultPath, "0"), null);
+		TextFileReader reader1 = new TextFileReader(getConfiguration(), new Path(testDefaultPath, "0"), null);
 		List<String> splitData1 = TestUtils.readData(reader1);
 
-		TextFileReader reader2 = new TextFileReader(testConfig, new Path(testDefaultPath, "1"), null);
+		TextFileReader reader2 = new TextFileReader(getConfiguration(), new Path(testDefaultPath, "1"), null);
 		List<String> splitData2 = TestUtils.readData(reader2);
 
-		TextFileReader reader3 = new TextFileReader(testConfig, new Path(testDefaultPath, "2"), null);
+		TextFileReader reader3 = new TextFileReader(getConfiguration(), new Path(testDefaultPath, "2"), null);
 		List<String> splitData3 = TestUtils.readData(reader3);
 
 		assertThat(splitData1.size() + splitData2.size() + splitData3.size(), is(3));

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TextFileStoreSplitTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TextFileStoreSplitTests.java
@@ -29,6 +29,9 @@ import org.springframework.data.hadoop.store.output.TextFileWriter;
 import org.springframework.data.hadoop.store.split.Split;
 import org.springframework.data.hadoop.store.split.Splitter;
 import org.springframework.data.hadoop.store.split.StaticLengthSplitter;
+import org.springframework.data.hadoop.test.context.HadoopDelegatingSmartContextLoader;
+import org.springframework.data.hadoop.test.context.MiniHadoopCluster;
+import org.springframework.test.context.ContextConfiguration;
 
 /**
  * Tests for writing and reading text using text file.
@@ -36,29 +39,36 @@ import org.springframework.data.hadoop.store.split.StaticLengthSplitter;
  * @author Janne Valkealahti
  *
  */
+@ContextConfiguration(loader=HadoopDelegatingSmartContextLoader.class)
+@MiniHadoopCluster
 public class TextFileStoreSplitTests extends AbstractStoreTests {
+
+	@org.springframework.context.annotation.Configuration
+	static class Config {
+		// just empty to survive without xml configs
+	}
 
 	@Test
 	public void testWriteReadSplitTextManyLines() throws IOException {
-		TextFileWriter writer = new TextFileWriter(testConfig, testDefaultPath, null);
+		TextFileWriter writer = new TextFileWriter(getConfiguration(), testDefaultPath, null);
 		TestUtils.writeData(writer, DATA09ARRAY, false);
 		TestUtils.writeData(writer, DATA09ARRAY, false);
 		TestUtils.writeData(writer, DATA09ARRAY, true);
 
-		Splitter splitter = new StaticLengthSplitter(testConfig, 110l);
+		Splitter splitter = new StaticLengthSplitter(getConfiguration(), 110l);
 		List<Split> inputSplits = splitter.getSplits(testDefaultPath);
 		assertNotNull(inputSplits);
 		assertThat(inputSplits.size(), is(3));
 
-		TextFileReader reader1 = new TextFileReader(testConfig, testDefaultPath, null, inputSplits.get(0), null);
+		TextFileReader reader1 = new TextFileReader(getConfiguration(), testDefaultPath, null, inputSplits.get(0), null);
 		List<String> readData1 = TestUtils.readData(reader1);
 		assertNotNull(readData1);
 
-		TextFileReader reader2 = new TextFileReader(testConfig, testDefaultPath, null, inputSplits.get(1), null);
+		TextFileReader reader2 = new TextFileReader(getConfiguration(), testDefaultPath, null, inputSplits.get(1), null);
 		List<String> readData2 = TestUtils.readData(reader2);
 		assertNotNull(readData2);
 
-		TextFileReader reader3 = new TextFileReader(testConfig, testDefaultPath, null, inputSplits.get(2), null);
+		TextFileReader reader3 = new TextFileReader(getConfiguration(), testDefaultPath, null, inputSplits.get(2), null);
 		List<String> readData3 = TestUtils.readData(reader3);
 		assertNotNull(readData3);
 
@@ -67,25 +77,25 @@ public class TextFileStoreSplitTests extends AbstractStoreTests {
 
 	@Test
 	public void testWriteReadBZip2WithSplitSmallData() throws IOException {
-		TextFileWriter writer = new TextFileWriter(testConfig, testDefaultPath, Codecs.BZIP2.getCodecInfo());
+		TextFileWriter writer = new TextFileWriter(getConfiguration(), testDefaultPath, Codecs.BZIP2.getCodecInfo());
 		TestUtils.writeData(writer, DATA09ARRAY, false);
 		TestUtils.writeData(writer, DATA09ARRAY, false);
 		TestUtils.writeData(writer, DATA09ARRAY, true);
 
-		Splitter splitter = new StaticLengthSplitter(testConfig, 30l);
+		Splitter splitter = new StaticLengthSplitter(getConfiguration(), 30l);
 		List<Split> inputSplits = splitter.getSplits(testDefaultPath);
 		assertNotNull(inputSplits);
 		assertThat(inputSplits.size(), is(3));
 
-		TextFileReader reader1 = new TextFileReader(testConfig, testDefaultPath, Codecs.BZIP2.getCodecInfo(), inputSplits.get(0), null);
+		TextFileReader reader1 = new TextFileReader(getConfiguration(), testDefaultPath, Codecs.BZIP2.getCodecInfo(), inputSplits.get(0), null);
 		List<String> readData1 = TestUtils.readData(reader1);
 		assertNotNull(readData1);
 
-		TextFileReader reader2 = new TextFileReader(testConfig, testDefaultPath, Codecs.BZIP2.getCodecInfo(), inputSplits.get(1), null);
+		TextFileReader reader2 = new TextFileReader(getConfiguration(), testDefaultPath, Codecs.BZIP2.getCodecInfo(), inputSplits.get(1), null);
 		List<String> readData2 = TestUtils.readData(reader2);
 		assertNotNull(readData2);
 
-		TextFileReader reader3 = new TextFileReader(testConfig, testDefaultPath, Codecs.BZIP2.getCodecInfo(), inputSplits.get(2), null);
+		TextFileReader reader3 = new TextFileReader(getConfiguration(), testDefaultPath, Codecs.BZIP2.getCodecInfo(), inputSplits.get(2), null);
 		List<String> readData3 = TestUtils.readData(reader3);
 		assertNotNull(readData3);
 

--- a/spring-hadoop-store/src/test/resources/org/springframework/data/hadoop/store/SequenceFileStoreCtxTests-context.xml
+++ b/spring-hadoop-store/src/test/resources/org/springframework/data/hadoop/store/SequenceFileStoreCtxTests-context.xml
@@ -14,8 +14,6 @@
 	<task:executor id="taskExecutor" pool-size="2"/>
 	<task:scheduler id="taskScheduler" pool-size="2"/>
 
-	<bean id="hadoopConfiguration" class="org.apache.hadoop.conf.Configuration"/>
-
 	<bean id="storeEventPublisher" class="org.springframework.data.hadoop.store.event.DefaultStoreEventPublisher"/>
 
 	<bean id="loggingListener" class="org.springframework.data.hadoop.store.event.LoggingListener">

--- a/spring-hadoop-store/src/test/resources/org/springframework/data/hadoop/store/TextFileStoreCtxTests-context.xml
+++ b/spring-hadoop-store/src/test/resources/org/springframework/data/hadoop/store/TextFileStoreCtxTests-context.xml
@@ -14,8 +14,6 @@
 	<task:executor id="taskExecutor" pool-size="2"/>
 	<task:scheduler id="taskScheduler" pool-size="2"/>
 
-	<bean id="hadoopConfiguration" class="org.apache.hadoop.conf.Configuration"/>
-
 	<bean id="storeEventPublisher" class="org.springframework.data.hadoop.store.event.DefaultStoreEventPublisher"/>
 
 	<bean id="loggingListener" class="org.springframework.data.hadoop.store.event.LoggingListener">


### PR DESCRIPTION
- Dataset tests using kite not changed due to SHDP-358
- Using base class AbstractHadoopClusterTests to bring
  support from minicluster together with @MiniHadoopCluster and
  related @ContextConfiguration in test classes.
