### PR TITLE
SHDP-357 Fixes for potentially failing tests

### DIFF
--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/SequenceFileStoreCtxTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/SequenceFileStoreCtxTests.java
@@ -52,10 +52,11 @@ public class SequenceFileStoreCtxTests extends AbstractStoreTests {
 		assertNotNull(writer);
 
 		TestUtils.writeData(writer, new String[] { DATA10 }, false);
-		Thread.sleep(2000);
+		Thread.sleep(3000);
 		TestUtils.writeData(writer, new String[] { DATA11 }, false);
-		Thread.sleep(2000);
+		Thread.sleep(3000);
 		TestUtils.writeData(writer, new String[] { DATA12 }, true);
+		Thread.sleep(3000);
 
 		TextSequenceFileReader reader1 = new TextSequenceFileReader(getConfiguration(), new Path(testDefaultPath, "0"), null);
 		List<String> splitData1 = TestUtils.readData(reader1);

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TextFileStoreCtxTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TextFileStoreCtxTests.java
@@ -52,10 +52,11 @@ public class TextFileStoreCtxTests extends AbstractStoreTests {
 		assertNotNull(writer);
 
 		TestUtils.writeData(writer, new String[] { DATA10 }, false);
-		Thread.sleep(2000);
+		Thread.sleep(3000);
 		TestUtils.writeData(writer, new String[] { DATA11 }, false);
-		Thread.sleep(2000);
+		Thread.sleep(3000);
 		TestUtils.writeData(writer, new String[] { DATA12 }, true);
+		Thread.sleep(3000);
 
 		TextFileReader reader1 = new TextFileReader(getConfiguration(), new Path(testDefaultPath, "0"), null);
 		List<String> splitData1 = TestUtils.readData(reader1);

--- a/spring-hadoop-store/src/test/resources/org/springframework/data/hadoop/store/SequenceFileStoreCtxTests-context.xml
+++ b/spring-hadoop-store/src/test/resources/org/springframework/data/hadoop/store/SequenceFileStoreCtxTests-context.xml
@@ -23,7 +23,7 @@
 	<bean id="fileNamingStrategy" class="org.springframework.data.hadoop.store.strategy.naming.RollingFileNamingStrategy"/>
 
 	<bean id="tmpdir" class="java.lang.String">
-		<constructor-arg value="#{systemProperties['java.io.tmpdir']}"/>
+		<constructor-arg value="/tmp"/>
 	</bean>
 
 	<bean id="testBasePath" class="org.apache.hadoop.fs.Path">

--- a/spring-hadoop-store/src/test/resources/org/springframework/data/hadoop/store/TextFileStoreCtxTests-context.xml
+++ b/spring-hadoop-store/src/test/resources/org/springframework/data/hadoop/store/TextFileStoreCtxTests-context.xml
@@ -23,7 +23,7 @@
 	<bean id="fileNamingStrategy" class="org.springframework.data.hadoop.store.strategy.naming.RollingFileNamingStrategy"/>
 
 	<bean id="tmpdir" class="java.lang.String">
-		<constructor-arg value="#{systemProperties['java.io.tmpdir']}"/>
+		<constructor-arg value="/tmp"/>
 	</bean>
 
 	<bean id="testBasePath" class="org.apache.hadoop.fs.Path">


### PR DESCRIPTION
- TextFileStoreCtxTests and SequenceFileStoreCtxTests rely on
  executor to kick in and close/rollover to next file while
  we wait between writer. Added bigger wait after the writes.
- Changed tmp dir for those tests from #{systemProperties['java.io.tmpdir']}
  to /tmp.
