### PR TITLE
SHDP-360 Update Kite SDK to 0.14.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -729,6 +729,10 @@ project('spring-data-hadoop-batch') {
 project('spring-data-hadoop-store') {
 	description = 'Spring for Apache Hadoop Store Features'
 
+	configurations {
+		testRuntime.exclude group: 'org.apache.hive'
+	}
+
 	dependencies {
 		compile("org.kitesdk:kite-data-core:$kiteVersion") { dep ->
 			exclude group: "log4j", module: "log4j"

--- a/gradle.properties
+++ b/gradle.properties
@@ -66,7 +66,7 @@ jackson2Version = 2.3.2
 commonsioVersion = 2.4
 cglibVersion = 3.1
 snakeYamlVersion = 1.13
-kiteVersion = 0.13.0
+kiteVersion = 0.14.0
 
 ## Common testing libraries
 junitVersion = 4.11


### PR DESCRIPTION
- Kite from 13 to 14
- Excluded hive from store testRuntime due to avro classes
  being present on both avro-1.7.6.jar and hive-exec-0.12.0.jar.
