### PR TITLE
SHDP-256 Add security config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -313,6 +313,10 @@ configure(javaProjects()) {
 	ext.skipHBase = true
 	ext.skipWebHdfs = true
 
+	test {
+		systemProperty("testGroups", project.properties.get("testGroups"))
+	}
+
 	// exclude poms from the classpath (pulled in by Cloudera)
 	eclipse.classpath.file {
 		whenMerged { classpath ->
@@ -791,6 +795,7 @@ project('spring-data-hadoop-build-tests') {
 		compile project(":spring-data-hadoop-batch")
 		compile project(":spring-data-hadoop")
 		compile project(":spring-data-hadoop-test")
+		testCompile project(path:":spring-data-hadoop-test", configuration:"testArtifacts")
 
 		// Testing
 		testCompile "junit:junit:$junitVersion"

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/ConfigurationSecureHdfsTest.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/ConfigurationSecureHdfsTest.java
@@ -1,0 +1,56 @@
+package org.springframework.data.hadoop.config;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.junit.Test;
+import org.springframework.context.support.AbstractApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.data.hadoop.TestUtils;
+import org.springframework.data.hadoop.test.tests.Assume;
+import org.springframework.data.hadoop.test.tests.TestGroup;
+import org.springframework.util.Assert;
+
+/**
+ * tests for yarn:configuration secure.
+ *
+ * @author David Liu
+ * @author Janne Valkealahti
+ *
+ */
+public class ConfigurationSecureHdfsTest {
+
+	private static final Log log = LogFactory.getLog(ConfigurationSecureHdfsTest.class);
+
+	@Test
+	public void testSecurityConfigWithReadFromKerberizedHdfs() throws Exception {
+		// This test is guarded by test group to be run manually
+		// until we have a proper way to use secured miniclusters.
+		Assume.group(TestGroup.KERBEROS);
+		AbstractApplicationContext context = new ClassPathXmlApplicationContext(
+				"ConfigurationSecureHdfsTest-context.xml",
+				ConfigurationSecureHdfsTest.class);
+		Assert.notNull(context.getBean("secureHdfsConfig"));
+		Configuration configuration = context.getBean("secureHdfsConfig", Configuration.class);
+		Object factory = context.getBean("&secureHdfsConfig");
+		String userKeytab = TestUtils.readField("userKeytab", factory);
+		assertThat(userKeytab, containsString("keytab"));
+		String namenodePrincipal = TestUtils.readField("namenodePrincipal", factory);
+		assertThat(namenodePrincipal, containsString("hdfs"));
+		String rmPrincipal = TestUtils.readField("rmManagerPrincipal", factory);
+		assertThat(rmPrincipal, containsString("yarn"));
+		FileSystem fs = FileSystem.get(configuration);
+		FileStatus[] listStatus = fs.listStatus(new Path("/"));
+		for (FileStatus fileStatus : listStatus) {
+			log.info("fileStatus: " + fileStatus);
+		}
+		context.close();
+	}
+
+}

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/config/ConfigurationSecureHdfsTest-context.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/config/ConfigurationSecureHdfsTest-context.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans:beans xmlns="http://www.springframework.org/schema/hadoop"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:beans="http://www.springframework.org/schema/beans"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+	http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+	http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+
+	<configuration id="secureHdfsConfig" file-system-uri="hdfs://localhost:8020" user-keytab="/usr/local/hadoops/janne.keytab"
+		user-principal="janne/neo" security-method="kerberos" rm-manager-principal="yarn/neo@LOCALDOMAIN"
+		namenode-principal="hdfs/neo@LOCALDOMAIN"/>
+
+</beans:beans>

--- a/spring-hadoop-config/src/main/resources/org/springframework/data/hadoop/config/spring-hadoop-2.1.xsd
+++ b/spring-hadoop-config/src/main/resources/org/springframework/data/hadoop/config/spring-hadoop-2.1.xsd
@@ -203,6 +203,42 @@ in a given JVM hence the default is false.
 				]]></xsd:documentation>
 				</xsd:annotation>
 				</xsd:attribute>
+				<xsd:attribute name="user-keytab" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+Security keytab.
+					]]></xsd:documentation>
+				</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="user-principal" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+User Security Principal
+					]]></xsd:documentation>
+				</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="namenode-principal" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+Namenode Security Principal
+					]]></xsd:documentation>
+				</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="rm-manager-principal" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+Resource Manager Security Principal
+					]]></xsd:documentation>
+				</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="security-method" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+The security method for hadoop
+					]]></xsd:documentation>
+				</xsd:annotation>
+				</xsd:attribute>
+
 				<xsd:attribute name="depends-on" use="optional"><xsd:annotation><xsd:documentation>
 	The names of the beans that this bean depends on being initialized. Typically used to guarantee
 	the initialization of certain beans before the Hadoop cluster gets configured and started (directly

--- a/spring-hadoop-test/src/test/java/org/springframework/data/hadoop/test/tests/TestGroup.java
+++ b/spring-hadoop-test/src/test/java/org/springframework/data/hadoop/test/tests/TestGroup.java
@@ -49,6 +49,11 @@ public enum TestGroup {
 	PERFORMANCE,
 
 	/**
+	 * Tests that should only be run with a specific kerberized environment.
+	 */
+	KERBEROS,
+
+	/**
 	 * Tests that should only be run on the continuous integration server.
 	 */
 	CI;

--- a/spring-hadoop-test/src/test/java/org/springframework/data/hadoop/test/tests/TestGroupTests.java
+++ b/spring-hadoop-test/src/test/java/org/springframework/data/hadoop/test/tests/TestGroupTests.java
@@ -65,7 +65,7 @@ public class TestGroupTests {
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("Unable to find test group 'missing' when parsing " +
                 "testGroups value: 'performance, missing'. Available groups include: " +
-                "[LONG_RUNNING,PERFORMANCE,CI]");
+                "[LONG_RUNNING,PERFORMANCE,KERBEROS,CI]");
         TestGroup.parse("performance, missing");
     }
 


### PR DESCRIPTION
- New options for configuration namespace controlling
  security, principals and keytab.
- schema changes for new 2.1 files
- User can login using a keytab file.
- Keeping test out of a way by forcing to use
  testGroup 'kerberos' because for now test
  assumes a specific kerberos setup which we
  don't have in CI.
