### PR TITLE
SHDP-361 SHDP-256 Yarn security javaconfig

### DIFF
--- a/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/configurers/DefaultSecurityConfigurer.java
+++ b/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/configurers/DefaultSecurityConfigurer.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.hadoop.config.common.annotation.configurers;
+
+import org.springframework.data.hadoop.config.common.annotation.AnnotationBuilder;
+import org.springframework.data.hadoop.config.common.annotation.AnnotationConfigurerAdapter;
+import org.springframework.data.hadoop.security.HadoopSecurity;
+import org.springframework.data.hadoop.security.SecurityAuthMethod;
+import org.springframework.util.StringUtils;
+
+/**
+ * {@link org.springframework.data.hadoop.config.common.annotation.AnnotationConfigurer AnnotationConfigurer}
+ * which knows how to handle configuring a {@link HadoopSecurity}.
+ *
+ * @author Janne Valkealahti
+ *
+ * @param <O> The Object being built by B
+ * @param <I> The type of interface or builder itself returned by the configurer
+ * @param <B> The Builder that is building O and is configured by {@link AnnotationConfigurerAdapter}
+ */
+public class DefaultSecurityConfigurer<O, I, B extends AnnotationBuilder<O>> extends
+		AnnotationConfigurerAdapter<O, I, B> implements SecurityConfigurer<I> {
+
+	private HadoopSecurity hadoopSecurity = new HadoopSecurity();
+
+	@Override
+	public SecurityConfigurer<I> authMethod(String authMethod) {
+		if (StringUtils.hasText(authMethod)) {
+			SecurityAuthMethod method = SecurityAuthMethod.valueOf(authMethod.toUpperCase());
+			if (method != null) {
+				hadoopSecurity.setSecurityAuthMethod(method);
+			}
+		}
+		return this;
+	}
+
+	@Override
+	public SecurityConfigurer<I> authMethod(SecurityAuthMethod authMethod) {
+		if (authMethod != null) {
+			hadoopSecurity.setSecurityAuthMethod(authMethod);
+		}
+		return this;
+	}
+
+	@Override
+	public SecurityConfigurer<I> userPrincipal(String principal) {
+		if (StringUtils.hasText(principal)) {
+			hadoopSecurity.setUserPrincipal(principal);
+		}
+		return this;
+	}
+
+	@Override
+	public SecurityConfigurer<I> userKeytab(String keytab) {
+		if (StringUtils.hasText(keytab)) {
+			hadoopSecurity.setUserKeytab(keytab);
+		}
+		return this;
+	}
+
+	@Override
+	public void configure(B builder) throws Exception {
+		if (!configureSecurity(builder, hadoopSecurity)) {
+			if (builder instanceof SecurityConfigurerAware) {
+				((SecurityConfigurerAware) builder).configureSecurity(hadoopSecurity);
+			}
+		}
+	}
+
+	@Override
+	public SecurityConfigurer<I> namenodePrincipal(String principal) {
+		if (StringUtils.hasText(principal)) {
+			hadoopSecurity.setNamenodePrincipal(principal);
+		}
+		return this;
+	}
+
+	@Override
+	public SecurityConfigurer<I> rmManagerPrincipal(String principal) {
+		if (StringUtils.hasText(principal)) {
+			hadoopSecurity.setRmManagerPrincipal(principal);
+		}
+		return this;
+	}
+
+	/**
+	 * Gets the {@link HadoopSecurity} configured for this builder.
+	 *
+	 * @return the security
+	 */
+	public HadoopSecurity getSecurity() {
+		return hadoopSecurity;
+	}
+
+	/**
+	 * Configure security. If this implementation is extended, custom configure
+	 * handling can be handled here.
+	 *
+	 * @param builder the builder
+	 * @param security the security
+	 * @return true, if security configure is handled
+	 */
+	protected boolean configureSecurity(B builder, HadoopSecurity security) {
+		return false;
+	}
+
+}

--- a/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/configurers/SecurityConfigurer.java
+++ b/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/configurers/SecurityConfigurer.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.hadoop.config.common.annotation.configurers;
+
+import org.springframework.data.hadoop.config.common.annotation.AnnotationConfigurerBuilder;
+import org.springframework.data.hadoop.security.SecurityAuthMethod;
+
+/**
+ * Interface for {@link DefaultSecurityConfigurer} which act
+ * as intermediate gatekeeper between a user and
+ * an {@link AnnotationConfigurerBuilder}.
+ *
+ * @author Janne Valkealahti
+ *
+ * @param <I> The type of an interface of B
+ */
+public interface SecurityConfigurer<I> extends AnnotationConfigurerBuilder<I> {
+
+	SecurityConfigurer<I> authMethod(String authMethod);
+
+	SecurityConfigurer<I> authMethod(SecurityAuthMethod authMethod);
+
+	SecurityConfigurer<I> userPrincipal(String principal);
+
+	SecurityConfigurer<I> userKeytab(String keytab);
+
+	SecurityConfigurer<I> namenodePrincipal(String principal);
+
+	SecurityConfigurer<I> rmManagerPrincipal(String principal);
+
+}

--- a/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/configurers/SecurityConfigurerAware.java
+++ b/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/configurers/SecurityConfigurerAware.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.hadoop.config.common.annotation.configurers;
+
+import org.springframework.data.hadoop.config.common.annotation.AnnotationBuilder;
+import org.springframework.data.hadoop.security.HadoopSecurity;
+
+/**
+ * Interface for {@link AnnotationBuilder} which wants to be
+ * aware of {@link HadoopSecurity} configured by {@link DefaultSecurityConfigurer}.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public interface SecurityConfigurerAware {
+
+	/**
+	 * Configure {@link HadoopSecurity}.
+	 *
+	 * @param hadoopSecurity the hadoop security
+	 */
+	void configureSecurity(HadoopSecurity hadoopSecurity);
+
+}

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/security/HadoopSecurity.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/security/HadoopSecurity.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.hadoop.security;
+
+/**
+ * This class keeps together all hadoop security related settings.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class HadoopSecurity {
+
+	private SecurityAuthMethod securityAuthMethod;
+	private String userPrincipal;
+	private String userKeytab;
+	private String rmManagerPrincipal;
+	private String namenodePrincipal;
+
+	public HadoopSecurity() {
+	}
+
+	public HadoopSecurity(SecurityAuthMethod securityAuthMethod, String userPrincipal, String userKeytab) {
+		this(securityAuthMethod, userPrincipal, userKeytab, null, null);
+	}
+
+	public HadoopSecurity(SecurityAuthMethod securityAuthMethod, String userPrincipal, String userKeytab,
+			String rmManagerPrincipal, String namenodePrincipal) {
+		this.securityAuthMethod = securityAuthMethod;
+		this.userPrincipal = userPrincipal;
+		this.userKeytab = userKeytab;
+		this.rmManagerPrincipal = rmManagerPrincipal;
+		this.namenodePrincipal = namenodePrincipal;
+	}
+
+	public SecurityAuthMethod getSecurityAuthMethod() {
+		return securityAuthMethod;
+	}
+
+	public void setSecurityAuthMethod(SecurityAuthMethod securityAuthMethod) {
+		this.securityAuthMethod = securityAuthMethod;
+	}
+
+	public String getUserPrincipal() {
+		return userPrincipal;
+	}
+
+	public void setUserPrincipal(String userPrincipal) {
+		this.userPrincipal = userPrincipal;
+	}
+
+	public String getUserKeytab() {
+		return userKeytab;
+	}
+
+	public void setUserKeytab(String userKeytab) {
+		this.userKeytab = userKeytab;
+	}
+
+	public String getRmManagerPrincipal() {
+		return rmManagerPrincipal;
+	}
+
+	public void setRmManagerPrincipal(String rmManagerPrincipal) {
+		this.rmManagerPrincipal = rmManagerPrincipal;
+	}
+
+	public String getNamenodePrincipal() {
+		return namenodePrincipal;
+	}
+
+	public void setNamenodePrincipal(String namenodePrincipal) {
+		this.namenodePrincipal = namenodePrincipal;
+	}
+
+}

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/security/SecurityAuthMethod.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/security/SecurityAuthMethod.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.hadoop.security;
+
+/**
+ * Supported security authentication methods in Spring Yarn.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public enum SecurityAuthMethod {
+
+	/** Indicates that global security is kerberos */
+	KERBEROS;
+}

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/YarnAppmasterAutoConfiguration.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/YarnAppmasterAutoConfiguration.java
@@ -216,7 +216,15 @@ public class YarnAppmasterAutoConfiguration {
 				.resourceManagerAddress(shp.getResourceManagerAddress())
 				.schedulerAddress(shp.getResourceManagerSchedulerAddress())
 				.withResources()
-					.resources(shp.getResources());
+					.resources(shp.getResources())
+					.and()
+				.withSecurity()
+					.namenodePrincipal(shp.getSecurity() != null ? shp.getSecurity().getNamenodePrincipal() : null)
+					.rmManagerPrincipal(shp.getSecurity() != null ? shp.getSecurity().getRmManagerPrincipal() : null)
+					.authMethod(shp.getSecurity() != null ? shp.getSecurity().getAuthMethod() : null);
+					// TODO: appmaster breaks if we try to use user principals
+					//.userPrincipal(shp.getSecurity() != null ? shp.getSecurity().getUserPrincipal() : null)
+					//.userKeytab(shp.getSecurity() != null ? shp.getSecurity().getUserKeytab() : null);
 		}
 
 		@Override

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/YarnClientAutoConfiguration.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/YarnClientAutoConfiguration.java
@@ -140,7 +140,14 @@ public class YarnClientAutoConfiguration {
 				.resourceManagerAddress(shp.getResourceManagerAddress())
 				.schedulerAddress(shp.getResourceManagerSchedulerAddress())
 				.withResources()
-					.resources(shp.getResources());
+					.resources(shp.getResources())
+					.and()
+				.withSecurity()
+					.namenodePrincipal(shp.getSecurity() != null ? shp.getSecurity().getNamenodePrincipal() : null)
+					.rmManagerPrincipal(shp.getSecurity() != null ? shp.getSecurity().getRmManagerPrincipal() : null)
+					.authMethod(shp.getSecurity() != null ? shp.getSecurity().getAuthMethod() : null)
+					.userPrincipal(shp.getSecurity() != null ? shp.getSecurity().getUserPrincipal() : null)
+					.userKeytab(shp.getSecurity() != null ? shp.getSecurity().getUserKeytab() : null);
 		}
 
 		@Override

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/YarnContainerAutoConfiguration.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/YarnContainerAutoConfiguration.java
@@ -113,7 +113,13 @@ public class YarnContainerAutoConfiguration {
 		@Override
 		public void configure(YarnConfigConfigurer config) throws Exception {
 			config
-				.fileSystemUri(shp.getFsUri());
+				.fileSystemUri(shp.getFsUri())
+				.withSecurity()
+					.namenodePrincipal(shp.getSecurity() != null ? shp.getSecurity().getNamenodePrincipal() : null)
+					.rmManagerPrincipal(shp.getSecurity() != null ? shp.getSecurity().getRmManagerPrincipal() : null)
+					.authMethod(shp.getSecurity() != null ? shp.getSecurity().getAuthMethod() : null)
+					.userPrincipal(shp.getSecurity() != null ? shp.getSecurity().getUserPrincipal() : null)
+					.userKeytab(shp.getSecurity() != null ? shp.getSecurity().getUserKeytab() : null);
 		}
 
 		@Override

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/SpringHadoopProperties.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/SpringHadoopProperties.java
@@ -21,6 +21,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.data.hadoop.security.SecurityAuthMethod;
 import org.springframework.util.StringUtils;
 
 /**
@@ -40,6 +41,7 @@ public class SpringHadoopProperties {
 	private Integer resourceManagerPort = 8032;
 	private Integer resourceManagerSchedulerPort = 8030;
 	private List<String> resources;
+	private SpringHadoopSecurityProperties security;
 
 	@Autowired
 	private SpringYarnEnvProperties syep;
@@ -117,6 +119,65 @@ public class SpringHadoopProperties {
 
 	public void setResources(List<String> resources) {
 		this.resources = resources;
+	}
+
+	public SpringHadoopSecurityProperties getSecurity() {
+		return security;
+	}
+
+	public void setSecurity(SpringHadoopSecurityProperties security) {
+		this.security = security;
+	}
+
+	public static class SpringHadoopSecurityProperties {
+		private SecurityAuthMethod authMethod;
+		private String userPrincipal;
+		private String userKeytab;
+		private String namenodePrincipal;
+		private String rmManagerPrincipal;
+
+		public SecurityAuthMethod getAuthMethod() {
+			return authMethod;
+		}
+
+		public void setAuthMethod(String authMethod) {
+			if (StringUtils.hasText(authMethod)) {
+				this.authMethod = SecurityAuthMethod.valueOf(authMethod.toUpperCase());
+			}
+		}
+
+		public String getUserPrincipal() {
+			return userPrincipal;
+		}
+
+		public void setUserPrincipal(String userPrincipal) {
+			this.userPrincipal = userPrincipal;
+		}
+
+		public String getUserKeytab() {
+			return userKeytab;
+		}
+
+		public void setUserKeytab(String userKeytab) {
+			this.userKeytab = userKeytab;
+		}
+
+		public String getNamenodePrincipal() {
+			return namenodePrincipal;
+		}
+
+		public void setNamenodePrincipal(String namenodePrincipal) {
+			this.namenodePrincipal = namenodePrincipal;
+		}
+
+		public String getRmManagerPrincipal() {
+			return rmManagerPrincipal;
+		}
+
+		public void setRmManagerPrincipal(String rmManagerPrincipal) {
+			this.rmManagerPrincipal = rmManagerPrincipal;
+		}
+
 	}
 
 }

--- a/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringHadoopSecurityPropertiesTests.java
+++ b/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringHadoopSecurityPropertiesTests.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.yarn.boot.properties;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.hadoop.security.SecurityAuthMethod;
+
+/**
+ * Tests for {@link SpringHadoopProperties} security bindings.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class SpringHadoopSecurityPropertiesTests {
+
+	@Test
+	public void testSecurityProperties() {
+		SpringApplication app = new SpringApplication(TestConfiguration.class);
+		app.setWebEnvironment(false);
+		ConfigurableApplicationContext context = app
+				.run(new String[] { "--spring.config.name=SpringHadoopSecurityPropertiesTests" });
+		SpringHadoopProperties properties = context.getBean(SpringHadoopProperties.class);
+		assertThat(properties, notNullValue());
+		assertThat(properties.getSecurity(), notNullValue());
+		assertThat(properties.getSecurity().getAuthMethod(), is(SecurityAuthMethod.KERBEROS));
+		assertThat(properties.getSecurity().getUserPrincipal(), is("userPrincipalFoo"));
+		assertThat(properties.getSecurity().getUserKeytab(), is("userKeytabFoo"));
+		assertThat(properties.getSecurity().getNamenodePrincipal(), is("hdfs/foo@LOCALDOMAIN"));
+		assertThat(properties.getSecurity().getRmManagerPrincipal(), is("yarn/foo@LOCALDOMAIN"));
+		context.close();
+	}
+
+	@Configuration
+	@EnableConfigurationProperties({ SpringHadoopProperties.class, SpringYarnEnvProperties.class })
+	protected static class TestConfiguration {
+	}
+
+}

--- a/spring-yarn/spring-yarn-boot/src/test/resources/SpringHadoopSecurityPropertiesTests.yml
+++ b/spring-yarn/spring-yarn-boot/src/test/resources/SpringHadoopSecurityPropertiesTests.yml
@@ -1,0 +1,8 @@
+spring:
+    hadoop:
+        security:
+            authMethod: kerberos
+            userPrincipal: userPrincipalFoo
+            userKeytab: userKeytabFoo
+            namenodePrincipal: hdfs/foo@LOCALDOMAIN
+            rmManagerPrincipal: yarn/foo@LOCALDOMAIN

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/builders/YarnConfigConfigurer.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/builders/YarnConfigConfigurer.java
@@ -18,6 +18,7 @@ package org.springframework.yarn.config.annotation.builders;
 import org.apache.hadoop.conf.Configuration;
 import org.springframework.data.hadoop.config.common.annotation.configurers.PropertiesConfigurer;
 import org.springframework.data.hadoop.config.common.annotation.configurers.ResourceConfigurer;
+import org.springframework.data.hadoop.config.common.annotation.configurers.SecurityConfigurer;
 import org.springframework.yarn.config.annotation.SpringYarnConfigurerAdapter;
 
 /**
@@ -109,6 +110,31 @@ public interface YarnConfigConfigurer {
 	 * @throws Exception if error occurred
 	 */
 	PropertiesConfigurer<YarnConfigConfigurer> withProperties() throws Exception;
+
+	/**
+	 * Specify security options with a {@link SecurityConfigurer}.
+	 *
+	 * <p>
+	 * <p>JavaConfig:
+	 * <p>
+	 * <pre>
+	 * public void configure(YarnConfigConfigure config) throws Exception {
+	 *   config
+	 *     .withSecurity()
+	 *       .authMethod("kerberos")
+	 *       .namenodePrincipal("hdfs/myhost@LOCALDOMAIN")
+	 *       .rmManagerPrincipal("yarn/myhost@LOCALDOMAIN");
+	 * }
+	 * </pre>
+	 *
+	 * <p>XML:
+	 * <p>
+	 * No equivalent
+	 *
+	 * @return {@link SecurityConfigurer} for chaining
+	 * @throws Exception if error occurred
+	 */
+	SecurityConfigurer<YarnConfigConfigurer> withSecurity() throws Exception;
 
 	/**
 	 * Specify a Hdfs file system uri.


### PR DESCRIPTION
- Javaconfig and boot integration of enabling
  kerberos. This add a whole app stack to be
  able to run on kerberized yarn/hdfs cluster.
- Fixes for usage of delegation tokens. Previously
  nodemanager failed for localization process due
  to missing tokens if appmaster and container were
  on different hosts.
- Preliminary support of using user keytab.
