### PR TITLE
SHDP-375 Adding fix for unparseable numeric parts

### DIFF
--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/strategy/naming/RollingFileNamingStrategy.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/strategy/naming/RollingFileNamingStrategy.java
@@ -69,7 +69,11 @@ public class RollingFileNamingStrategy extends AbstractFileNamingStrategy {
 			Pattern counterPattern = Pattern.compile(prefix + "(" + "\\d+" + ")");
 			Matcher m = counterPattern.matcher(name);
 			while (m.find()) {
-				counter = Integer.parseInt(m.group(1)) + 1;
+				try {
+					counter = Integer.parseInt(m.group(1)) + 1;
+				} catch (NumberFormatException e) {
+					// we don't care about numeric parts we can't parse
+				}
 			}
 			log.debug("Initialized counter starting from " + counter);
 

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/strategy/naming/RollingFileNamingStrategyTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/strategy/naming/RollingFileNamingStrategyTests.java
@@ -72,4 +72,15 @@ public class RollingFileNamingStrategyTests {
 		assertThat(strategy.resolve(new Path("/foo/jee")).toString(), is("/foo/jee-0"));
 	}
 
+	@Test
+	public void testInitPaths() throws Exception {
+		RollingFileNamingStrategy strategy = new RollingFileNamingStrategy();
+		strategy.init(new Path("/foo/jee-123.txt"));
+		int counter = TestUtils.readField("counter", strategy);
+		assertThat(counter, is(124));
+		strategy.init(new Path("/projects/loganalysis/yarn/2014/07/24/00/logIngestion-98e327c1-5f24-463a-88d7-571195529825-0.txt"));
+		counter = TestUtils.readField("counter", strategy);
+		assertThat(counter, is(1));
+	}
+
 }


### PR DESCRIPTION
- Now catching exceptions if numeric parts in
  a filename can't be parsed as integer.
- Some tests to verify this.
