### PR TITLE
SHDP-365 Fix for hadoop1 test

### DIFF
--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TextFileStoreTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TextFileStoreTests.java
@@ -267,6 +267,8 @@ public class TextFileStoreTests extends AbstractStoreTests {
 	public void testHdfsAvailableAfterWriterInitsSeeWriteException() throws Exception {
 		Configuration failConfiguration = new Configuration();
 		failConfiguration.set("fs.defaultFS", "hdfs://localhost:12345");
+		// for hadoop1
+		failConfiguration.set("fs.default.name", "hdfs://localhost:12345");
 		String[] dataArray = new String[] { DATA10 };
 
 		// use configuration which would not work for hdfs


### PR DESCRIPTION
- Trying to add hadoop1 deprecated property
  'fs.default.name' for failing test.
  testHdfsAvailableAfterWriterInitsSeeWriteException
  is failing only on hadoop1.
