### PR TITLE
SHDP-365 Fix AbstractDataStreamWriter for hadoop1

### DIFF
--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/AbstractDataStreamWriter.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/AbstractDataStreamWriter.java
@@ -78,7 +78,13 @@ public abstract class AbstractDataStreamWriter extends OutputStoreObjectSupport 
 	 */
 	protected StreamsHolder<OutputStream> getOutput() throws IOException {
 		StreamsHolder<OutputStream> holder = new StreamsHolder<OutputStream>();
-		FileSystem fs = FileSystem.get(getConfiguration());
+		FileSystem fs = null;
+		try {
+			fs = FileSystem.get(getConfiguration());
+		} catch (Exception e) {
+			// hadoop1 specific error so we throw it here
+			throw new StoreException("Unable to access FileSystem", e);
+		}
 
 		// Using maxOpenAttempts try to resolve path and open
 		// an output stream and automatically rolling strategies


### PR DESCRIPTION
- Previous attempt to fix failing test resulted
  exception from a different location than on hadoop2.
  Adding hadoop1 specific catch for
  FileSystem.get(Configuration) and rethrow as
  StoreException.
