### PR TITLE
SHDP-211 Fixes for hadoop24

### DIFF
--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/grid/support/TestDNSToSwitchMapping.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/grid/support/TestDNSToSwitchMapping.java
@@ -26,4 +26,9 @@ public class TestDNSToSwitchMapping implements DNSToSwitchMapping {
 	public void reloadCachedMappings() {
 	}
 
+	public void reloadCachedMappings(List<String> names) {
+		// this method added in hadoop 2.4, so keep it here
+		// and don't add override for compile not to fail with 2.2
+	}
+
 }


### PR DESCRIPTION
- Implementing new method in TestDNSToSwitchMapping
  due to changes in DNSToSwitchMapping hadoop22/hadoop24.
