### PR TITLE
SHDP-381 New argumentsList launch context option

### DIFF
--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/YarnAppmasterAutoConfiguration.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/YarnAppmasterAutoConfiguration.java
@@ -419,6 +419,8 @@ public class YarnAppmasterAutoConfiguration {
 			factory.setRunnerClass("org.springframework.boot.loader.PropertiesLauncher");
 		}
 
+		factory.setArgumentsList(syalcp.getArgumentsList());
+
 		if (syalcp.getArguments() != null) {
 			Properties arguments = new Properties();
 			arguments.putAll(syalcp.getArguments());

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/YarnClientAutoConfiguration.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/YarnClientAutoConfiguration.java
@@ -217,6 +217,8 @@ public class YarnClientAutoConfiguration {
 			factory.setRunnerClass("org.springframework.boot.loader.PropertiesLauncher");
 		}
 
+		factory.setArgumentsList(syclcp.getArgumentsList());
+
 		if (syclcp.getArguments() != null) {
 			Properties arguments = new Properties();
 			arguments.putAll(syclcp.getArguments());

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/AbstractLaunchContextProperties.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/AbstractLaunchContextProperties.java
@@ -24,6 +24,7 @@ public abstract class AbstractLaunchContextProperties {
 	private String runnerClass;
 	private List<String> options;
 	private Map<String, String> arguments;
+	private List<String> argumentsList;
 	private List<String> containerAppClasspath;
 	private String pathSeparator;
 	private boolean includeBaseDirectory = true;
@@ -65,6 +66,14 @@ public abstract class AbstractLaunchContextProperties {
 
 	public List<String> getContainerAppClasspath() {
 		return containerAppClasspath;
+	}
+
+	public List<String> getArgumentsList() {
+		return argumentsList;
+	}
+
+	public void setArgumentsList(List<String> argumentsList) {
+		this.argumentsList = argumentsList;
 	}
 
 	public void setContainerAppClasspath(List<String> containerAppClasspath) {

--- a/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringYarnAppmasterContainerClusterPropertiesTests.java
+++ b/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringYarnAppmasterContainerClusterPropertiesTests.java
@@ -17,6 +17,7 @@ package org.springframework.yarn.boot.properties;
 
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -71,6 +72,12 @@ public class SpringYarnAppmasterContainerClusterPropertiesTests {
 		assertThat(arguments.size(), is(2));
 		assertThat(arguments.get("argumentsKeyFoo1"), is("argumentsValFoo1"));
 		assertThat(arguments.get("argumentsKeyFoo2"), is("argumentsValFoo2"));
+
+		List<String> argumentsList = properties1.getArgumentsList();
+		assertThat(argumentsList, notNullValue());
+		assertThat(argumentsList.size(), is(2));
+		assertThat(argumentsList, contains("argumentsListFoo1", "argumentsListFoo2"));
+
 		List<String> classpath = properties1.getContainerAppClasspath();
 		assertThat(classpath, notNullValue());
 		assertThat(classpath.size(), is(2));

--- a/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringYarnAppmasterLaunchContextPropertiesTests.java
+++ b/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringYarnAppmasterLaunchContextPropertiesTests.java
@@ -16,6 +16,7 @@
 package org.springframework.yarn.boot.properties;
 
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -45,6 +46,11 @@ public class SpringYarnAppmasterLaunchContextPropertiesTests {
 		assertThat(arguments.size(), is(2));
 		assertThat(arguments.get("argumentsKeyFoo1"), is("argumentsValFoo1"));
 		assertThat(arguments.get("argumentsKeyFoo2"), is("argumentsValFoo2"));
+
+		List<String> argumentsList = properties.getArgumentsList();
+		assertThat(argumentsList, notNullValue());
+		assertThat(argumentsList.size(), is(2));
+		assertThat(argumentsList, contains("argumentsListFoo1", "argumentsListFoo2"));
 
 		List<String> classpath = properties.getContainerAppClasspath();
 		assertThat(classpath, notNullValue());

--- a/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringYarnClientLaunchContextPropertiesTests.java
+++ b/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringYarnClientLaunchContextPropertiesTests.java
@@ -16,6 +16,7 @@
 package org.springframework.yarn.boot.properties;
 
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -45,6 +46,11 @@ public class SpringYarnClientLaunchContextPropertiesTests {
 		assertThat(arguments.size(), is(2));
 		assertThat(arguments.get("argumentsKeyFoo1"), is("argumentsValFoo1"));
 		assertThat(arguments.get("argumentsKeyFoo2"), is("argumentsValFoo2"));
+
+		List<String> argumentsList = properties.getArgumentsList();
+		assertThat(argumentsList, notNullValue());
+		assertThat(argumentsList.size(), is(2));
+		assertThat(argumentsList, contains("argumentsListFoo1", "argumentsListFoo2"));
 
 		List<String> classpath = properties.getContainerAppClasspath();
 		assertThat(classpath, notNullValue());

--- a/spring-yarn/spring-yarn-boot/src/test/resources/SpringYarnAppmasterContainerClusterPropertiesTests1.yml
+++ b/spring-yarn/spring-yarn-boot/src/test/resources/SpringYarnAppmasterContainerClusterPropertiesTests1.yml
@@ -24,6 +24,9 @@ spring:
                         : argumentsValFoo1
                         ? argumentsKeyFoo2
                         : argumentsValFoo2
+                      argumentsList:
+                        - argumentsListFoo1
+                        - argumentsListFoo2
                       containerAppClasspath:
                         - "classpath1Foo"
                         - "classpath2Foo"

--- a/spring-yarn/spring-yarn-boot/src/test/resources/SpringYarnAppmasterLaunchContextPropertiesTests.yml
+++ b/spring-yarn/spring-yarn-boot/src/test/resources/SpringYarnAppmasterLaunchContextPropertiesTests.yml
@@ -9,6 +9,9 @@ spring:
                   : argumentsValFoo1
                   ? argumentsKeyFoo2
                   : argumentsValFoo2
+                argumentsList:
+                  - argumentsListFoo1
+                  - argumentsListFoo2
                 containerAppClasspath:
                   - "classpath1Foo"
                   - "classpath2Foo"

--- a/spring-yarn/spring-yarn-boot/src/test/resources/SpringYarnClientLaunchContextPropertiesTests.yml
+++ b/spring-yarn/spring-yarn-boot/src/test/resources/SpringYarnClientLaunchContextPropertiesTests.yml
@@ -9,6 +9,9 @@ spring:
                   : argumentsValFoo1
                   ? argumentsKeyFoo2
                   : argumentsValFoo2
+                argumentsList:
+                  - argumentsListFoo1
+                  - argumentsListFoo2
                 containerAppClasspath:
                   - "classpath1Foo"
                   - "classpath2Foo"

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/launch/LaunchCommandsFactoryBean.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/launch/LaunchCommandsFactoryBean.java
@@ -55,6 +55,9 @@ public class LaunchCommandsFactoryBean implements InitializingBean, FactoryBean<
 	/** Possible arguments */
 	private Properties arguments;
 
+	/** Possible arguments as list */
+	private List<String> argumentsList;
+
 	/** Possible jvm options */
 	private List<String> options;
 
@@ -114,6 +117,10 @@ public class LaunchCommandsFactoryBean implements InitializingBean, FactoryBean<
 			}
 		}
 
+		if (argumentsList != null) {
+			commandsList.addAll(argumentsList);
+		}
+
 		// program arguments at the end before stdout/stderr
 		commandsList.addAll(resolveProgramArguments());
 
@@ -125,8 +132,7 @@ public class LaunchCommandsFactoryBean implements InitializingBean, FactoryBean<
 	/**
 	 * Sets the main command.
 	 *
-	 * @param command
-	 *            the new command
+	 * @param command the new command
 	 */
 	public void setCommand(String command) {
 		this.command = command;
@@ -135,8 +141,7 @@ public class LaunchCommandsFactoryBean implements InitializingBean, FactoryBean<
 	/**
 	 * Sets the runner class.
 	 *
-	 * @param runner
-	 *            the new runner class
+	 * @param runner the new runner class
 	 */
 	public void setRunner(Class<?> runner) {
 		this.runner = runner;
@@ -145,8 +150,7 @@ public class LaunchCommandsFactoryBean implements InitializingBean, FactoryBean<
 	/**
 	 * Sets the runner class.
 	 *
-	 * @param runnerClass
-	 *            the new runner class
+	 * @param runnerClass the new runner class
 	 */
 	public void setRunnerClass(String runnerClass) {
 		this.runnerClass = runnerClass;
@@ -156,8 +160,7 @@ public class LaunchCommandsFactoryBean implements InitializingBean, FactoryBean<
 	 * Sets the jar file name. If this is set, the command mode is automatically
 	 * to use executable jar with 'java -jar'.
 	 *
-	 * @param jarFile
-	 *            the new jar file
+	 * @param jarFile the new jar file
 	 */
 	public void setJarFile(String jarFile) {
 		this.jarFile = jarFile;
@@ -166,8 +169,7 @@ public class LaunchCommandsFactoryBean implements InitializingBean, FactoryBean<
 	/**
 	 * Sets the context file.
 	 *
-	 * @param contextFile
-	 *            the new context file
+	 * @param contextFile the new context file
 	 */
 	public void setContextFile(String contextFile) {
 		this.contextFile = contextFile;
@@ -176,8 +178,7 @@ public class LaunchCommandsFactoryBean implements InitializingBean, FactoryBean<
 	/**
 	 * Sets the bean name.
 	 *
-	 * @param beanName
-	 *            the new bean name
+	 * @param beanName the new bean name
 	 */
 	public void setBeanName(String beanName) {
 		this.beanName = beanName;
@@ -186,18 +187,27 @@ public class LaunchCommandsFactoryBean implements InitializingBean, FactoryBean<
 	/**
 	 * Sets the arguments.
 	 *
-	 * @param arguments
-	 *            the new arguments
+	 * @param arguments the new arguments
 	 */
 	public void setArguments(Properties arguments) {
 		this.arguments = arguments;
 	}
 
 	/**
+	 * Sets the arguments as a list. Arguments set using
+	 * this method are handled before arguments set via
+	 * {@link #setArguments(Properties)}.
+	 *
+	 * @param argumentsList the new arguments
+	 */
+	public void setArgumentsList(List<String> argumentsList) {
+		this.argumentsList = argumentsList;
+	}
+
+	/**
 	 * Sets the options.
 	 *
-	 * @param options
-	 *            the new options
+	 * @param options the new options
 	 */
 	public void setOptions(List<String> options) {
 		this.options = options;
@@ -206,8 +216,7 @@ public class LaunchCommandsFactoryBean implements InitializingBean, FactoryBean<
 	/**
 	 * Sets the stdout.
 	 *
-	 * @param stdout
-	 *            the new stdout
+	 * @param stdout the new stdout
 	 */
 	public void setStdout(String stdout) {
 		this.stdout = stdout;
@@ -216,8 +225,7 @@ public class LaunchCommandsFactoryBean implements InitializingBean, FactoryBean<
 	/**
 	 * Sets the stderr.
 	 *
-	 * @param stderr
-	 *            the new stderr
+	 * @param stderr the new stderr
 	 */
 	public void setStderr(String stderr) {
 		this.stderr = stderr;


### PR DESCRIPTION
- Adding new option to be able to pass programm arguments
  as list instead of map. This allows to keep order
  and use arguments which are not key-value based delimited
  by '='.
