### PR TITLE
SHDP-385 Container exit -100 not processed

### DIFF
--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/monitor/DefaultContainerMonitor.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/monitor/DefaultContainerMonitor.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.api.records.ContainerState;
 import org.apache.hadoop.yarn.api.records.ContainerStatus;
 import org.apache.hadoop.yarn.util.ConverterUtils;
+import org.springframework.util.StringUtils;
 import org.springframework.yarn.listener.ContainerMonitorListener.ContainerMonitorState;
 
 /**
@@ -123,9 +124,9 @@ public class DefaultContainerMonitor extends AbstractMonitor implements Containe
 
 			synchronized (lock) {
 				if (state.equals(ContainerState.COMPLETE)) {
-					if (exitStatus > 0) {
+					if (exitStatus > 0 || exitStatus == -100 || exitStatus == -101 || exitStatus == -1000) {
 						failed.add(cid);
-					} else if (exitStatus != -100){
+					} else if (exitStatus != -100) {
 						// TODO: should do something centrally about exit statuses
 						//       -100 - container released by app
 						completed.add(cid);
@@ -176,10 +177,7 @@ public class DefaultContainerMonitor extends AbstractMonitor implements Containe
 	private String toDebugStringContainerSet(Set<String> set) {
 		StringBuilder buf = new StringBuilder();
 		buf.append('[');
-		for (String containerId : set) {
-			buf.append(containerId);
-			buf.append(',');
-		}
+		buf.append(StringUtils.collectionToCommaDelimitedString(set));
 		buf.append(']');
 		return buf.toString();
 	}

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/monitor/DefaultContainerMonitorTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/monitor/DefaultContainerMonitorTests.java
@@ -121,8 +121,49 @@ public class DefaultContainerMonitorTests {
 
 		// container 3
 		monitor.onContainerStatus(Arrays.asList(getMockContainerStatus(containerId3, ContainerState.COMPLETE, -100)));
-		assertMonitorState(monitor, 0, 0, 2, 0);
+		assertMonitorState(monitor, 0, 0, 2, 1);
 
+	}
+
+	@Test
+	public void testFailedWithContainerLoss() throws Exception {
+		// SHDP-385 case when nm is killed and eventually rm receives
+		// Container released on a *lost* node" exit_status: -100
+		DefaultContainerMonitor monitor = new DefaultContainerMonitor();
+		ApplicationAttemptId applicationAttemptId = getMockApplicationAttemptId(1, 1);
+		ContainerId containerId1 = getMockContainerId(applicationAttemptId, 1);
+		Container container1 = getMockContainer(containerId1, null, null, null);
+		monitor.onContainer(Arrays.asList(container1));
+		assertMonitorState(monitor, 1, 0, 0, 0);
+
+		monitor.onContainerStatus(Arrays.asList(getMockContainerStatus(containerId1, ContainerState.COMPLETE, -100)));
+		assertMonitorState(monitor, 0, 0, 0, 1);
+	}
+
+	@Test
+	public void testFailedWithContainerDiskFailed() throws Exception {
+		DefaultContainerMonitor monitor = new DefaultContainerMonitor();
+		ApplicationAttemptId applicationAttemptId = getMockApplicationAttemptId(1, 1);
+		ContainerId containerId1 = getMockContainerId(applicationAttemptId, 1);
+		Container container1 = getMockContainer(containerId1, null, null, null);
+		monitor.onContainer(Arrays.asList(container1));
+		assertMonitorState(monitor, 1, 0, 0, 0);
+
+		monitor.onContainerStatus(Arrays.asList(getMockContainerStatus(containerId1, ContainerState.COMPLETE, -101)));
+		assertMonitorState(monitor, 0, 0, 0, 1);
+	}
+
+	@Test
+	public void testFailedWithContainerInvalid() throws Exception {
+		DefaultContainerMonitor monitor = new DefaultContainerMonitor();
+		ApplicationAttemptId applicationAttemptId = getMockApplicationAttemptId(1, 1);
+		ContainerId containerId1 = getMockContainerId(applicationAttemptId, 1);
+		Container container1 = getMockContainer(containerId1, null, null, null);
+		monitor.onContainer(Arrays.asList(container1));
+		assertMonitorState(monitor, 1, 0, 0, 0);
+
+		monitor.onContainerStatus(Arrays.asList(getMockContainerStatus(containerId1, ContainerState.COMPLETE, -1000)));
+		assertMonitorState(monitor, 0, 0, 0, 1);
 	}
 
 	/**


### PR DESCRIPTION
- Previously if nodemanager died or was brought
  down together with its containers, appmaster
  didn't process exit status of -100 indicating
  that container was lost.
- Modifying appmaster and container monitoring
  components to handle other yarn specific exit
  statuses.
