### PR TITLE
SHDP-389 Append for PartitionTextFileWriter

### DIFF
--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/AbstractPartitionDataStoreWriter.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/AbstractPartitionDataStoreWriter.java
@@ -73,6 +73,9 @@ public abstract class AbstractPartitionDataStoreWriter<T, K> extends LifecycleOb
 	/** Idle timeout for writers */
 	private long idleTimeout;
 
+	/** Append flag for writers */
+	private boolean append = false;
+
 	/** Max number of free file path open/find attempts guard against infinite loop */
 	private int maxOpenAttempts = AbstractDataStreamWriter.DEFAULT_MAX_OPEN_ATTEMPTS;
 
@@ -275,8 +278,32 @@ public abstract class AbstractPartitionDataStoreWriter<T, K> extends LifecycleOb
 		log.info("Setting overwrite to " + overwrite);
 	}
 
+	/**
+	 * Checks if overwrite is enabled.
+	 *
+	 * @return true, if overwrite enabled
+	 * @see #setOverwrite(boolean)
+	 */
     public boolean isOverwrite() {
 		return overwrite;
+	}
+
+	/**
+	 * Checks if append is enabled.
+	 *
+	 * @return true, if append enabled
+	 */
+	public boolean isAppendable() {
+		return append;
+	}
+
+	/**
+	 * Set stream as append mode.
+	 *
+	 * @param append the append flag
+	 */
+	public void setAppendable(boolean append) {
+		this.append = append;
 	}
 
 	/**

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/PartitionTextFileWriter.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/PartitionTextFileWriter.java
@@ -71,6 +71,7 @@ public class PartitionTextFileWriter<K> extends AbstractPartitionDataStoreWriter
 		}
 		writer.setIdleTimeout(getIdleTimeout());
 		writer.setOverwrite(isOverwrite());
+		writer.setAppendable(isAppendable());
 		writer.setInWritingPrefix(getInWritingPrefix());
 		writer.setInWritingSuffix(getInWritingSuffix());
 		writer.setMaxOpenAttempts(getMaxOpenAttempts());

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/support/OutputStoreObjectSupport.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/support/OutputStoreObjectSupport.java
@@ -58,7 +58,7 @@ public abstract class OutputStoreObjectSupport extends StoreObjectSupport {
 	private boolean overwrite = false;
 
 	/** Flag guarding if file is appended or not */
-	private boolean append=false;
+	private boolean append = false;
 
 	/**
 	 * Instantiates a new abstract output store support.
@@ -197,6 +197,24 @@ public abstract class OutputStoreObjectSupport extends StoreObjectSupport {
 	}
 
 	/**
+	 * Checks if file is appendable
+	 *
+	 * @return true, if append enabled
+	 */
+	public boolean isAppendable() {
+		return append;
+	}
+
+	/**
+	 * Set stream as append mode.
+	 *
+	 * @param append the append flag
+	 */
+	public void setAppendable(boolean append) {
+		this.append = append;
+	}
+
+	/**
 	 * Gets the resolved path.
 	 *
 	 * @return the resolved path
@@ -283,14 +301,6 @@ public abstract class OutputStoreObjectSupport extends StoreObjectSupport {
 		} catch (IOException e) {
 		}
 		return false;
-	}
-
-	public boolean isAppendable() {
-		return append;
-	}
-
-	public void setAppendable(boolean append) {
-		this.append = append;
 	}
 
 }

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TestUtils.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TestUtils.java
@@ -55,10 +55,16 @@ public abstract class TestUtils {
 	}
 
 	public static void writeData(DataStoreWriter<String> writer, String[] data, boolean close) throws IOException {
+		writeData(writer, data, close, true);
+	}
+
+	public static void writeData(DataStoreWriter<String> writer, String[] data, boolean close, boolean flush) throws IOException {
 		for (String line : data) {
 			writer.write(line);
 		}
-		writer.flush();
+		if (flush) {
+			writer.flush();
+		}
 		if (close) {
 			writer.close();
 		}

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TextFileStoreAppendCtxTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TextFileStoreAppendCtxTests.java
@@ -15,12 +15,8 @@
  */
 package org.springframework.data.hadoop.store;
 
-import static org.junit.Assert.assertNotNull;
-
 import java.io.IOException;
-import java.util.List;
 
-import org.apache.commons.lang.ArrayUtils;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
@@ -33,6 +29,7 @@ import org.springframework.test.context.ContextConfiguration;
 /**
  * Tests for reading and writing text using context configuration.
  *
+ * @author Janne Valkealahti
  * @author liu jiong
  *
  */
@@ -46,29 +43,14 @@ public class TextFileStoreAppendCtxTests extends AbstractStoreTests {
 	@Test
 	public void testWriteReadManyLines() throws IOException, InterruptedException {
 		TextFileWriter writer = context.getBean("writer", TextFileWriter.class);
-		assertNotNull(writer);
-		writer.setAppendable(true);
 
-		String[] dataArray = new String[] { DATA10, DATA11 };
+		TestUtils.writeData(writer, DATA09ARRAY, false, false);
+		writer.flush();
 
 		TextFileReader reader = new TextFileReader(getConfiguration(), writer.getPath(), null);
-
-		String[] strings = null;
-		if (writer.getPath().getFileSystem(writer.getConfiguration()).exists(writer.getPath())) {
-			List<String> tmpList = TestUtils.readData(reader);
-			strings = new String[tmpList.size()];
-			tmpList.toArray(strings);
-		}
-		for (String data : dataArray) {
-			writer.write(data);
-		}
-
-		// we're on append mode so file is still open and hflush
-		// should have made the data available.
-		writer.resetIdleTimeout();
-		Thread.sleep(5000);
-		reader = new TextFileReader(getConfiguration(), writer.getPath(), null);
-		TestUtils.readDataAndAssert(reader, (String[]) ArrayUtils.addAll(strings, dataArray));
+		TestUtils.readDataAndAssert(reader, DATA09ARRAY);
+		writer.close();
+		reader.close();
 	}
 
 }

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TextFileStoreAppendTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TextFileStoreAppendTests.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.hadoop.store;
+
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.hadoop.fs.Path;
+import org.junit.Test;
+import org.springframework.data.hadoop.store.input.TextFileReader;
+import org.springframework.data.hadoop.store.output.PartitionTextFileWriter;
+import org.springframework.data.hadoop.store.output.TextFileWriter;
+import org.springframework.data.hadoop.store.partition.DefaultPartitionStrategy;
+import org.springframework.data.hadoop.store.strategy.naming.StaticFileNamingStrategy;
+import org.springframework.data.hadoop.test.context.HadoopDelegatingSmartContextLoader;
+import org.springframework.data.hadoop.test.context.MiniHadoopCluster;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.util.StringUtils;
+
+@ContextConfiguration(loader=HadoopDelegatingSmartContextLoader.class)
+@MiniHadoopCluster
+public class TextFileStoreAppendTests extends AbstractStoreTests {
+
+	@org.springframework.context.annotation.Configuration
+	static class Config {
+		// just empty to survive without xml configs
+	}
+
+	@Test
+	public void testWriteAppendReadTextManyLines() throws IOException {
+		TextFileWriter writer = new TextFileWriter(getConfiguration(), testDefaultPath, null);
+		writer.setAppendable(true);
+		TestUtils.writeData(writer, DATA09ARRAY, false);
+
+		TextFileReader reader = new TextFileReader(getConfiguration(), testDefaultPath, null);
+		TestUtils.readDataAndAssert(reader, DATA09ARRAY);
+		writer.close();
+	}
+
+	@Test
+	public void testWriteAppendReopen() throws IOException {
+		TextFileWriter writer = new TextFileWriter(getConfiguration(), testDefaultPath, null);
+		writer.setAppendable(true);
+		TestUtils.writeData(writer, DATA09ARRAY, false);
+		TextFileReader reader = new TextFileReader(getConfiguration(), testDefaultPath, null);
+		TestUtils.readDataAndAssert(reader, DATA09ARRAY);
+		writer.close();
+		reader.close();
+
+		writer = new TextFileWriter(getConfiguration(), testDefaultPath, null);
+		writer.setAppendable(true);
+		TestUtils.writeData(writer, DATA09ARRAY, false);
+		reader = new TextFileReader(getConfiguration(), testDefaultPath, null);
+		TestUtils.readDataAndAssert(reader, StringUtils.concatenateStringArrays(DATA09ARRAY, DATA09ARRAY));
+		writer.close();
+		reader.close();
+	}
+
+	@Test
+	public void testMapWriteAppendReadTextOneLine() throws IOException {
+		String expression = "path(region,dateFormat('yyyy/MM',timestamp),hash(region,1),list(region,{{'jee','foo'}}),range(range,{10}))";
+		String[] dataArray = new String[] { DATA10 };
+		DefaultPartitionStrategy<String> strategy = new DefaultPartitionStrategy<String>(expression);
+
+		Map<String, Object> headers = new HashMap<String, Object>();
+		headers.put("region", "foo");
+		headers.put("range", 10);
+		headers.put("timestamp", System.currentTimeMillis());
+		String nowYYYYMM = new SimpleDateFormat("yyyy/MM").format(new Date());
+
+		PartitionTextFileWriter<Map<String, Object>> writer =
+				new PartitionTextFileWriter<Map<String, Object>>(getConfiguration(), testDefaultPath, null, strategy);
+		writer.setFileNamingStrategyFactory(new StaticFileNamingStrategy("bar"));
+		writer.setAppendable(true);
+
+		writer.write(dataArray[0], headers);
+		writer.flush();
+
+		TextFileReader reader = new TextFileReader(getConfiguration(), new Path(testDefaultPath, "foo/" + nowYYYYMM + "/0_hash/jee_list/10_range/bar"), null);
+		TestUtils.readDataAndAssert(reader, dataArray);
+		writer.close();
+		reader.close();
+	}
+
+}

--- a/spring-hadoop-store/src/test/resources/org/springframework/data/hadoop/store/TextFileStoreAppendCtxTests-context.xml
+++ b/spring-hadoop-store/src/test/resources/org/springframework/data/hadoop/store/TextFileStoreAppendCtxTests-context.xml
@@ -31,7 +31,8 @@
 		<constructor-arg ref="hadoopConfiguration"/>
 		<constructor-arg ref="testBasePath"/>
 		<constructor-arg><null/></constructor-arg>
-		<property name="idleTimeout" value="1"/>
+		<property name="idleTimeout" value="0"/>
+		<property name="appendable" value="true"/>
 
 	</bean>
 


### PR DESCRIPTION
- Added append flag in PartitionTextFileWriter
- Tidy up whole append code
- Removed hflush() method and combined it with flush()
- Made better tests
