### PR TITLE
SHDP-391 Remove unneeded YarnContainerClusterMvcEndpoint response entiti...

### DIFF
--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/actuate/endpoint/mvc/YarnContainerClusterMvcEndpoint.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/actuate/endpoint/mvc/YarnContainerClusterMvcEndpoint.java
@@ -142,21 +142,19 @@ public class YarnContainerClusterMvcEndpoint extends EndpointMvcAdapter {
 	 * @return the container cluster status response
 	 */
 	@RequestMapping(value = "/{clusterId}", method = RequestMethod.PUT)
-	public HttpEntity<ContainerClusterResource> modifyCluster(@PathVariable("clusterId") String clusterId,
+	public HttpEntity<Void> modifyCluster(@PathVariable("clusterId") String clusterId,
 			@RequestBody ContainerClusterModifyRequest request) {
 		ModifyAction action = ContainerClusterModifyRequest.getModifyAction(request.getAction());
 		if (action == null) {
 			throw new NoSuchActionException("Action " + request.getAction() + " not supported");
 		}
-		ContainerCluster cluster = getClusterMayThrow(clusterId);
+		getClusterMayThrow(clusterId);
 		if (ModifyAction.START.equals(action)) {
 			delegate.startCluster(clusterId);
 		} else if (ModifyAction.STOP.equals(action)) {
 			delegate.stopCluster(clusterId);
 		}
-		ContainerClusterResource response = new ContainerClusterResource(cluster);
-		return new ResponseEntity<ContainerClusterResource>(response,
-				HttpStatus.OK);
+		return new ResponseEntity<Void>(HttpStatus.OK);
 	}
 
 	@RequestMapping(value = "/{clusterId}", method = RequestMethod.DELETE)
@@ -173,7 +171,7 @@ public class YarnContainerClusterMvcEndpoint extends EndpointMvcAdapter {
 	 * @return the container cluster modify response
 	 */
 	@RequestMapping(value = "/{clusterId}", method = RequestMethod.PATCH)
-	public HttpEntity<ContainerClusterResource> updateCluster(@PathVariable("clusterId") String clusterId, @RequestBody ContainerClusterCreateRequest request) {
+	public HttpEntity<Void> updateCluster(@PathVariable("clusterId") String clusterId, @RequestBody ContainerClusterCreateRequest request) {
 		ContainerCluster cluster = delegate.getClusters().get(clusterId);
 		if (cluster == null) {
 			throw new NoSuchClusterException("No such cluster: " + clusterId);
@@ -190,9 +188,7 @@ public class YarnContainerClusterMvcEndpoint extends EndpointMvcAdapter {
 		}
 		delegate.modifyCluster(clusterId, data);
 
-		ContainerClusterResource response = new ContainerClusterResource(delegate.getClusters().get(clusterId));
-		return new ResponseEntity<ContainerClusterResource>(response,
-				HttpStatus.OK);
+		return new ResponseEntity<Void>(HttpStatus.OK);
 	}
 
 	/**

--- a/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/actuate/endpoint/mvc/YarnContainerClusterMvcEndpointTests.java
+++ b/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/actuate/endpoint/mvc/YarnContainerClusterMvcEndpointTests.java
@@ -230,7 +230,7 @@ public class YarnContainerClusterMvcEndpointTests {
 		mvc.
 			perform(put(BASE + "/foo").content(content).contentType(MediaType.APPLICATION_JSON)).
 			andExpect(status().isOk()).
-			andExpect(content().string(not(isEmptyString())));
+			andExpect(content().string(isEmptyString()));
 
 		Map<String, ContainerCluster> clusters = TestUtils.readField("clusters", appmaster);
 		assertThat(clusters.size(), is(1));
@@ -254,7 +254,7 @@ public class YarnContainerClusterMvcEndpointTests {
 		mvc.
 		perform(put(BASE + "/foo").content(content).contentType(MediaType.APPLICATION_JSON)).
 		andExpect(status().isOk()).
-		andExpect(content().string(not(isEmptyString())));
+		andExpect(content().string(isEmptyString()));
 		Map<String, ContainerCluster> clusters = TestUtils.readField("clusters", appmaster);
 		assertThat(clusters.size(), is(1));
 		assertThat(clusters.containsKey("foo"), is(true));


### PR DESCRIPTION
...es
- Remove and void response entities for PUT and
  PATCH requests for clusters. This aligns API
  as it's documented and as generally how REST
  should work.
