### PR TITLE
SHDP-396 Reorganize build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -869,6 +869,8 @@ project('spring-data-hadoop-spark') {
             exclude group: "org.eclipse.jetty", module: "jetty-server"
             exclude group: "org.eclipse.jetty", module: "jetty-plus"
             exclude group: "org.eclipse.jetty", module: "jetty-security"
+            // jline would mess up yarn boot cli because boot uses newer version
+            exclude group: "jline", module: "jline"
         }
 		compile "org.apache.hadoop:hadoop-client:$hadoopVersion"
 	}


### PR DESCRIPTION
- Adding exclude for jline for spark because
  it would bring older version which would not
  work with cli classes copied into yarn boot
  cli which is based on boot cli classes.
