### PR TITLE
SHDP-409 Fixes for stream create handling

### DIFF
--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/output/FileWriteOpenTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/output/FileWriteOpenTests.java
@@ -23,7 +23,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.data.hadoop.store.AbstractStoreTests;
 import org.springframework.data.hadoop.store.StoreException;
@@ -36,7 +35,6 @@ import org.springframework.test.context.ContextConfiguration;
 
 @ContextConfiguration(loader=HadoopDelegatingSmartContextLoader.class)
 @MiniHadoopCluster
-@Ignore
 public class FileWriteOpenTests extends AbstractStoreTests {
 
 	private static final Log log = LogFactory.getLog(FileWriteOpenTests.class);
@@ -46,6 +44,7 @@ public class FileWriteOpenTests extends AbstractStoreTests {
 		// just empty to survive without xml configs
 	}
 
+	@Test
 	public void testDoubleOpenWriteFailure() throws Exception {
 		log.info("testDoubleOpenWriteFailure1");
 		// what we do here is to make sure that if we're


### PR DESCRIPTION
- AbstractDataStreamWriter has been enhanced for
  guarding against same leaseholder to try recreating
  same path.
- re-enable tests in FileWriteOpenTests
