### PR TITLE
SHDP-423 Partition writer doesn't clean resources

### DIFF
--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/AbstractPartitionDataStoreWriter.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/AbstractPartitionDataStoreWriter.java
@@ -370,4 +370,22 @@ public abstract class AbstractPartitionDataStoreWriter<T, K> extends LifecycleOb
 	 */
 	protected abstract DataStoreWriter<T> createWriter(Configuration configuration, Path basePath, CodecInfo codec);
 
+	/**
+	 * Destroys a writer with a given {@link Path} if exist.
+	 *
+	 * @param path the path
+	 */
+	protected void destroyWriter(Path path) {
+		if (path == null) {
+			return;
+		}
+		DataStoreWriter<T> writer = writers.remove(path);
+		if (writer != null) {
+			try {
+				writer.close();
+			} catch (IOException e) {
+			}
+		}
+	}
+
 }


### PR DESCRIPTION
- Add AbstractPartitionDataStoreWriter.destroyWriter(Path)
  so that subclass can destroy writers by path.
- Override TextFileWriter.close() in PartitionTextFileWriter
  to catch close and notify parent.
