### PR TITLE
SHDP-423 Fix rollover and concurrency issues

### DIFF
--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/PartitionTextFileWriter.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/PartitionTextFileWriter.java
@@ -53,9 +53,11 @@ public class PartitionTextFileWriter<K> extends AbstractPartitionDataStoreWriter
 		TextFileWriter writer = new TextFileWriter(getConfiguration(), path != null ? new Path(getBasePath(), path) : getBasePath(), codec) {
 			@Override
 			public synchronized void close() throws IOException {
-				super.close();
 				// catch close() and destroy from parent
+				// this needs to happen before we pass
+				// close() to writer
 				destroyWriter(path);
+				super.close();
 			}
 		};
 		if (getBeanFactory() != null) {

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/TextFileWriter.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/TextFileWriter.java
@@ -87,7 +87,7 @@ public class TextFileWriter extends AbstractDataStreamWriter implements DataStor
 	}
 
 	@Override
-	public synchronized  void flush() throws IOException {
+	public synchronized void flush() throws IOException {
 		if (streamsHolder != null) {
 			OutputStream stream = streamsHolder.getStream();
 			stream.flush();
@@ -135,6 +135,7 @@ public class TextFileWriter extends AbstractDataStreamWriter implements DataStor
 	protected void handleIdleTimeout() {
 		try {
 			log.info("Idle timeout detected for this writer, closing stream");
+			flush();
 			close();
 		} catch (IOException e) {
 			log.error("error closing", e);

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/output/PartitionTextFileWriterSmokeTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/output/PartitionTextFileWriterSmokeTests.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.hadoop.store.output;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.data.hadoop.fs.FsShell;
+import org.springframework.data.hadoop.store.AbstractStoreTests;
+import org.springframework.data.hadoop.store.DataStoreWriter;
+import org.springframework.data.hadoop.store.TestUtils;
+import org.springframework.data.hadoop.store.event.DefaultStoreEventPublisher;
+import org.springframework.data.hadoop.store.event.LoggingListener;
+import org.springframework.data.hadoop.store.event.StoreEventPublisher;
+import org.springframework.data.hadoop.store.partition.PartitionKeyResolver;
+import org.springframework.data.hadoop.store.partition.PartitionResolver;
+import org.springframework.data.hadoop.store.partition.PartitionStrategy;
+import org.springframework.data.hadoop.store.strategy.naming.RollingFileNamingStrategy;
+import org.springframework.data.hadoop.test.context.HadoopDelegatingSmartContextLoader;
+import org.springframework.data.hadoop.test.context.MiniHadoopCluster;
+import org.springframework.data.hadoop.test.tests.Assume;
+import org.springframework.data.hadoop.test.tests.TestGroup;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.ContextConfiguration;
+
+@ContextConfiguration(loader=HadoopDelegatingSmartContextLoader.class)
+@MiniHadoopCluster
+@DirtiesContext(classMode=ClassMode.AFTER_EACH_TEST_METHOD)
+public class PartitionTextFileWriterSmokeTests extends AbstractStoreTests {
+
+	@Autowired
+	private ApplicationContext context;
+
+	@Autowired
+	private org.apache.hadoop.conf.Configuration hadoopConfiguration;
+
+	private final static String PATH = "/tmp/PartitionTextFileWriterSmokeTests/default";
+
+	@Test
+	public void testWritePartitions() throws Exception {
+		Assume.group(TestGroup.PERFORMANCE);
+		int threads = 30;
+		int count = 20000;
+		int iterations = 10;
+
+		@SuppressWarnings("unchecked")
+		PartitionTextFileWriter<String> writer = context.getBean("writer1", PartitionTextFileWriter.class);
+		assertNotNull(writer);
+
+		for (int i = 0; i < iterations; i++) {
+			doConcurrentWrites(writer, threads, count);
+			// do sleeps to kick of idle timeout and
+			// enough time to rename the file from used postfix
+			Thread.sleep(2000);
+		}
+		Thread.sleep(3000);
+
+		Map<Path, DataStoreWriter<String>> writers = TestUtils.readField("writers", writer);
+		assertThat(writers.size(), is(0));
+
+		writer.flush();
+		writer.close();
+
+		// assuming items in DATA09ARRAY have same length
+		assertThat(getTotalWritten(), is((long) count * (DATA10.length() + 1) * threads * iterations));
+
+	}
+
+	private long getTotalWritten() {
+		@SuppressWarnings("resource")
+		FsShell shell = new FsShell(hadoopConfiguration);
+		long total = 0;
+		for (FileStatus s : shell.ls(true, PATH)) {
+			System.out.println(s);
+			if (s.isFile()) {
+				total += s.getLen();
+			}
+		}
+		return total;
+	}
+
+	private void doConcurrentWrites(final PartitionTextFileWriter<String> writer, int threadCount, final int writeCount) {
+		final CountDownLatch latch = new CountDownLatch(1);
+		final ArrayList<Thread> joins = new ArrayList<Thread>();
+		for (int i = 0; i < threadCount; ++i) {
+			Runnable runner = new Runnable() {
+				public void run() {
+					try {
+						latch.await();
+						for (int j = 0; j < writeCount; j++) {
+							writer.write(DATA09ARRAY[j%DATA09ARRAY.length]);
+						}
+					} catch (Exception ie) {
+					}
+				}
+			};
+			Thread t = new Thread(runner, "SmokeThread" + i);
+			joins.add(t);
+			t.start();
+		}
+		latch.countDown();
+		for (Thread t : joins) {
+			try {
+				t.join();
+			} catch (InterruptedException e) {
+			}
+		}
+	}
+
+	private static class TestPartitionStrategy implements PartitionStrategy<String, String> {
+
+		TestPartitionResolver partitionResolver = new TestPartitionResolver();
+		TestPartitionKeyResolver keyResolver = new TestPartitionKeyResolver();
+
+		@Override
+		public PartitionResolver<String> getPartitionResolver() {
+			return partitionResolver;
+		}
+
+		@Override
+		public PartitionKeyResolver<String, String> getPartitionKeyResolver() {
+			return keyResolver;
+		}
+	}
+
+	private static class TestPartitionResolver implements PartitionResolver<String> {
+
+		@Override
+		public Path resolvePath(String partitionKey) {
+			return new Path(partitionKey);
+		}
+	}
+
+	private static class TestPartitionKeyResolver implements PartitionKeyResolver<String, String> {
+
+		@Override
+		public String resolvePartitionKey(String entity) {
+			return entity.substring(0, 2);
+		}
+	}
+
+	@Configuration
+	public static class Config {
+
+		@Autowired
+		private org.apache.hadoop.conf.Configuration hadoopConfiguration;
+
+		@Bean
+		public TaskExecutor taskExecutor() {
+			return new ThreadPoolTaskExecutor();
+		}
+
+		@Bean
+		public TaskScheduler taskScheduler() {
+			return new ThreadPoolTaskScheduler();
+		}
+
+		@Bean
+		public StoreEventPublisher storeEventPublisher() {
+			return new DefaultStoreEventPublisher();
+		}
+
+		@Bean
+		public LoggingListener loggingListener() {
+			return new LoggingListener("INFO");
+		}
+
+		@Bean
+		public RollingFileNamingStrategy fileNamingStrategy() {
+			return new RollingFileNamingStrategy();
+		}
+
+		@Bean
+		public Path testBasePath() {
+			return new Path(PATH);
+		}
+
+		@Bean
+		public PartitionStrategy<String, String> partitionStrategy() {
+			return new TestPartitionStrategy();
+		}
+
+		@Bean
+		public PartitionTextFileWriter<String> writer1() {
+			PartitionTextFileWriter<String> writer = new PartitionTextFileWriter<String>(hadoopConfiguration,
+					testBasePath(), null, partitionStrategy());
+			writer.setIdleTimeout(1000);
+			writer.setFileNamingStrategyFactory(fileNamingStrategy());
+			writer.setInWritingSuffix(".tmp");
+			return writer;
+		}
+
+	}
+
+}

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/output/TextFileWriterSmokeTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/output/TextFileWriterSmokeTests.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.hadoop.store.output;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.ArrayList;
+import java.util.concurrent.CountDownLatch;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.data.hadoop.fs.FsShell;
+import org.springframework.data.hadoop.store.AbstractStoreTests;
+import org.springframework.data.hadoop.store.TestUtils;
+import org.springframework.data.hadoop.store.event.DefaultStoreEventPublisher;
+import org.springframework.data.hadoop.store.event.LoggingListener;
+import org.springframework.data.hadoop.store.event.StoreEventPublisher;
+import org.springframework.data.hadoop.store.strategy.naming.RollingFileNamingStrategy;
+import org.springframework.data.hadoop.store.strategy.rollover.SizeRolloverStrategy;
+import org.springframework.data.hadoop.test.context.HadoopDelegatingSmartContextLoader;
+import org.springframework.data.hadoop.test.context.MiniHadoopCluster;
+import org.springframework.data.hadoop.test.tests.Assume;
+import org.springframework.data.hadoop.test.tests.TestGroup;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.ContextConfiguration;
+
+@ContextConfiguration(loader=HadoopDelegatingSmartContextLoader.class)
+@MiniHadoopCluster
+@DirtiesContext(classMode=ClassMode.AFTER_EACH_TEST_METHOD)
+public class TextFileWriterSmokeTests extends AbstractStoreTests {
+
+	@Autowired
+	private ApplicationContext context;
+
+	@Autowired
+	private org.apache.hadoop.conf.Configuration hadoopConfiguration;
+
+	private final static String PATH = "/tmp/TextFileWriterSmokeTests/default";
+
+	@Test
+	public void testWriteToSingleFile() throws Exception {
+		Assume.group(TestGroup.PERFORMANCE);
+		int threads = 20;
+		int count = 1000;
+
+		TextFileWriter writer = context.getBean("writer1", TextFileWriter.class);
+		assertNotNull(writer);
+
+		doConcurrentWrites(writer, threads, count);
+		writer.close();
+
+		assertThat(getTotalWritten(), is((long) count * (DATA10.length() + 1) * threads));
+	}
+
+	@Test
+	public void testWritesWithRollover() throws Exception {
+		Assume.group(TestGroup.PERFORMANCE);
+
+		TextFileWriter writer = context.getBean("writer2", TextFileWriter.class);
+		assertNotNull(writer);
+
+		int threads = 5;
+		int count = 1000;
+		doConcurrentWrites(writer, threads, count);
+		writer.close();
+
+		assertThat(getTotalWritten(), is((long) count * (DATA10.length() + 1) * threads));
+	}
+
+	private long getTotalWritten() {
+		@SuppressWarnings("resource")
+		FsShell shell = new FsShell(hadoopConfiguration);
+		long total = 0;
+		for (FileStatus s : shell.ls(true, PATH)) {
+			System.out.println(s);
+			if (s.isFile()) {
+				total += s.getLen();
+			}
+		}
+		return total;
+	}
+
+	private void doConcurrentWrites(final TextFileWriter writer, int threadCount, final int writeCount) {
+		final CountDownLatch latch = new CountDownLatch(1);
+		final ArrayList<Thread> joins = new ArrayList<Thread>();
+		for (int i = 0; i < threadCount; ++i) {
+			Runnable runner = new Runnable() {
+				public void run() {
+					try {
+						latch.await();
+						for (int j = 0; j < writeCount; j++) {
+							TestUtils.writeData(writer, new String[] { DATA10 }, false);
+						}
+					} catch (Exception ie) {
+					}
+				}
+			};
+			Thread t = new Thread(runner, "SmokeThread" + i);
+			joins.add(t);
+			t.start();
+		}
+		latch.countDown();
+		for (Thread t : joins) {
+			try {
+				t.join();
+			} catch (InterruptedException e) {
+			}
+		}
+	}
+
+	@Configuration
+	public static class Config {
+
+		@Autowired
+		private org.apache.hadoop.conf.Configuration hadoopConfiguration;
+
+		@Bean
+		public TaskExecutor taskExecutor() {
+			return new ThreadPoolTaskExecutor();
+		}
+
+		@Bean
+		public TaskScheduler taskScheduler() {
+			return new ThreadPoolTaskScheduler();
+		}
+
+		@Bean
+		public StoreEventPublisher storeEventPublisher() {
+			return new DefaultStoreEventPublisher();
+		}
+
+		@Bean
+		public LoggingListener loggingListener() {
+			return new LoggingListener("INFO");
+		}
+
+		@Bean
+		public RollingFileNamingStrategy fileNamingStrategy() {
+			return new RollingFileNamingStrategy();
+		}
+
+		@Bean
+		public Path testBasePath() {
+			return new Path(PATH);
+		}
+
+		@Bean
+		public TextFileWriter writer1() {
+			TextFileWriter writer = new TextFileWriter(hadoopConfiguration, testBasePath(), null);
+			writer.setIdleTimeout(1000);
+			writer.setFileNamingStrategy(fileNamingStrategy());
+			writer.setInWritingSuffix(".tmp");
+			return writer;
+		}
+
+		@Bean
+		public TextFileWriter writer2() {
+			TextFileWriter writer = new TextFileWriter(hadoopConfiguration, testBasePath(), null);
+			writer.setIdleTimeout(1000);
+			writer.setFileNamingStrategy(fileNamingStrategy());
+			writer.setRolloverStrategy(new SizeRolloverStrategy(1000));
+			writer.setInWritingSuffix(".tmp");
+			return writer;
+		}
+
+	}
+
+}


### PR DESCRIPTION
- Previous tweak didn't work very well with writer
  using a rollover. Additionally there was concurrency
  issues with threading.
- Adding more fixes and syncs.
- Adding threading smoke tests which for now are
  disabled from a normal build cycle but can be
  run manually.
