### PR TITLE
Change tests to work with jdk6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1076,9 +1076,7 @@ project('spring-yarn:spring-yarn-boot') {
 		compile "org.springframework.boot:spring-boot-actuator:$springBootVersion"
 		compile "org.apache.httpcomponents:httpclient:$httpclientVersion"
 		runtime "org.yaml:snakeyaml:$snakeYamlVersion"
-		testRuntime("org.springframework.boot:spring-boot-starter-web:$springBootVersion") {
-			exclude group:'ch.qos.logback'
-		}
+		testRuntime "org.apache.tomcat.embed:tomcat-embed-jasper:$tomcatEmbedVersion"
 		testCompile("org.mockito:mockito-core:$mockitoVersion") { dep ->
 			exclude group: "org.hamcrest"
 		}

--- a/gradle.properties
+++ b/gradle.properties
@@ -64,6 +64,7 @@ snakeYamlVersion = 1.13
 kiteVersion = 0.17.0
 httpclientVersion = 4.3.3
 jsonpathVersion = 0.8.1
+tomcatEmbedVersion = 7.0.56
 
 ## Common testing libraries
 junitVersion = 4.11


### PR DESCRIPTION
- Boot 1.2.0.RC1 changed deps for tomcat8
  which we used in tests for servlet mocking.
  This dep had hard 1.7 level and thus failed
  with jdk6 tests.
- Instead of using boot starter-web, just pull
  in embedded tomcat.
