### PR TITLE
SHDP-426 Change container cluster create/modify options

### DIFF
--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/CliSystemConstants.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/CliSystemConstants.java
@@ -47,6 +47,8 @@ public abstract class CliSystemConstants {
 
 	public final static List<String> OPTIONS_PROJECTION_RACKS  = asList("projection-racks", "r");
 
+	public final static List<String> OPTIONS_PROJECTION_DATA  = asList("projection-data", "y");
+
 	public final static String DESC_APPLICATION_ID = "Specify YARN application id";
 
 	public final static String DESC_CLUSTER_ID = "Specify cluster id";
@@ -66,5 +68,7 @@ public abstract class CliSystemConstants {
 	public final static String DESC_PROJECTION_HOSTS = "Projection hosts counts";
 
 	public final static String DESC_PROJECTION_RACKS = "Projection racks counts";
+
+	public final static String DESC_PROJECTION_DATA = "Raw projection data";
 
 }

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnClusterModifyCommand.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnClusterModifyCommand.java
@@ -15,15 +15,15 @@
  */
 package org.springframework.yarn.boot.cli;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 
 import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
 
+import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 import org.springframework.yarn.boot.app.YarnContainerClusterApplication;
@@ -71,6 +71,8 @@ public class YarnClusterModifyCommand extends AbstractApplicationCommand {
 
 	public static class ClusterModifyOptionHandler extends ApplicationOptionHandler {
 
+		private static final String PREFIX = "spring.yarn.internal.ContainerClusterApplication";
+
 		private OptionSpec<String> applicationIdOption;
 
 		private OptionSpec<String> clusterIdOption;
@@ -81,6 +83,8 @@ public class YarnClusterModifyCommand extends AbstractApplicationCommand {
 
 		private OptionSpec<String> projectionDataRacksOption;
 
+		private OptionSpec<String> projectionDataRawOption;
+
 		@Override
 		protected final void options() {
 			this.applicationIdOption = option(CliSystemConstants.OPTIONS_APPLICATION_ID,
@@ -90,9 +94,11 @@ public class YarnClusterModifyCommand extends AbstractApplicationCommand {
 			this.projectionDataAnyOption = option(CliSystemConstants.OPTIONS_PROJECTION_ANY,
 					CliSystemConstants.DESC_PROJECTION_ANY).withRequiredArg();
 			this.projectionDataHostsOption = option(CliSystemConstants.OPTIONS_PROJECTION_HOSTS,
-					CliSystemConstants.DESC_PROJECTION_HOSTS).withOptionalArg().withValuesSeparatedBy(",");
+					CliSystemConstants.DESC_PROJECTION_HOSTS).withOptionalArg();
 			this.projectionDataRacksOption = option(CliSystemConstants.OPTIONS_PROJECTION_RACKS,
-					CliSystemConstants.DESC_PROJECTION_RACKS).withOptionalArg().withValuesSeparatedBy(",");
+					CliSystemConstants.DESC_PROJECTION_RACKS).withOptionalArg();
+			this.projectionDataRawOption = option(CliSystemConstants.OPTIONS_PROJECTION_DATA,
+					CliSystemConstants.DESC_PROJECTION_DATA).withOptionalArg();
 		}
 
 		@Override
@@ -107,8 +113,10 @@ public class YarnClusterModifyCommand extends AbstractApplicationCommand {
 			String appId = options.valueOf(applicationIdOption);
 			String clusterId = options.valueOf(clusterIdOption);
 			String projectionAny = options.valueOf(projectionDataAnyOption);
-			List<String> projectionHosts = options.valuesOf(projectionDataHostsOption);
-			List<String> projectionRacks = options.valuesOf(projectionDataRacksOption);
+			String projectionHosts = options.valueOf(projectionDataHostsOption);
+			String projectionRacks = options.valueOf(projectionDataRacksOption);
+			String projectionRaw = options.valueOf(projectionDataRawOption);
+
 			YarnContainerClusterApplication app = new YarnContainerClusterApplication();
 			Properties appProperties = new Properties();
 			appProperties.setProperty("spring.yarn.internal.ContainerClusterApplication.operation", "CLUSTERMODIFY");
@@ -118,18 +126,25 @@ public class YarnClusterModifyCommand extends AbstractApplicationCommand {
 					clusterId);
 
 			if (StringUtils.hasText(projectionAny)) {
-				appProperties
-						.setProperty("spring.yarn.internal.ContainerClusterApplication.projectionDataAny", projectionAny);
+				appProperties.setProperty(PREFIX + ".projectionData.any", projectionAny);
 			}
 
-			for (Entry<String, Integer> entry : getMapFromString(projectionHosts).entrySet()) {
-				appProperties.setProperty("spring.yarn.internal.ContainerClusterApplication.projectionDataHosts."
-						+ entry.getKey(), entry.getValue().toString());
+			if (StringUtils.hasText(projectionHosts)) {
+				for (Entry<Object, Object> entry : getPropertiesFromRawYaml(projectionHosts).entrySet()) {
+					appProperties.setProperty(PREFIX + ".projectionData.hosts." + entry.getKey(), entry.getValue().toString());
+				}
 			}
 
-			for (Entry<String, Integer> entry : getMapFromString(projectionRacks).entrySet()) {
-				appProperties.setProperty("spring.yarn.internal.ContainerClusterApplication.projectionDataRacks."
-						+ entry.getKey(), entry.getValue().toString());
+			if (StringUtils.hasText(projectionRacks)) {
+				for (Entry<Object, Object> entry : getPropertiesFromRawYaml(projectionRacks).entrySet()) {
+					appProperties.setProperty(PREFIX + ".projectionData.racks." + entry.getKey(), entry.getValue().toString());
+				}
+			}
+
+			if (StringUtils.hasText(projectionRaw)) {
+				for (Entry<Object, Object> entry : getPropertiesFromRawYaml(projectionRaw).entrySet()) {
+					appProperties.setProperty(PREFIX + ".projectionData." + entry.getKey(), entry.getValue().toString());
+				}
 			}
 
 			app.appProperties(appProperties);
@@ -157,32 +172,15 @@ public class YarnClusterModifyCommand extends AbstractApplicationCommand {
 			return projectionDataRacksOption;
 		}
 
-		private static Map<String, Integer> getMapFromString(List<String> sources) {
-			HashMap<String, Integer> map = new HashMap<String, Integer>();
-			if (sources != null) {
-				String currentHost = null;
-				for (String source : sources) {
-					if (isNumber(source)) {
-						map.put(currentHost, Integer.parseInt(source));
-					} else {
-						currentHost = source;
-					}
-					if (!map.containsKey(currentHost)) {
-						map.put(currentHost, 1);
-					} else {
-					}
-				}
+		private static Properties getPropertiesFromRawYaml(String raw) {
+			if (StringUtils.isEmpty(raw)) {
+				return new Properties();
 			}
-			return map;
-		}
-
-		private static boolean isNumber(String source) {
-			try {
-				Integer.parseInt(source);
-				return true;
-			} catch (NumberFormatException e) {
-			}
-			return false;
+			Resource resource = new ByteArrayResource(raw.getBytes());
+			YamlPropertiesFactoryBean ypfb = new YamlPropertiesFactoryBean();
+			ypfb.setResources(resource);
+			ypfb.afterPropertiesSet();
+			return ypfb.getObject();
 		}
 
 	}

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/actuate/endpoint/mvc/AbstractContainerClusterRequest.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/actuate/endpoint/mvc/AbstractContainerClusterRequest.java
@@ -39,6 +39,7 @@ public abstract class AbstractContainerClusterRequest {
 		Integer any;
 		Map<String, Integer> hosts;
 		Map<String, Integer> racks;
+		Map<String, Object> properties;
 		public Integer getAny() {
 			return any;
 		}
@@ -56,6 +57,12 @@ public abstract class AbstractContainerClusterRequest {
 		}
 		public void setRacks(Map<String, Integer> racks) {
 			this.racks = racks;
+		}
+		public Map<String, Object> getProperties() {
+			return properties;
+		}
+		public void setProperties(Map<String, Object> properties) {
+			this.properties = properties;
 		}
 	}
 

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/actuate/endpoint/mvc/YarnContainerClusterMvcEndpoint.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/actuate/endpoint/mvc/YarnContainerClusterMvcEndpoint.java
@@ -99,6 +99,9 @@ public class YarnContainerClusterMvcEndpoint extends EndpointMvcAdapter {
 		if (request.getProjectionData().getRacks() != null) {
 			projectionData.setRacks(request.getProjectionData().getRacks());
 		}
+		if (request.getProjectionData().getProperties() != null) {
+			projectionData.setProperties(request.getProjectionData().getProperties());
+		}
 
 		if (request.getProjection() == null) {
 			throw new InvalidInputException("Projection not defined");

--- a/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/app/YarnContainerClusterApplicationOperationPropertiesTests.java
+++ b/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/app/YarnContainerClusterApplicationOperationPropertiesTests.java
@@ -33,18 +33,18 @@ public class YarnContainerClusterApplicationOperationPropertiesTests {
 		SpringApplication app = new SpringApplication(TestConfiguration.class);
 		app.setWebEnvironment(false);
 		ConfigurableApplicationContext context = app.run(new String[] {
-				"--spring.yarn.internal.ContainerClusterApplication.projectionDataAny=1",
-				"--spring.yarn.internal.ContainerClusterApplication.projectionDataHosts.host1=1",
-				"--spring.yarn.internal.ContainerClusterApplication.projectionDataRacks.rack1=1",
-				"--spring.yarn.internal.ContainerClusterApplication.projectionDataHosts.host2=2",
-				"--spring.yarn.internal.ContainerClusterApplication.projectionDataRacks.rack2=2" });
+				"--spring.yarn.internal.ContainerClusterApplication.projectionData.any=1",
+				"--spring.yarn.internal.ContainerClusterApplication.projectionData.hosts.host1=1",
+				"--spring.yarn.internal.ContainerClusterApplication.projectionData.racks.rack1=1",
+				"--spring.yarn.internal.ContainerClusterApplication.projectionData.hosts.host2=2",
+				"--spring.yarn.internal.ContainerClusterApplication.projectionData.racks.rack2=2" });
 		OperationProperties properties = context.getBean(OperationProperties.class);
 		assertThat(properties, notNullValue());
-		assertThat(properties.getProjectionDataAny(), is(1));
-		assertThat(properties.getProjectionDataHosts().get("host1"), is(1));
-		assertThat(properties.getProjectionDataHosts().get("host2"), is(2));
-		assertThat(properties.getProjectionDataRacks().get("rack1"), is(1));
-		assertThat(properties.getProjectionDataRacks().get("rack2"), is(2));
+		assertThat(properties.getProjectionData().getAny(), is(1));
+		assertThat(properties.getProjectionData().getHosts().get("host1"), is(1));
+		assertThat(properties.getProjectionData().getHosts().get("host2"), is(2));
+		assertThat(properties.getProjectionData().getRacks().get("rack1"), is(1));
+		assertThat(properties.getProjectionData().getRacks().get("rack2"), is(2));
 		context.close();
 	}
 


### PR DESCRIPTION
- Remove legacy awkward delimited list format for
  defining hosts, racks in container cluster create
  options. Replace it with proper json which in same
  format can be used in yml.
- Add option to set whole projection data as one parameter.
