### PR TITLE
SHDP-429 Abstract boot app run in AbstractApplicationCommand

### DIFF
--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/AbstractApplicationCommand.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/AbstractApplicationCommand.java
@@ -22,6 +22,7 @@ import org.springframework.boot.cli.command.OptionParsingCommand;
 import org.springframework.boot.cli.command.options.OptionHandler;
 import org.springframework.boot.cli.command.status.ExitStatus;
 import org.springframework.boot.cli.util.Log;
+import org.springframework.yarn.boot.app.ClientApplicationRunner;
 
 /**
  * Base class for all commands implemented by
@@ -43,7 +44,7 @@ public class AbstractApplicationCommand extends OptionParsingCommand {
 		super(name, description, handler);
 	}
 
-	public abstract static class ApplicationOptionHandler extends OptionHandler {
+	public abstract static class ApplicationOptionHandler<R> extends OptionHandler {
 
 		@Override
 		protected final ExitStatus run(OptionSet options) throws Exception {
@@ -90,6 +91,28 @@ public class AbstractApplicationCommand extends OptionParsingCommand {
 		 */
 		protected void handleOutput(String output) {
 			Log.info(output);
+		}
+
+		/**
+		 * Handles run of {@link ClientApplicationRunner}.
+		 *
+		 * @param app the app
+		 */
+		protected void handleApplicationRun(ClientApplicationRunner<R> app) {
+			handleApplicationRun(app, new String[0]);
+		}
+
+		/**
+		 * Handles run of {@link ClientApplicationRunner}.
+		 *
+		 * @param app the app
+		 * @param args the args
+		 */
+		protected void handleApplicationRun(ClientApplicationRunner<R> app, String... args) {
+			R run = app.run(args);
+			if (run != null) {
+				handleOutput(run.toString());
+			}
 		}
 
 	}

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnClusterCreateCommand.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnClusterCreateCommand.java
@@ -69,7 +69,7 @@ public class YarnClusterCreateCommand extends AbstractApplicationCommand {
 		super(name, description, handler);
 	}
 
-	public static class ClusterCreateOptionHandler extends ApplicationOptionHandler {
+	public static class ClusterCreateOptionHandler extends ApplicationOptionHandler<String> {
 
 		private static final String PREFIX = "spring.yarn.internal.ContainerClusterApplication";
 
@@ -134,10 +134,13 @@ public class YarnClusterCreateCommand extends AbstractApplicationCommand {
 					appId);
 			appProperties.setProperty("spring.yarn.internal.ContainerClusterApplication.clusterId",
 					clusterId);
-			appProperties.setProperty("spring.yarn.internal.ContainerClusterApplication.clusterDef",
-					clusterDef);
-			appProperties.setProperty("spring.yarn.internal.ContainerClusterApplication.projectionType",
-					projectionType);
+			if (clusterDef != null) {
+				appProperties.setProperty("spring.yarn.internal.ContainerClusterApplication.clusterDef", clusterDef);
+			}
+			if (projectionType != null) {
+				appProperties.setProperty("spring.yarn.internal.ContainerClusterApplication.projectionType",
+						projectionType);
+			}
 
 			if (StringUtils.hasText(projectionAny)) {
 				appProperties.setProperty(PREFIX + ".projectionData.any", projectionAny);
@@ -170,7 +173,7 @@ public class YarnClusterCreateCommand extends AbstractApplicationCommand {
 			}
 
 			app.appProperties(appProperties);
-			handleOutput(app.run());
+			handleApplicationRun(app);
 		}
 
 		public OptionSpec<String> getApplicationIdOption() {

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnClusterDestroyCommand.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnClusterDestroyCommand.java
@@ -65,7 +65,7 @@ public class YarnClusterDestroyCommand extends AbstractApplicationCommand {
 		super(name, description, handler);
 	}
 
-	public static class ClusterDestroyOptionHandler extends ApplicationOptionHandler {
+	public static class ClusterDestroyOptionHandler extends ApplicationOptionHandler<String> {
 
 		private OptionSpec<String> applicationIdOption;
 
@@ -98,8 +98,7 @@ public class YarnClusterDestroyCommand extends AbstractApplicationCommand {
 			appProperties.setProperty("spring.yarn.internal.ContainerClusterApplication.clusterId",
 					versionId);
 			app.appProperties(appProperties);
-			String info = app.run(new String[0]);
-			handleOutput(info);
+			handleApplicationRun(app);
 		}
 
 		public OptionSpec<String> getApplicationIdOption() {

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnClusterInfoCommand.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnClusterInfoCommand.java
@@ -65,7 +65,7 @@ public class YarnClusterInfoCommand extends AbstractApplicationCommand {
 		super(name, description, handler);
 	}
 
-	public static class ClusterInfoOptionHandler extends ApplicationOptionHandler {
+	public static class ClusterInfoOptionHandler extends ApplicationOptionHandler<String> {
 
 		private OptionSpec<String> applicationIdOption;
 
@@ -103,8 +103,7 @@ public class YarnClusterInfoCommand extends AbstractApplicationCommand {
 				appProperties.setProperty("spring.yarn.internal.ContainerClusterApplication.verbose", "true");
 			}
 			app.appProperties(appProperties);
-			String info = app.run(new String[0]);
-			handleOutput(info);
+			handleApplicationRun(app);
 		}
 
 		public OptionSpec<String> getApplicationIdOption() {

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnClusterModifyCommand.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnClusterModifyCommand.java
@@ -69,7 +69,7 @@ public class YarnClusterModifyCommand extends AbstractApplicationCommand {
 		super(name, description, handler);
 	}
 
-	public static class ClusterModifyOptionHandler extends ApplicationOptionHandler {
+	public static class ClusterModifyOptionHandler extends ApplicationOptionHandler<String> {
 
 		private static final String PREFIX = "spring.yarn.internal.ContainerClusterApplication";
 
@@ -148,8 +148,7 @@ public class YarnClusterModifyCommand extends AbstractApplicationCommand {
 			}
 
 			app.appProperties(appProperties);
-			String info = app.run(new String[0]);
-			handleOutput(info);
+			handleApplicationRun(app);
 		}
 
 		public OptionSpec<String> getApplicationIdOption() {

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnClusterStartCommand.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnClusterStartCommand.java
@@ -65,7 +65,7 @@ public class YarnClusterStartCommand extends AbstractApplicationCommand {
 		super(name, description, handler);
 	}
 
-	public static class ClusterStartOptionHandler extends ApplicationOptionHandler {
+	public static class ClusterStartOptionHandler extends ApplicationOptionHandler<String> {
 
 		private OptionSpec<String> applicationIdOption;
 
@@ -99,8 +99,7 @@ public class YarnClusterStartCommand extends AbstractApplicationCommand {
 			appProperties.setProperty("spring.yarn.internal.ContainerClusterApplication.clusterId",
 					clusterId);
 			app.appProperties(appProperties);
-			String info = app.run(new String[0]);
-			handleOutput(info);
+			handleApplicationRun(app);
 		}
 
 		public OptionSpec<String> getApplicationIdOption() {

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnClusterStopCommand.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnClusterStopCommand.java
@@ -65,7 +65,7 @@ public class YarnClusterStopCommand extends AbstractApplicationCommand {
 		super(name, description, handler);
 	}
 
-	public static class ClusterStopOptionHandler extends ApplicationOptionHandler {
+	public static class ClusterStopOptionHandler extends ApplicationOptionHandler<String> {
 
 		private OptionSpec<String> applicationIdOption;
 
@@ -99,8 +99,7 @@ public class YarnClusterStopCommand extends AbstractApplicationCommand {
 			appProperties.setProperty("spring.yarn.internal.ContainerClusterApplication.clusterId",
 					clusterId);
 			app.appProperties(appProperties);
-			String info = app.run(new String[0]);
-			handleOutput(info);
+			handleApplicationRun(app);
 		}
 
 		public OptionSpec<String> getApplicationIdOption() {

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnClustersInfoCommand.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnClustersInfoCommand.java
@@ -64,7 +64,7 @@ public class YarnClustersInfoCommand extends AbstractApplicationCommand {
 		super(name, description, handler);
 	}
 
-	public static class ClustersInfoOptionHandler extends ApplicationOptionHandler {
+	public static class ClustersInfoOptionHandler extends ApplicationOptionHandler<String> {
 
 		private OptionSpec<String> applicationIdOption;
 
@@ -88,8 +88,7 @@ public class YarnClustersInfoCommand extends AbstractApplicationCommand {
 			appProperties.setProperty("spring.yarn.internal.ContainerClusterApplication.applicationId",
 					appId);
 			app.appProperties(appProperties);
-			String info = app.run(new String[0]);
-			handleOutput(info);
+			handleApplicationRun(app);
 		}
 
 		public OptionSpec<String> getApplicationIdOption() {

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnKillCommand.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnKillCommand.java
@@ -64,7 +64,7 @@ public class YarnKillCommand extends AbstractApplicationCommand {
 		super(name, description, handler);
 	}
 
-	public static class KillOptionHandler extends ApplicationOptionHandler {
+	public static class KillOptionHandler extends ApplicationOptionHandler<String> {
 
 		private OptionSpec<String> applicationIdOption;
 
@@ -82,8 +82,7 @@ public class YarnKillCommand extends AbstractApplicationCommand {
 			Properties appProperties = new Properties();
 			appProperties.setProperty("spring.yarn.internal.YarnKillApplication.applicationId", appId);
 			app.appProperties(appProperties);
-			String info = app.run(new String[0]);
-			handleOutput(info);
+			handleApplicationRun(app);
 		}
 
 		public OptionSpec<String> getApplicationIdOption() {

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnPushCommand.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnPushCommand.java
@@ -20,6 +20,7 @@ import java.util.Properties;
 import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
 
+import org.springframework.yarn.boot.app.ClientApplicationRunner;
 import org.springframework.yarn.boot.app.YarnPushApplication;
 
 /**
@@ -63,7 +64,7 @@ public class YarnPushCommand extends AbstractApplicationCommand {
 		super(name, description, handler);
 	}
 
-	public static class PushOptionHandler extends ApplicationOptionHandler {
+	public static class PushOptionHandler extends ApplicationOptionHandler<String> {
 
 		private OptionSpec<String> applicationVersionOption;
 
@@ -81,8 +82,13 @@ public class YarnPushCommand extends AbstractApplicationCommand {
 			Properties instanceProperties = new Properties();
 			instanceProperties.setProperty("spring.yarn.applicationVersion", appVersion);
 			app.configFile("application.properties", instanceProperties);
+			handleApplicationRun(app);
+		}
+
+		@Override
+		protected void handleApplicationRun(ClientApplicationRunner<String> app) {
 			app.run();
-			handleOutput("New instance " + appVersion + " installed");
+			handleOutput("New instance submitted");
 		}
 
 		public OptionSpec<String> getApplicationVersionOption() {

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnPushedCommand.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnPushedCommand.java
@@ -62,7 +62,7 @@ public class YarnPushedCommand extends AbstractApplicationCommand {
 		super(name, description, handler);
 	}
 
-	public static class PushedOptionHandler extends ApplicationOptionHandler {
+	public static class PushedOptionHandler extends ApplicationOptionHandler<String> {
 
 		@Override
 		protected void runApplication(OptionSet options) throws Exception {
@@ -70,8 +70,7 @@ public class YarnPushedCommand extends AbstractApplicationCommand {
 			Properties appProperties = new Properties();
 			appProperties.setProperty("spring.yarn.internal.YarnInfoApplication.operation", "PUSHED");
 			app.appProperties(appProperties);
-			String info = app.run();
-			handleOutput(info);
+			handleApplicationRun(app);
 		}
 
 	}

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnSubmitCommand.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnSubmitCommand.java
@@ -20,6 +20,7 @@ import joptsimple.OptionSpec;
 
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.springframework.util.Assert;
+import org.springframework.yarn.boot.app.ClientApplicationRunner;
 import org.springframework.yarn.boot.app.YarnSubmitApplication;
 
 /**
@@ -63,7 +64,7 @@ public class YarnSubmitCommand extends AbstractApplicationCommand {
 		super(name, description, handler);
 	}
 
-	public static class SubmitOptionHandler extends ApplicationOptionHandler {
+	public static class SubmitOptionHandler extends ApplicationOptionHandler<ApplicationId> {
 
 		private OptionSpec<String> applicationVersionOption;
 
@@ -79,6 +80,11 @@ public class YarnSubmitCommand extends AbstractApplicationCommand {
 			Assert.hasText(appVersion, "Application version must be defined");
 			YarnSubmitApplication app = new YarnSubmitApplication();
 			app.applicationVersion(appVersion);
+			handleApplicationRun(app);
+		}
+
+		@Override
+		protected void handleApplicationRun(ClientApplicationRunner<ApplicationId> app) {
 			ApplicationId applicationId = app.run();
 			handleOutput("New instance submitted with id " + applicationId);
 		}

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnSubmittedCommand.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnSubmittedCommand.java
@@ -64,7 +64,7 @@ public class YarnSubmittedCommand extends AbstractApplicationCommand {
 		super(name, description, handler);
 	}
 
-	public static class SubmittedOptionHandler extends ApplicationOptionHandler {
+	public static class SubmittedOptionHandler extends ApplicationOptionHandler<String> {
 
 		private String defaultAppType = "BOOT";
 
@@ -99,8 +99,7 @@ public class YarnSubmittedCommand extends AbstractApplicationCommand {
 			}
 			appProperties.setProperty("spring.yarn.internal.YarnInfoApplication.type", options.valueOf(typeOption));
 			app.appProperties(appProperties);
-			String info = app.run(new String[0]);
-			handleOutput(info);
+			handleApplicationRun(app);
 		}
 
 		public String getDefaultAppType() {

--- a/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnClusterCreateCommandTests.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnClusterCreateCommandTests.java
@@ -23,6 +23,7 @@ import joptsimple.OptionSet;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.springframework.yarn.boot.app.ClientApplicationRunner;
 import org.springframework.yarn.boot.cli.YarnClusterCreateCommand.ClusterCreateOptionHandler;
 
 /**
@@ -46,20 +47,21 @@ public class YarnClusterCreateCommandTests {
 		assertThat(command.getHelp(), containsString("-p, --projection-type"));
 		assertThat(command.getHelp(), containsString("-r, --projection-racks"));
 		assertThat(command.getHelp(), containsString("-w, --projection-any"));
+		assertThat(command.getHelp(), containsString("-y, --projection-data"));
 	}
 
 	@Test
 	public void testFailureNoArgs() throws Exception {
 		thrown.expect(IllegalStateException.class);
 		thrown.expectMessage(containsString("Cluster Id and Application Id must be defined"));
-		NoRunClusterCreateOptionHandler handler = new NoRunClusterCreateOptionHandler();
+		NoRunApplicationClusterCreateOptionHandler handler = new NoRunApplicationClusterCreateOptionHandler();
 		YarnClusterCreateCommand command = new YarnClusterCreateCommand(handler);
 		command.run(new String[0]);
 	}
 
 	@Test
 	public void testShouldNotFail() throws Exception {
-		NoRunClusterCreateOptionHandler handler = new NoRunClusterCreateOptionHandler();
+		NoRunApplicationClusterCreateOptionHandler handler = new NoRunApplicationClusterCreateOptionHandler();
 		YarnClusterCreateCommand command = new YarnClusterCreateCommand(handler);
 		command.run("-a", "xxx", "-c", "xxx");
 	}
@@ -71,6 +73,14 @@ public class YarnClusterCreateCommandTests {
 		CustomClusterCreateOptionHandler handler = new CustomClusterCreateOptionHandler();
 		YarnClusterCreateCommand command = new YarnClusterCreateCommand(handler);
 		command.run("-a", "foo");
+	}
+
+	@Test
+	public void testMissingClusterDef() throws Exception {
+		NoHandleApplicationOptionHandler handler = new NoHandleApplicationOptionHandler();
+		YarnClusterCreateCommand command = new YarnClusterCreateCommand(handler);
+		command.run("-a", "aaa", "-c", "ccc");
+		assertThat(handler.output, is("output"));
 	}
 
 	private static class CustomClusterCreateOptionHandler extends ClusterCreateOptionHandler {
@@ -85,10 +95,21 @@ public class YarnClusterCreateCommandTests {
 
 	}
 
-	private static class NoRunClusterCreateOptionHandler extends ClusterCreateOptionHandler {
+	private static class NoRunApplicationClusterCreateOptionHandler extends ClusterCreateOptionHandler {
 
 		@Override
 		protected void runApplication(OptionSet options) throws Exception {
+		}
+
+	}
+
+	private static class NoHandleApplicationOptionHandler extends ClusterCreateOptionHandler {
+
+		String output;
+
+		@Override
+		protected void handleApplicationRun(ClientApplicationRunner<String> app) {
+			this.output = "output";
 		}
 
 	}

--- a/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnClusterDestroyCommandTests.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnClusterDestroyCommandTests.java
@@ -23,6 +23,7 @@ import joptsimple.OptionSet;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.springframework.yarn.boot.app.ClientApplicationRunner;
 import org.springframework.yarn.boot.cli.YarnClusterDestroyCommand.ClusterDestroyOptionHandler;
 
 /**
@@ -68,6 +69,14 @@ public class YarnClusterDestroyCommandTests {
 		command.run("-a", "foo");
 	}
 
+	@Test
+	public void testRequiredArgs() throws Exception {
+		NoHandleApplicationOptionHandler handler = new NoHandleApplicationOptionHandler();
+		YarnClusterDestroyCommand command = new YarnClusterDestroyCommand(handler);
+		command.run("-a", "aaa", "-c", "ccc");
+		assertThat(handler.output, is("output"));
+	}
+
 	private static class CustomClusterDestroyOptionHandler extends ClusterDestroyOptionHandler {
 
 		@Override
@@ -84,6 +93,17 @@ public class YarnClusterDestroyCommandTests {
 
 		@Override
 		protected void runApplication(OptionSet options) throws Exception {
+		}
+
+	}
+
+	private static class NoHandleApplicationOptionHandler extends ClusterDestroyOptionHandler {
+
+		String output;
+
+		@Override
+		protected void handleApplicationRun(ClientApplicationRunner<String> app) {
+			this.output = "output";
 		}
 
 	}

--- a/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnClusterInfoCommandTests.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnClusterInfoCommandTests.java
@@ -23,6 +23,7 @@ import joptsimple.OptionSet;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.springframework.yarn.boot.app.ClientApplicationRunner;
 import org.springframework.yarn.boot.cli.YarnClusterInfoCommand.ClusterInfoOptionHandler;
 
 /**
@@ -69,6 +70,14 @@ public class YarnClusterInfoCommandTests {
 		command.run("-a", "foo");
 	}
 
+	@Test
+	public void testRequiredArgs() throws Exception {
+		NoHandleApplicationOptionHandler handler = new NoHandleApplicationOptionHandler();
+		YarnClusterInfoCommand command = new YarnClusterInfoCommand(handler);
+		command.run("-a", "aaa", "-c", "ccc");
+		assertThat(handler.output, is("output"));
+	}
+
 	private static class CustomClusterInfoOptionHandler extends ClusterInfoOptionHandler {
 
 		@Override
@@ -85,6 +94,17 @@ public class YarnClusterInfoCommandTests {
 
 		@Override
 		protected void runApplication(OptionSet options) throws Exception {
+		}
+
+	}
+
+	private static class NoHandleApplicationOptionHandler extends ClusterInfoOptionHandler {
+
+		String output;
+
+		@Override
+		protected void handleApplicationRun(ClientApplicationRunner<String> app) {
+			this.output = "output";
 		}
 
 	}

--- a/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnClusterModifyCommandTests.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnClusterModifyCommandTests.java
@@ -23,6 +23,7 @@ import joptsimple.OptionSet;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.springframework.yarn.boot.app.ClientApplicationRunner;
 import org.springframework.yarn.boot.cli.YarnClusterModifyCommand.ClusterModifyOptionHandler;
 
 /**
@@ -71,6 +72,14 @@ public class YarnClusterModifyCommandTests {
 		command.run("-a", "foo");
 	}
 
+	@Test
+	public void testMissingOptionalArgs() throws Exception {
+		NoHandleApplicationOptionHandler handler = new NoHandleApplicationOptionHandler();
+		YarnClusterModifyCommand command = new YarnClusterModifyCommand(handler);
+		command.run("-a", "aaa", "-c", "ccc");
+		assertThat(handler.output, is("output"));
+	}
+
 	private static class CustomClusterModifyOptionHandler extends ClusterModifyOptionHandler {
 
 		@Override
@@ -87,6 +96,17 @@ public class YarnClusterModifyCommandTests {
 
 		@Override
 		protected void runApplication(OptionSet options) throws Exception {
+		}
+
+	}
+
+	private static class NoHandleApplicationOptionHandler extends ClusterModifyOptionHandler {
+
+		String output;
+
+		@Override
+		protected void handleApplicationRun(ClientApplicationRunner<String> app) {
+			this.output = "output";
 		}
 
 	}

--- a/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnClusterStartCommandTests.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnClusterStartCommandTests.java
@@ -23,6 +23,7 @@ import joptsimple.OptionSet;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.springframework.yarn.boot.app.ClientApplicationRunner;
 import org.springframework.yarn.boot.cli.YarnClusterStartCommand.ClusterStartOptionHandler;
 
 /**
@@ -68,6 +69,14 @@ public class YarnClusterStartCommandTests {
 		command.run("-a", "foo");
 	}
 
+	@Test
+	public void testRequiredArgs() throws Exception {
+		NoHandleApplicationOptionHandler handler = new NoHandleApplicationOptionHandler();
+		YarnClusterStartCommand command = new YarnClusterStartCommand(handler);
+		command.run("-a", "aaa", "-c", "ccc");
+		assertThat(handler.output, is("output"));
+	}
+
 	private static class CustomClusterStartOptionHandler extends ClusterStartOptionHandler {
 
 		@Override
@@ -84,6 +93,17 @@ public class YarnClusterStartCommandTests {
 
 		@Override
 		protected void runApplication(OptionSet options) throws Exception {
+		}
+
+	}
+
+	private static class NoHandleApplicationOptionHandler extends ClusterStartOptionHandler {
+
+		String output;
+
+		@Override
+		protected void handleApplicationRun(ClientApplicationRunner<String> app) {
+			this.output = "output";
 		}
 
 	}

--- a/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnClusterStopCommandTests.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnClusterStopCommandTests.java
@@ -23,6 +23,7 @@ import joptsimple.OptionSet;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.springframework.yarn.boot.app.ClientApplicationRunner;
 import org.springframework.yarn.boot.cli.YarnClusterStopCommand.ClusterStopOptionHandler;
 
 /**
@@ -68,6 +69,14 @@ public class YarnClusterStopCommandTests {
 		command.run("-a", "foo");
 	}
 
+	@Test
+	public void testRequiredArgs() throws Exception {
+		NoHandleApplicationOptionHandler handler = new NoHandleApplicationOptionHandler();
+		YarnClusterStopCommand command = new YarnClusterStopCommand(handler);
+		command.run("-a", "aaa", "-c", "ccc");
+		assertThat(handler.output, is("output"));
+	}
+
 	private static class CustomClusterStopOptionHandler extends ClusterStopOptionHandler {
 
 		@Override
@@ -84,6 +93,17 @@ public class YarnClusterStopCommandTests {
 
 		@Override
 		protected void runApplication(OptionSet options) throws Exception {
+		}
+
+	}
+
+	private static class NoHandleApplicationOptionHandler extends ClusterStopOptionHandler {
+
+		String output;
+
+		@Override
+		protected void handleApplicationRun(ClientApplicationRunner<String> app) {
+			this.output = "output";
 		}
 
 	}

--- a/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnClustersInfoCommandTests.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnClustersInfoCommandTests.java
@@ -23,6 +23,7 @@ import joptsimple.OptionSet;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.springframework.yarn.boot.app.ClientApplicationRunner;
 import org.springframework.yarn.boot.cli.YarnClustersInfoCommand.ClustersInfoOptionHandler;
 
 /**
@@ -67,6 +68,14 @@ public class YarnClustersInfoCommandTests {
 		command.run("-a", "foo");
 	}
 
+	@Test
+	public void testRequiredArgs() throws Exception {
+		NoHandleApplicationOptionHandler handler = new NoHandleApplicationOptionHandler();
+		YarnClustersInfoCommand command = new YarnClustersInfoCommand(handler);
+		command.run("-a", "aaa");
+		assertThat(handler.output, is("output"));
+	}
+
 	private static class CustomClustersInfoOptionHandler extends ClustersInfoOptionHandler {
 
 		@Override
@@ -83,6 +92,17 @@ public class YarnClustersInfoCommandTests {
 
 		@Override
 		protected void runApplication(OptionSet options) throws Exception {
+		}
+
+	}
+
+	private static class NoHandleApplicationOptionHandler extends ClustersInfoOptionHandler {
+
+		String output;
+
+		@Override
+		protected void handleApplicationRun(ClientApplicationRunner<String> app) {
+			this.output = "output";
 		}
 
 	}

--- a/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnKillCommandTests.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnKillCommandTests.java
@@ -23,6 +23,7 @@ import joptsimple.OptionSet;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.springframework.yarn.boot.app.ClientApplicationRunner;
 import org.springframework.yarn.boot.cli.YarnKillCommand.KillOptionHandler;
 
 /**
@@ -59,6 +60,14 @@ public class YarnKillCommandTests {
 		command.run("-a", "foo");
 	}
 
+	@Test
+	public void testRequiredArgs() throws Exception {
+		NoHandleApplicationOptionHandler handler = new NoHandleApplicationOptionHandler();
+		YarnKillCommand command = new YarnKillCommand(handler);
+		command.run("-a", "aaa");
+		assertThat(handler.output, is("output"));
+	}
+
 	private static class CustomKillOptionHandler extends KillOptionHandler {
 
 		@Override
@@ -78,6 +87,17 @@ public class YarnKillCommandTests {
 		@Override
 		protected void runApplication(OptionSet options) throws Exception {
 			appId = options.valueOf(getApplicationIdOption());
+		}
+
+	}
+
+	private static class NoHandleApplicationOptionHandler extends KillOptionHandler {
+
+		String output;
+
+		@Override
+		protected void handleApplicationRun(ClientApplicationRunner<String> app) {
+			this.output = "output";
 		}
 
 	}

--- a/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnPushCommandTests.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnPushCommandTests.java
@@ -23,6 +23,7 @@ import joptsimple.OptionSet;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.springframework.yarn.boot.app.ClientApplicationRunner;
 import org.springframework.yarn.boot.cli.YarnPushCommand.PushOptionHandler;
 
 /**
@@ -59,6 +60,14 @@ public class YarnPushCommandTests {
 		command.run("-v", "foo");
 	}
 
+	@Test
+	public void testRequiredArgs() throws Exception {
+		NoHandleApplicationOptionHandler handler = new NoHandleApplicationOptionHandler();
+		YarnPushCommand command = new YarnPushCommand(handler);
+		command.run();
+		assertThat(handler.output, is("output"));
+	}
+
 	private static class CustomClusterCreateOptionHandler extends PushOptionHandler {
 
 		@Override
@@ -78,6 +87,17 @@ public class YarnPushCommandTests {
 		@Override
 		protected void runApplication(OptionSet options) throws Exception {
 			appVersion = options.valueOf(getApplicationVersionOption());
+		}
+
+	}
+
+	private static class NoHandleApplicationOptionHandler extends PushOptionHandler {
+
+		String output;
+
+		@Override
+		protected void handleApplicationRun(ClientApplicationRunner<String> app) {
+			this.output = "output";
 		}
 
 	}

--- a/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnPushedCommandTests.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnPushedCommandTests.java
@@ -23,6 +23,7 @@ import joptsimple.OptionSet;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.springframework.yarn.boot.app.ClientApplicationRunner;
 import org.springframework.yarn.boot.cli.YarnPushedCommand.PushedOptionHandler;
 
 /**
@@ -58,6 +59,14 @@ public class YarnPushedCommandTests {
 		command.run();
 	}
 
+	@Test
+	public void testRequiredArgs() throws Exception {
+		NoHandleApplicationOptionHandler handler = new NoHandleApplicationOptionHandler();
+		YarnPushedCommand command = new YarnPushedCommand(handler);
+		command.run();
+		assertThat(handler.output, is("output"));
+	}
+
 	private static class CustomPushedOptionHandler extends PushedOptionHandler {
 
 		@Override
@@ -71,6 +80,17 @@ public class YarnPushedCommandTests {
 
 		@Override
 		protected void runApplication(OptionSet options) throws Exception {
+		}
+
+	}
+
+	private static class NoHandleApplicationOptionHandler extends PushedOptionHandler {
+
+		String output;
+
+		@Override
+		protected void handleApplicationRun(ClientApplicationRunner<String> app) {
+			this.output = "output";
 		}
 
 	}

--- a/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnSubmitCommandTests.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnSubmitCommandTests.java
@@ -20,9 +20,11 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import joptsimple.OptionSet;
 
+import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.springframework.yarn.boot.app.ClientApplicationRunner;
 import org.springframework.yarn.boot.cli.YarnSubmitCommand.SubmitOptionHandler;
 
 public class YarnSubmitCommandTests {
@@ -53,6 +55,14 @@ public class YarnSubmitCommandTests {
 		command.run("-v", "foo");
 	}
 
+	@Test
+	public void testNoArgsRun() throws Exception {
+		NoHandleApplicationOptionHandler handler = new NoHandleApplicationOptionHandler();
+		YarnSubmitCommand command = new YarnSubmitCommand(handler);
+		command.run();
+		assertThat(handler.output, is("output"));
+	}
+
 	private static class CustomSubmitOptionHandler extends SubmitOptionHandler {
 
 		@Override
@@ -72,6 +82,17 @@ public class YarnSubmitCommandTests {
 		@Override
 		protected void runApplication(OptionSet options) throws Exception {
 			appVersion = options.valueOf(getApplicationVersionOption());
+		}
+
+	}
+
+	private static class NoHandleApplicationOptionHandler extends SubmitOptionHandler {
+
+		String output;
+
+		@Override
+		protected void handleApplicationRun(ClientApplicationRunner<ApplicationId> app) {
+			this.output = "output";
 		}
 
 	}

--- a/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnSubmittedCommandTests.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnSubmittedCommandTests.java
@@ -23,6 +23,7 @@ import joptsimple.OptionSet;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.springframework.yarn.boot.app.ClientApplicationRunner;
 import org.springframework.yarn.boot.cli.YarnSubmittedCommand.SubmittedOptionHandler;
 
 /**
@@ -80,6 +81,14 @@ public class YarnSubmittedCommandTests {
 		command.run();
 	}
 
+	@Test
+	public void testRequiredArgs() throws Exception {
+		NoHandleApplicationOptionHandler handler = new NoHandleApplicationOptionHandler();
+		YarnSubmittedCommand command = new YarnSubmittedCommand(handler);
+		command.run();
+		assertThat(handler.output, is("output"));
+	}
+
 	private static class CustomSubmittedOptionHandler extends SubmittedOptionHandler {
 
 		public CustomSubmittedOptionHandler(String defaultAppType) {
@@ -110,6 +119,17 @@ public class YarnSubmittedCommandTests {
 
 		@Override
 		protected void runApplication(OptionSet options) throws Exception {
+		}
+
+	}
+
+	private static class NoHandleApplicationOptionHandler extends SubmittedOptionHandler {
+
+		String output;
+
+		@Override
+		protected void handleApplicationRun(ClientApplicationRunner<String> app) {
+			this.output = "output";
 		}
 
 	}

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/AbstractClientApplication.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/AbstractClientApplication.java
@@ -32,13 +32,21 @@ import org.springframework.util.StringUtils;
  *
  * @param <T> the type of a sub-class
  */
-public abstract class AbstractClientApplication<T extends AbstractClientApplication<T>> {
+public abstract class AbstractClientApplication<R, T extends AbstractClientApplication<R, T>> implements ClientApplicationRunner<R> {
 
 	protected String applicationVersion;
 	protected String applicationBaseDir;
 	protected List<Object> sources = new ArrayList<Object>();
 	protected List<String> profiles = new ArrayList<String>();
 	protected Properties appProperties = new Properties();
+
+	@Override
+	public R run() {
+		return run(new String[0]);
+	}
+
+	@Override
+	public abstract R run(String... args);
 
 	/**
 	 * Sets an application version to be used by a builder.

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/ClientApplicationRunner.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/ClientApplicationRunner.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.yarn.boot.app;
+
+/**
+ * Interface for running client applications.
+ *
+ * @author Janne Valkealahti
+ *
+ * @param <R> the type of output
+ */
+public interface ClientApplicationRunner<R> {
+
+	/**
+	 * Run the application.
+	 *
+	 * @return the output
+	 */
+	R run();
+
+	/**
+	 * Run the application.
+	 *
+	 * @param args the application arguments
+	 * @return the output
+	 */
+	R run(String... args);
+
+}

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/YarnContainerClusterApplication.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/YarnContainerClusterApplication.java
@@ -61,7 +61,7 @@ import org.springframework.yarn.support.console.ContainerClusterReport.ClustersI
 @EnableAutoConfiguration(exclude = { EmbeddedServletContainerAutoConfiguration.class, WebMvcAutoConfiguration.class,
 		JmxAutoConfiguration.class, BatchAutoConfiguration.class, JmxAutoConfiguration.class,
 		EndpointMBeanExportAutoConfiguration.class, EndpointAutoConfiguration.class })
-public class YarnContainerClusterApplication extends AbstractClientApplication<YarnContainerClusterApplication> {
+public class YarnContainerClusterApplication extends AbstractClientApplication<String, YarnContainerClusterApplication> {
 
 	@Override
 	protected YarnContainerClusterApplication getThis() {

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/YarnInfoApplication.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/YarnInfoApplication.java
@@ -55,7 +55,7 @@ import org.springframework.yarn.support.console.ApplicationsReport.SubmittedRepo
 @EnableAutoConfiguration(exclude = { EmbeddedServletContainerAutoConfiguration.class, WebMvcAutoConfiguration.class,
 		JmxAutoConfiguration.class, BatchAutoConfiguration.class, JmxAutoConfiguration.class,
 		EndpointMBeanExportAutoConfiguration.class, EndpointAutoConfiguration.class })
-public class YarnInfoApplication extends AbstractClientApplication<YarnInfoApplication> {
+public class YarnInfoApplication extends AbstractClientApplication<String, YarnInfoApplication> {
 
 	/**
 	 * Run a {@link SpringApplication} build by a

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/YarnKillApplication.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/YarnKillApplication.java
@@ -46,7 +46,7 @@ import org.springframework.yarn.client.YarnClient;
 @EnableAutoConfiguration(exclude = { EmbeddedServletContainerAutoConfiguration.class, WebMvcAutoConfiguration.class,
 		JmxAutoConfiguration.class, BatchAutoConfiguration.class, JmxAutoConfiguration.class,
 		EndpointMBeanExportAutoConfiguration.class, EndpointAutoConfiguration.class })
-public class YarnKillApplication extends AbstractClientApplication<YarnKillApplication> {
+public class YarnKillApplication extends AbstractClientApplication<String, YarnKillApplication> {
 
 	public String run() {
 		return run(new String[0]);

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/YarnPushApplication.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/YarnPushApplication.java
@@ -54,7 +54,7 @@ import org.springframework.yarn.client.YarnClient;
 @EnableAutoConfiguration(exclude = { EmbeddedServletContainerAutoConfiguration.class, WebMvcAutoConfiguration.class,
 		JmxAutoConfiguration.class, BatchAutoConfiguration.class, JmxAutoConfiguration.class,
 		EndpointMBeanExportAutoConfiguration.class, EndpointAutoConfiguration.class })
-public class YarnPushApplication extends AbstractClientApplication<YarnPushApplication> {
+public class YarnPushApplication extends AbstractClientApplication<String, YarnPushApplication> {
 
 	private Map<String, Properties> configFilesContents = new HashMap<String, Properties>();
 
@@ -78,8 +78,8 @@ public class YarnPushApplication extends AbstractClientApplication<YarnPushAppli
 	 *
 	 * @see #run(String...)
 	 */
-	public void run() {
-		run(new String[0]);
+	public String run() {
+		return run(new String[0]);
 	}
 
 	/**
@@ -87,7 +87,7 @@ public class YarnPushApplication extends AbstractClientApplication<YarnPushAppli
 	 *
 	 * @param args the Spring Application args
 	 */
-	public void run(String... args) {
+	public String run(String... args) {
 		if (!StringUtils.hasText(applicationVersion)) {
 			throw new SpringApplicationException("Error executing a spring application", new IllegalArgumentException(
 					"Instance id must be set"));
@@ -107,10 +107,10 @@ public class YarnPushApplication extends AbstractClientApplication<YarnPushAppli
 		SpringYarnBootUtils.addApplicationListener(builder, appProperties);
 
 		SpringApplicationTemplate template = new SpringApplicationTemplate(builder);
-		template.execute(new SpringApplicationCallback<Void>() {
+		return template.execute(new SpringApplicationCallback<String>() {
 
 			@Override
-			public Void runWithSpringApplication(ApplicationContext context) throws Exception {
+			public String runWithSpringApplication(ApplicationContext context) throws Exception {
 				YarnClient client = context.getBean(YarnClient.class);
 				SpringYarnProperties syp = context.getBean(SpringYarnProperties.class);
 				String applicationdir = SpringYarnBootUtils.resolveApplicationdir(syp);

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/YarnSubmitApplication.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/YarnSubmitApplication.java
@@ -47,7 +47,7 @@ import org.springframework.yarn.client.YarnClient;
 @EnableAutoConfiguration(exclude = { EmbeddedServletContainerAutoConfiguration.class, WebMvcAutoConfiguration.class,
 		JmxAutoConfiguration.class, BatchAutoConfiguration.class, JmxAutoConfiguration.class,
 		EndpointMBeanExportAutoConfiguration.class, EndpointAutoConfiguration.class })
-public class YarnSubmitApplication extends AbstractClientApplication<YarnSubmitApplication> {
+public class YarnSubmitApplication extends AbstractClientApplication<ApplicationId, YarnSubmitApplication> {
 
 	/**
 	 * Run a {@link SpringApplication} build by a


### PR DESCRIPTION
- Big refactoring of yarn boot cli commands to have a better
  internal moded of running boot apps.
- This also makes it much easier to test internal functionality
  of commands without actually running the boot app context.
- Added new basic tests for all commands.
