### PR TITLE
SHDP-430 YarnContainerClusterMvcEndpoint registered twice

### DIFF
--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/actuate/endpoint/mvc/YarnContainerClusterMvcEndpoint.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/actuate/endpoint/mvc/YarnContainerClusterMvcEndpoint.java
@@ -49,7 +49,6 @@ import org.springframework.yarn.boot.actuate.endpoint.mvc.domain.YarnContainerCl
  * @author Janne Valkealahti
  *
  */
-@RequestMapping("/" + YarnContainerClusterEndpoint.ENDPOINT_ID)
 public class YarnContainerClusterMvcEndpoint extends EndpointMvcAdapter {
 
 	private final YarnContainerClusterEndpoint delegate;

--- a/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/actuate/endpoint/mvc/YarnContainerClusterMvcEndpointTests.java
+++ b/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/actuate/endpoint/mvc/YarnContainerClusterMvcEndpointTests.java
@@ -129,7 +129,7 @@ public class YarnContainerClusterMvcEndpointTests {
 			perform(post(BASE).content(content).contentType(MediaType.APPLICATION_JSON)).
 			andExpect(status().isCreated()).
 			andExpect(content().string(is(""))).
-			andExpect(header().string("Location", endsWith(BASE + "/cluster1")));
+			andExpect(header().string("Location", endsWith("/cluster1")));
 		Map<String, ContainerCluster> clusters = TestUtils.readField("clusters", appmaster);
 		assertThat(clusters.size(), is(1));
 		assertThat(clusters.containsKey("cluster1"), is(true));
@@ -146,7 +146,7 @@ public class YarnContainerClusterMvcEndpointTests {
 			perform(post(BASE).content(content).contentType(MediaType.APPLICATION_JSON)).
 			andExpect(status().isCreated()).
 			andExpect(content().string(is(""))).
-			andExpect(header().string("Location", endsWith(BASE + "/cluster1")));
+			andExpect(header().string("Location", endsWith("/cluster1")));
 
 		Map<String, ContainerCluster> clusters = TestUtils.readField("clusters", appmaster);
 		assertThat(clusters.size(), is(1));
@@ -166,7 +166,7 @@ public class YarnContainerClusterMvcEndpointTests {
 			perform(post(BASE).content(content).contentType(MediaType.APPLICATION_JSON)).
 			andExpect(status().isCreated()).
 			andExpect(content().string(is(""))).
-			andExpect(header().string("Location", endsWith(BASE + "/cluster1")));
+			andExpect(header().string("Location", endsWith("/cluster1")));
 		Map<String, ContainerCluster> clusters = TestUtils.readField("clusters", appmaster);
 		assertThat(clusters.size(), is(1));
 		assertThat(clusters.containsKey("cluster1"), is(true));

--- a/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/actuate/endpoint/mvc/YarnContainerClusterWithCustomProjectionsMvcEndpointTests.java
+++ b/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/actuate/endpoint/mvc/YarnContainerClusterWithCustomProjectionsMvcEndpointTests.java
@@ -109,7 +109,7 @@ public class YarnContainerClusterWithCustomProjectionsMvcEndpointTests {
 			perform(post(BASE).content(content).contentType(MediaType.APPLICATION_JSON)).
 			andExpect(status().isCreated()).
 			andExpect(content().string(is(""))).
-			andExpect(header().string("Location", endsWith(BASE + "/cluster1")));
+			andExpect(header().string("Location", endsWith("/cluster1")));
 		Map<String, ContainerCluster> clusters = TestUtils.readField("clusters", appmaster);
 		assertThat(clusters.size(), is(1));
 		assertThat(clusters.containsKey("cluster1"), is(true));


### PR DESCRIPTION
- Removed specific @RequestMapping from YarnContainerClusterMvcEndpoint
  which caused double recursive mappings.
- Fixed tests for this change.
