### PR TITLE
SHDP-431 Support multiple @YarnComponents

### DIFF
--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/ContainerHandler.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/ContainerHandler.java
@@ -17,6 +17,7 @@ package org.springframework.yarn.container;
 
 import java.lang.reflect.Method;
 
+import org.springframework.core.Ordered;
 import org.springframework.yarn.annotation.OnContainerStart;
 import org.springframework.yarn.annotation.YarnComponent;
 
@@ -28,9 +29,11 @@ import org.springframework.yarn.annotation.YarnComponent;
  * @author Janne Valkealahti
  *
  */
-public class ContainerHandler {
+public class ContainerHandler implements Ordered {
 
 	private final YarnContainerRuntimeProcessor<?> processor;
+
+	private int order = Ordered.LOWEST_PRECEDENCE;
 
 	/**
 	 * Instantiates a new container handler.
@@ -69,6 +72,21 @@ public class ContainerHandler {
 	 */
 	public <T> ContainerHandler(MethodInvokingYarnContainerRuntimeProcessor<T> processor) {
 		this.processor = processor;
+	}
+
+	@Override
+	public int getOrder() {
+		return order;
+	}
+
+	/**
+	 * Sets the order used get value from {@link #getOrder()}.
+	 * Default value is {@link Ordered#LOWEST_PRECEDENCE}.
+	 *
+	 * @param order the new order
+	 */
+	public void setOrder(int order) {
+		this.order = order;
 	}
 
 	/**

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/DefaultYarnContainer.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/DefaultYarnContainer.java
@@ -15,11 +15,20 @@
  */
 package org.springframework.yarn.container;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.core.OrderComparator;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 import org.springframework.yarn.listener.ContainerStateListener.ContainerState;
 
 /**
@@ -32,27 +41,35 @@ public class DefaultYarnContainer extends AbstractYarnContainer implements BeanF
 
 	private final static Log log = LogFactory.getLog(DefaultYarnContainer.class);
 
-	private BeanFactory beanFactory;
+	private ListableBeanFactory beanFactory;
 
 	@Override
 	protected void runInternal() {
 		Exception runtimeException = null;
-		Object result = null;
+		List<Object> results = new ArrayList<Object>();
 
 		try {
-			ContainerHandler containerHandler = beanFactory.getBean(ContainerHandler.class);
-			result = containerHandler.handle(this);
+			Map<String, ContainerHandler> handlers = beanFactory.getBeansOfType(ContainerHandler.class);
+			List<ContainerHandler> orderHandlers = orderHandlers(handlers);
+			for (ContainerHandler handler : orderHandlers) {
+				results.add(handler.handle(this));
+			}
 		} catch (Exception e) {
 			runtimeException = e;
 			log.error("Error handling container", e);
 		}
 
-		log.info("Container state based on result=[" + result + "] runtimeException=[" + runtimeException + "]");
+		log.info("Container state based on method results=[" + StringUtils.arrayToCommaDelimitedString(results.toArray())
+				+ "] runtimeException=[" + runtimeException + "]");
 
 		if (runtimeException != null) {
 			notifyContainerState(ContainerState.FAILED, runtimeException);
-		} else if (result != null) {
-			notifyContainerState(ContainerState.COMPLETED, result);
+		} else if (!isEmptyValues(results)) {
+			if (results.size() == 1) {
+				notifyContainerState(ContainerState.COMPLETED, results.get(0));
+			} else {
+				notifyContainerState(ContainerState.COMPLETED, results);
+			}
 		} else {
 			notifyCompleted();
 		}
@@ -60,13 +77,49 @@ public class DefaultYarnContainer extends AbstractYarnContainer implements BeanF
 
 	@Override
 	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
-		this.beanFactory = beanFactory;
+		Assert.isInstanceOf(ListableBeanFactory.class, beanFactory, "Beanfactory must be of type ListableBeanFactory");
+		this.beanFactory = (ListableBeanFactory) beanFactory;
 	}
 
 	@Override
 	public boolean isWaitCompleteState() {
 		// we need to tell boot ContainerLauncherRunner that we're
 		// about to notify state via events so it should wait
+		return true;
+	}
+
+	/**
+	 * Returns ordered list of {@link ContainerHandler}s.
+	 *
+	 * @param handlers the handlers
+	 * @return the list ordered list
+	 */
+	private List<ContainerHandler> orderHandlers(Map<String, ContainerHandler> handlers) {
+		List<ContainerHandler> handlersList = new ArrayList<ContainerHandler>(handlers.values());
+		OrderComparator comparator = new OrderComparator();
+		Collections.sort(handlersList, comparator);
+		return handlersList;
+	}
+
+	/**
+	 * Checks if list contains just null objects or
+	 * empty strings.
+	 *
+	 * @param results the results
+	 * @return true, if is empty values
+	 */
+	private boolean isEmptyValues(List<Object> results) {
+		for (Object o : results) {
+			if (o != null) {
+				if (o instanceof String) {
+					if (StringUtils.hasText((String)o)) {
+						return false;
+					}
+				} else {
+					return false;
+				}
+			}
+		}
 		return true;
 	}
 

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/annotation/SpringYarnComplexConfigurationContainerActivatorTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/annotation/SpringYarnComplexConfigurationContainerActivatorTests.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.yarn.config.annotation;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+import org.springframework.yarn.YarnSystemConstants;
+import org.springframework.yarn.annotation.OnContainerStart;
+import org.springframework.yarn.annotation.YarnComponent;
+import org.springframework.yarn.config.annotation.EnableYarn.Enable;
+import org.springframework.yarn.container.DefaultYarnContainer;
+import org.springframework.yarn.container.YarnContainer;
+
+/**
+ * Tests verifying container annotation config creating
+ * needed components and logic of pojo method execution
+ * happens correctly.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(loader=AnnotationConfigContextLoader.class)
+public class SpringYarnComplexConfigurationContainerActivatorTests {
+
+	@Autowired
+	private ApplicationContext ctx;
+
+	@Test
+	public void testSimpleConfig() throws Exception {
+		assertNotNull(ctx);
+		assertTrue(ctx.containsBean(YarnSystemConstants.DEFAULT_ID_CONTAINER));
+		assertTrue(ctx.containsBean("org.springframework.yarn.internal.springYarnAnnotationPostProcessor"));
+		YarnContainer container = ctx.getBean(YarnSystemConstants.DEFAULT_ID_CONTAINER, YarnContainer.class);
+		assertTrue(container instanceof DefaultYarnContainer);
+		assertNotNull(container);
+		container.run();
+		TestContainerPojo1 testContainerPojo1 = ctx.getBean(TestContainerPojo1.class);
+		assertTrue(testContainerPojo1.executed);
+		TestContainerPojo2 testContainerPojo2 = ctx.getBean(TestContainerPojo2.class);
+		assertTrue(testContainerPojo2.executed);
+	}
+
+	@Configuration
+	@EnableYarn(enable=Enable.CONTAINER)
+	static class Config extends SpringYarnConfigurerAdapter {
+
+		@Bean
+		TestContainerPojo1 testContainerPojo1() {
+			return new TestContainerPojo1();
+		}
+
+		@Bean
+		TestContainerPojo2 testContainerPojo2() {
+			return new TestContainerPojo2();
+		}
+
+	}
+
+	@YarnComponent
+	public static class TestContainerPojo1 {
+		boolean executed;
+
+		@OnContainerStart
+		public void doSomething() {
+			executed = true;
+		}
+
+	}
+
+	@YarnComponent
+	public static class TestContainerPojo2 {
+		boolean executed;
+
+		@OnContainerStart
+		public void doSomething() {
+			executed = true;
+		}
+
+	}
+
+}

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/container/DefaultYarnContainerTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/container/DefaultYarnContainerTests.java
@@ -17,12 +17,17 @@ package org.springframework.yarn.container;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isOneOf;
 import static org.junit.Assert.assertThat;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.yarn.annotation.OnContainerStart;
 import org.springframework.yarn.annotation.YarnComponent;
 import org.springframework.yarn.config.annotation.SpringYarnAnnotationPostProcessor;
@@ -130,28 +135,6 @@ public class DefaultYarnContainerTests {
 	}
 
 	@Test
-	public void testContainerBeanThrowsExceptionTwoAnnotations() {
-		@SuppressWarnings("resource")
-		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(BaseConfig.class, TestBean5Config.class);
-		DefaultYarnContainer container = context.getBean(DefaultYarnContainer.class);
-		final StateWrapper stateWrapper = new StateWrapper();
-
-		container.addContainerStateListener(new ContainerStateListener() {
-			@Override
-			public void state(ContainerState state, Object exit) {
-				stateWrapper.state = state;
-				stateWrapper.exit = exit;
-			}
-		});
-
-		container.run();
-		assertThat(stateWrapper.state, is(ContainerState.FAILED));
-		assertThat(stateWrapper.exit, instanceOf(Exception.class));
-
-		context.stop();
-	}
-
-	@Test
 	public void testContainerStringBean() {
 		@SuppressWarnings("resource")
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(BaseConfig.class, TestBean6Config.class);
@@ -170,6 +153,215 @@ public class DefaultYarnContainerTests {
 		assertThat(stateWrapper.state, is(ContainerState.COMPLETED));
 		assertThat(stateWrapper.exit, instanceOf(String.class));
 		assertThat((String)stateWrapper.exit, is("UNKNOWN"));
+
+		context.stop();
+	}
+
+	@Test
+	public void testMultipleClasses() {
+		@SuppressWarnings("resource")
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(BaseConfig.class, MultipleClassesConfig.class);
+		DefaultYarnContainer container = context.getBean(DefaultYarnContainer.class);
+		final StateWrapper stateWrapper = new StateWrapper();
+
+		container.addContainerStateListener(new ContainerStateListener() {
+			@Override
+			public void state(ContainerState state, Object exit) {
+				stateWrapper.state = state;
+				stateWrapper.exit = exit;
+			}
+		});
+
+		container.run();
+		assertThat(stateWrapper.state, is(ContainerState.COMPLETED));
+		assertThat(stateWrapper.exit, instanceOf(Integer.class));
+		assertThat((Integer)stateWrapper.exit, is(0));
+
+		TestBean1 testBean1 = context.getBean(TestBean1.class);
+		TestBean7 testBean7 = context.getBean(TestBean7.class);
+		assertThat(testBean1.called, is(true));
+		assertThat(testBean7.called, is(true));
+
+		context.stop();
+	}
+
+	@Test
+	public void testMultipleMethods() {
+		@SuppressWarnings("resource")
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(BaseConfig.class, MultipleMethodsConfig.class);
+		DefaultYarnContainer container = context.getBean(DefaultYarnContainer.class);
+		final StateWrapper stateWrapper = new StateWrapper();
+
+		container.addContainerStateListener(new ContainerStateListener() {
+			@Override
+			public void state(ContainerState state, Object exit) {
+				stateWrapper.state = state;
+				stateWrapper.exit = exit;
+			}
+		});
+
+		container.run();
+		assertThat(stateWrapper.state, is(ContainerState.COMPLETED));
+		assertThat(stateWrapper.exit, instanceOf(Integer.class));
+		assertThat((Integer)stateWrapper.exit, is(0));
+
+		TestBean5 testBean5 = context.getBean(TestBean5.class);
+		assertThat(testBean5.called1, is(true));
+		assertThat(testBean5.called2, is(true));
+
+		context.stop();
+	}
+
+	@Test
+	public void testMultipleClassesAndMethods() {
+		@SuppressWarnings("resource")
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(BaseConfig.class, MultipleClassesAndMethodsConfig.class);
+		DefaultYarnContainer container = context.getBean(DefaultYarnContainer.class);
+		final StateWrapper stateWrapper = new StateWrapper();
+
+		container.addContainerStateListener(new ContainerStateListener() {
+			@Override
+			public void state(ContainerState state, Object exit) {
+				stateWrapper.state = state;
+				stateWrapper.exit = exit;
+			}
+		});
+
+		container.run();
+		assertThat(stateWrapper.state, is(ContainerState.COMPLETED));
+		assertThat(stateWrapper.exit, instanceOf(Integer.class));
+		assertThat((Integer)stateWrapper.exit, is(0));
+
+		TestBean1 testBean1 = context.getBean(TestBean1.class);
+		TestBean7 testBean7 = context.getBean(TestBean7.class);
+		TestBean5 testBean5 = context.getBean(TestBean5.class);
+		assertThat(testBean1.called, is(true));
+		assertThat(testBean7.called, is(true));
+		assertThat(testBean5.called1, is(true));
+		assertThat(testBean5.called2, is(true));
+
+		context.stop();
+	}
+
+	@Test
+	public void testOrderingByClass() {
+		@SuppressWarnings("resource")
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(BaseConfig.class, OrderingByClassConfig.class);
+		DefaultYarnContainer container = context.getBean(DefaultYarnContainer.class);
+		final StateWrapper stateWrapper = new StateWrapper();
+
+		container.addContainerStateListener(new ContainerStateListener() {
+			@Override
+			public void state(ContainerState state, Object exit) {
+				stateWrapper.state = state;
+				stateWrapper.exit = exit;
+			}
+		});
+
+		container.run();
+		assertThat(stateWrapper.state, is(ContainerState.COMPLETED));
+		assertThat(stateWrapper.exit, instanceOf(Integer.class));
+		assertThat((Integer)stateWrapper.exit, is(0));
+
+		TestBean8 testBean8 = context.getBean(TestBean8.class);
+		TestBean9 testBean9 = context.getBean(TestBean9.class);
+		assertThat(testBean8.called1, is(true));
+		assertThat(testBean8.called2, is(true));
+		assertThat(testBean8.called3, is(true));
+		assertThat(testBean9.called1, is(true));
+		assertThat(testBean9.called2, is(true));
+		assertThat(testBean9.called3, is(true));
+		assertThat(testBean9.order1, isOneOf(0,1,2));
+		assertThat(testBean9.order2, isOneOf(0,1,2));
+		assertThat(testBean9.order3, isOneOf(0,1,2));
+		assertThat(testBean8.order1, isOneOf(3,4,5));
+		assertThat(testBean8.order2, isOneOf(3,4,5));
+		assertThat(testBean8.order3, isOneOf(3,4,5));
+
+		context.stop();
+	}
+
+	@Test
+	public void testOrderingByMethod() {
+		@SuppressWarnings("resource")
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(BaseConfig.class, OrderingByMethodConfig.class);
+		DefaultYarnContainer container = context.getBean(DefaultYarnContainer.class);
+		final StateWrapper stateWrapper = new StateWrapper();
+
+		container.addContainerStateListener(new ContainerStateListener() {
+			@Override
+			public void state(ContainerState state, Object exit) {
+				stateWrapper.state = state;
+				stateWrapper.exit = exit;
+			}
+		});
+
+		container.run();
+		assertThat(stateWrapper.state, is(ContainerState.COMPLETED));
+		assertThat(stateWrapper.exit, instanceOf(Integer.class));
+		assertThat((Integer)stateWrapper.exit, is(0));
+
+		TestBean10 testBean10 = context.getBean(TestBean10.class);
+		assertThat(testBean10.called1, is(true));
+		assertThat(testBean10.called2, is(true));
+		assertThat(testBean10.called3, is(true));
+		assertThat(testBean10.order2, is(0));
+		assertThat(testBean10.order3, is(1));
+		assertThat(testBean10.order1, is(2));
+
+		context.stop();
+	}
+
+	@Test
+	public void testOrderingByMixedClassAndMethod() {
+		@SuppressWarnings("resource")
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(BaseConfig.class, OrderingByMixedClassAndMethodConfig.class);
+		DefaultYarnContainer container = context.getBean(DefaultYarnContainer.class);
+		final StateWrapper stateWrapper = new StateWrapper();
+
+		container.addContainerStateListener(new ContainerStateListener() {
+			@Override
+			public void state(ContainerState state, Object exit) {
+				stateWrapper.state = state;
+				stateWrapper.exit = exit;
+			}
+		});
+
+		container.run();
+		assertThat(stateWrapper.state, is(ContainerState.COMPLETED));
+		assertThat(stateWrapper.exit, instanceOf(List.class));
+		assertThat((Integer)((List<?>)stateWrapper.exit).get(9), is(1));
+		assertThat((Integer)((List<?>)stateWrapper.exit).get(11), is(2));
+
+		TestBean8 testBean8 = context.getBean(TestBean8.class);
+		TestBean9 testBean9 = context.getBean(TestBean9.class);
+		TestBean10 testBean10 = context.getBean(TestBean10.class);
+		TestBean11 testBean11 = context.getBean(TestBean11.class);
+		assertThat(testBean8.called1, is(true));
+		assertThat(testBean8.called2, is(true));
+		assertThat(testBean8.called3, is(true));
+		assertThat(testBean9.called1, is(true));
+		assertThat(testBean9.called2, is(true));
+		assertThat(testBean9.called3, is(true));
+		assertThat(testBean10.called1, is(true));
+		assertThat(testBean10.called2, is(true));
+		assertThat(testBean10.called3, is(true));
+		assertThat(testBean11.called1, is(true));
+		assertThat(testBean11.called2, is(true));
+		assertThat(testBean11.called3, is(true));
+
+		assertThat(testBean8.order1, isOneOf(3,4,5));
+		assertThat(testBean8.order2, isOneOf(3,4,5));
+		assertThat(testBean8.order3, isOneOf(3,4,5));
+		assertThat(testBean9.order1, isOneOf(0,1,2));
+		assertThat(testBean9.order2, isOneOf(0,1,2));
+		assertThat(testBean9.order3, isOneOf(0,1,2));
+		assertThat(testBean10.order1, is(8));
+		assertThat(testBean10.order2, is(6));
+		assertThat(testBean10.order3, is(7));
+		assertThat(testBean11.order1, is(10));
+		assertThat(testBean11.order2, is(9));
+		assertThat(testBean11.order3, is(11));
 
 		context.stop();
 	}
@@ -239,11 +431,93 @@ public class DefaultYarnContainerTests {
 		}
 	}
 
+	@Configuration
+	static class MultipleClassesConfig {
+		@Bean
+		TestBean1 testBean1() {
+			return new TestBean1();
+		}
+		@Bean
+		TestBean7 testBean7() {
+			return new TestBean7();
+		}
+	}
+
+	@Configuration
+	static class MultipleMethodsConfig {
+		@Bean
+		TestBean5 testBean5() {
+			return new TestBean5();
+		}
+	}
+
+	@Configuration
+	static class MultipleClassesAndMethodsConfig {
+		@Bean
+		TestBean1 testBean1() {
+			return new TestBean1();
+		}
+		@Bean
+		TestBean7 testBean7() {
+			return new TestBean7();
+		}
+		@Bean
+		TestBean5 testBean5() {
+			return new TestBean5();
+		}
+	}
+
+	@Configuration
+	static class OrderingByClassConfig {
+		private AtomicInteger executionOrder = new AtomicInteger();
+		@Bean
+		TestBean9 testBean9() {
+			return new TestBean9(executionOrder);
+		}
+		@Bean
+		TestBean8 testBean8() {
+			return new TestBean8(executionOrder);
+		}
+	}
+
+	@Configuration
+	static class OrderingByMethodConfig {
+		private AtomicInteger executionOrder = new AtomicInteger();
+		@Bean
+		TestBean10 testBean10() {
+			return new TestBean10(executionOrder);
+		}
+	}
+
+	@Configuration
+	static class OrderingByMixedClassAndMethodConfig {
+		private AtomicInteger executionOrder = new AtomicInteger();
+		@Bean
+		TestBean9 testBean9() {
+			return new TestBean9(executionOrder);
+		}
+		@Bean
+		TestBean8 testBean8() {
+			return new TestBean8(executionOrder);
+		}
+		@Bean
+		TestBean10 testBean10() {
+			return new TestBean10(executionOrder);
+		}
+		@Bean
+		TestBean11 testBean11() {
+			return new TestBean11(executionOrder);
+		}
+	}
+
 	@YarnComponent
 	private static class TestBean1 {
 
+		boolean called = false;
+
 		@OnContainerStart
 		public void test() {
+			called = true;
 		}
 	}
 
@@ -277,12 +551,17 @@ public class DefaultYarnContainerTests {
 	@YarnComponent
 	private static class TestBean5 {
 
+		boolean called1 = false;
+		boolean called2 = false;
+
 		@OnContainerStart
 		public void test1() {
+			called1 = true;
 		}
 
 		@OnContainerStart
 		public void test2() {
+			called2 = true;
 		}
 	}
 
@@ -292,6 +571,164 @@ public class DefaultYarnContainerTests {
 		@OnContainerStart
 		public String test() {
 			return ExitStatus.UNKNOWN.getExitCode();
+		}
+	}
+
+	@YarnComponent
+	private static class TestBean7 {
+
+		boolean called = false;
+
+		@OnContainerStart
+		public void test() {
+			called = true;
+		}
+	}
+
+	@YarnComponent
+	@Order(20)
+	private static class TestBean8 {
+
+		AtomicInteger executionOrder;
+		boolean called1 = false;
+		boolean called2 = false;
+		boolean called3 = false;
+		int order1 = -1;
+		int order2 = -1;
+		int order3 = -1;
+
+		TestBean8(AtomicInteger executionOrder) {
+			this.executionOrder = executionOrder;
+		}
+
+		@OnContainerStart
+		public void test2() {
+			called2 = true;
+			order2 = executionOrder.getAndIncrement();
+		}
+
+		@OnContainerStart
+		public void test1() {
+			called1 = true;
+			order1 = executionOrder.getAndIncrement();
+		}
+
+		@OnContainerStart
+		public void test3() {
+			called3 = true;
+			order3 = executionOrder.getAndIncrement();
+		}		// TestBean9 10
+
+	}
+
+	@YarnComponent
+	@Order(10)
+	private static class TestBean9 {
+
+		AtomicInteger executionOrder;
+		boolean called1 = false;
+		boolean called2 = false;
+		boolean called3 = false;
+		int order1 = -1;
+		int order2 = -1;
+		int order3 = -1;
+
+		TestBean9(AtomicInteger executionOrder) {
+			this.executionOrder = executionOrder;
+		}
+
+		@OnContainerStart
+		public void test1() {
+			called1 = true;
+			order1 = executionOrder.getAndIncrement();
+		}
+
+		@OnContainerStart
+		public void test2() {
+			called2 = true;
+			order2 = executionOrder.getAndIncrement();
+		}
+
+		@OnContainerStart
+		public void test3() {
+			called3 = true;
+			order3 = executionOrder.getAndIncrement();
+		}
+	}
+
+	@YarnComponent
+	private static class TestBean10 {
+
+		AtomicInteger executionOrder;
+		boolean called1 = false;
+		boolean called2 = false;
+		boolean called3 = false;
+		int order1 = -1;
+		int order2 = -1;
+		int order3 = -1;
+
+		TestBean10(AtomicInteger executionOrder) {
+			this.executionOrder = executionOrder;
+		}
+
+		@OnContainerStart
+		@Order(33)
+		public void test1() {
+			called1 = true;
+			order1 = executionOrder.getAndIncrement();
+		}
+
+		@OnContainerStart
+		@Order(31)
+		public void test2() {
+			called2 = true;
+			order2 = executionOrder.getAndIncrement();
+		}
+
+		@OnContainerStart
+		@Order(32)
+		public void test3() {
+			called3 = true;
+			order3 = executionOrder.getAndIncrement();
+		}
+	}
+
+	@YarnComponent
+	private static class TestBean11 {
+
+		AtomicInteger executionOrder;
+		boolean called1 = false;
+		boolean called2 = false;
+		boolean called3 = false;
+		int order1 = -1;
+		int order2 = -1;
+		int order3 = -1;
+
+		TestBean11(AtomicInteger executionOrder) {
+			this.executionOrder = executionOrder;
+		}
+
+		@OnContainerStart
+		@Order(42)
+		public void test1() {
+			called1 = true;
+			order1 = executionOrder.getAndIncrement();
+		}
+
+		@OnContainerStart
+		@Order(41)
+		public int test2() {
+			called2 = true;
+			order2 = executionOrder.getAndIncrement();
+			return 1;
+		}
+
+		@OnContainerStart
+		@Order(43)
+		public int test3() {
+			called3 = true;
+			order3 = executionOrder.getAndIncrement();
+			return 2;
 		}
 	}
 


### PR DESCRIPTION
- Add support for multiple @YarnComponent
  and @OnContainerStart annotations.
- Exit result from pojo invocation is now either
  single value or list of values if multiple
  methods are invoked.
