### PR TITLE
SHDP-427 DefaultPartitionStrategy doesn't use spel compiler

### DIFF
--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/expression/MapExpressionMethods.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/expression/MapExpressionMethods.java
@@ -15,12 +15,14 @@
  */
 package org.springframework.data.hadoop.store.expression;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
-import org.springframework.context.expression.MapAccessor;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.EvaluationException;
 import org.springframework.expression.Expression;
+import org.springframework.expression.MethodResolver;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.util.Assert;
 
@@ -56,8 +58,26 @@ public class MapExpressionMethods {
 		} else {
 			context = new StandardEvaluationContext();
 			context.addMethodResolver(new PartitionKeyMethodResolver());
-			context.addPropertyAccessor(new MapAccessor());
+			context.addPropertyAccessor(new MapPartitionKeyPropertyAccessor());
 		}
+	}
+
+	public MapExpressionMethods(StandardEvaluationContext evaluationContext, boolean autoCustomize, boolean replaceMethodResolver) {
+		Assert.notNull(evaluationContext, "Evaluation context cannot be null");
+		if (autoCustomize) {
+			MethodResolver methodResolver = new PartitionKeyMethodResolver();
+			if (replaceMethodResolver) {
+				List<MethodResolver> methodResolvers = new ArrayList<MethodResolver>();
+				methodResolvers.add(methodResolver);
+				evaluationContext.setMethodResolvers(methodResolvers);
+			} else {
+				evaluationContext.addMethodResolver(methodResolver);
+			}
+		}
+		if (autoCustomize) {
+			evaluationContext.addPropertyAccessor(new MapPartitionKeyPropertyAccessor());
+		}
+		this.context = evaluationContext;
 	}
 
 	/**

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/expression/MapPartitionKeyPropertyAccessor.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/expression/MapPartitionKeyPropertyAccessor.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.hadoop.store.expression;
+
+import java.util.Map;
+
+import org.springframework.asm.MethodVisitor;
+import org.springframework.expression.AccessException;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.PropertyAccessor;
+import org.springframework.expression.TypedValue;
+import org.springframework.expression.spel.CodeFlow;
+import org.springframework.expression.spel.CompilablePropertyAccessor;
+import org.springframework.expression.spel.support.ReflectivePropertyAccessor;
+
+/**
+ * A {@link PropertyAccessor} reading values from a backing {@link Map} used by a
+ * partition key.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class MapPartitionKeyPropertyAccessor extends ReflectivePropertyAccessor {
+
+	private final static Class<?>[] CLASSES = new Class<?>[] { Map.class };
+
+	private final static String mapClassDescriptor = "java/util/Map";
+
+	private volatile String typeDescriptor;
+
+	@Override
+	public Class<?>[] getSpecificTargetClasses() {
+		return CLASSES;
+	}
+
+	@Override
+	public boolean canRead(EvaluationContext context, Object target, String name) throws AccessException {
+		boolean containsKey = ((Map<?, ?>) target).containsKey(name);
+		if (containsKey) {
+			this.typeDescriptor = CodeFlow.toDescriptorFromObject(((Map<?, ?>) target).get(name));
+		}
+		return containsKey;
+	}
+
+	@Override
+	public TypedValue read(EvaluationContext context, Object target, String name) throws AccessException {
+		Map<?, ?> map = (Map<?, ?>) target;
+		Object value = map.get(name);
+		if (value == null && !map.containsKey(name)) {
+			throw new MapAccessException(name);
+		}
+		return new TypedValue(value);
+	}
+
+	@Override
+	public PropertyAccessor createOptimalAccessor(EvaluationContext evalContext, Object target, String name) {
+		return new MapOptimalPropertyAccessor(this.typeDescriptor);
+	}
+
+	public static class MapOptimalPropertyAccessor implements CompilablePropertyAccessor {
+
+		private final String typeDescriptor;
+
+		public MapOptimalPropertyAccessor(String typeDescriptor) {
+			this.typeDescriptor = typeDescriptor;
+		}
+
+		@Override
+		public Class<?>[] getSpecificTargetClasses() {
+			throw new UnsupportedOperationException("Should not be called on an MessageOptimalPropertyAccessor");
+		}
+
+		@Override
+		public boolean canRead(EvaluationContext context, Object target, String name) throws AccessException {
+			return true;
+		}
+
+		@Override
+		public TypedValue read(EvaluationContext context, Object target, String name) throws AccessException {
+			return new TypedValue(((Map<?,?>) target).get(name));
+		}
+
+		@Override
+		public boolean canWrite(EvaluationContext context, Object target, String name) throws AccessException {
+			throw new UnsupportedOperationException("Should not be called on an MessageOptimalPropertyAccessor");
+		}
+
+		@Override
+		public void write(EvaluationContext context, Object target, String name, Object newValue)
+				throws AccessException {
+			throw new UnsupportedOperationException("Should not be called on an MessageOptimalPropertyAccessor");
+		}
+
+		@Override
+		public boolean isCompilable() {
+			return true;
+		}
+
+		@Override
+		public Class<?> getPropertyType() {
+			return Object.class;
+		}
+
+		@Override
+		public void generateCode(String propertyName, MethodVisitor mv, CodeFlow cf) {
+			String descriptor = cf.lastDescriptor();
+
+			if (descriptor == null) {
+				cf.loadTarget(mv);
+			}
+			if (descriptor == null || !mapClassDescriptor.equals(descriptor.substring(1))) {
+				mv.visitTypeInsn(CHECKCAST, mapClassDescriptor);
+			}
+
+			mv.visitLdcInsn(propertyName);
+			mv.visitMethodInsn(INVOKEINTERFACE, mapClassDescriptor, "get",
+					"(Ljava/lang/Object;)Ljava/lang/Object;", true);
+
+			if (typeDescriptor != null) {
+				CodeFlow.insertCheckCast(mv, typeDescriptor);
+			}
+		}
+
+	}
+
+	/**
+	 * Exception thrown from {@code read} in order to reset a cached
+	 * PropertyAccessor, allowing other accessors to have a try.
+	 */
+	@SuppressWarnings("serial")
+	private static class MapAccessException extends AccessException {
+
+		private final String key;
+
+		public MapAccessException(String key) {
+			super(null);
+			this.key = key;
+		}
+
+		@Override
+		public String getMessage() {
+			return "Map does not contain a value for key '" + this.key + "'";
+		}
+	}
+
+}

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/expression/MapExpressionMethodsTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/expression/MapExpressionMethodsTests.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.hadoop.store.expression;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+import org.springframework.context.expression.MapAccessor;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+public class MapExpressionMethodsTests {
+
+	@Test
+	public void testRawExpressions() {
+		Map<String, Object> message = new HashMap<String, Object>();
+		Map<String, Object> headers = new HashMap<String, Object>();
+		headers.put("timestamp", System.currentTimeMillis());
+		message.put("payload", "jee");
+		message.put("timestamp", System.currentTimeMillis());
+		message.put("headerkey", "headervalue");
+		message.put("headers", headers);
+
+		String nowYYYYMM = new SimpleDateFormat("yyyy/MM").format(new Date());
+
+		ExpressionParser parser = new SpelExpressionParser();
+		StandardEvaluationContext context = new StandardEvaluationContext();
+		PartitionKeyMethodResolver resolver = new PartitionKeyMethodResolver();
+		context.addMethodResolver(resolver);
+		context.addPropertyAccessor(new MapAccessor());
+
+		assertThat(parser.parseExpression("dateFormat('yyyy/MM', headers[timestamp])").getValue(context, message, String.class), is(nowYYYYMM));
+		assertThat(parser.parseExpression("dateFormat('yyyy/MM', timestamp)").getValue(context, message, String.class), is(nowYYYYMM));
+		assertThat(parser.parseExpression("dateFormat('yyyy/MM', T(java.lang.System).currentTimeMillis())").getValue(context, message, String.class), is(nowYYYYMM));
+		assertThat(parser.parseExpression("path('yyyy', 'MM')").getValue(context, message, String.class), is("yyyy/MM"));
+		assertThat(parser.parseExpression("path('yyyy', 'MM', payload.substring(0,3))").getValue(context, message, String.class), is("yyyy/MM/jee"));
+		assertThat(parser.parseExpression("headerkey").getValue(context, message, String.class), is("headervalue"));
+		assertThat(parser.parseExpression("headers.timestamp").getValue(context, message, Long.class), greaterThan(0l));
+		assertThat(parser.parseExpression("headers[timestamp]").getValue(context, message, Long.class), greaterThan(0l));
+		assertThat(parser.parseExpression("payload").getValue(context, message, String.class), is("jee"));
+	}
+
+}

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/expression/MapPartitionKeyPropertyAccessorTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/expression/MapPartitionKeyPropertyAccessorTests.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.hadoop.store.expression;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+import org.springframework.expression.PropertyAccessor;
+
+public class MapPartitionKeyPropertyAccessorTests extends AbstractExpressionTests {
+
+	@Test
+	public void testCompilables() throws Exception {
+		PartitionKeyMethodResolver resolver = new PartitionKeyMethodResolver();
+		MapPartitionKeyPropertyAccessor accessor = new MapPartitionKeyPropertyAccessor();
+		Long timestamp = System.currentTimeMillis();
+		Map<String, Object> rootObject = new HashMap<String, Object>();
+		Map<String, Object> headers = new HashMap<String, Object>();
+		rootObject.put("onestring", "1");
+		rootObject.put("oneint", 1);
+		headers.put("timestamp", timestamp);
+		rootObject.put("foo", "bar");
+		rootObject.put("payload", "foo-bar");
+		rootObject.put("timestamp", timestamp);
+		rootObject.put("headers", headers);
+
+
+		assertExpression((PropertyAccessor)null, "payload", "foo-bar", true);
+		assertExpression((PropertyAccessor)null, rootObject, "'foo' + 'bar'", "foobar", true);
+		assertExpression(accessor, "payload", "foo-bar", true);
+		assertExpression(accessor, rootObject, "headers.timestamp", timestamp.toString(), true);
+		assertExpression(accessor, rootObject, "timestamp", timestamp.toString(), true);
+		assertExpression(accessor, rootObject, "foo", "bar", true);
+
+		assertExpression(accessor, rootObject,
+				"T(Long).valueOf(headers.timestamp).toString() + '/' + T(Long).valueOf(headers.timestamp).toString()",
+				timestamp.toString() + "/" + timestamp.toString(), true);
+
+		assertExpression(accessor, rootObject,
+				"T(Long).valueOf(timestamp).toString() + '/' + T(Long).valueOf(timestamp).toString()",
+				timestamp.toString() + "/" + timestamp.toString(), true);
+
+		assertExpression(accessor, rootObject,
+				"T(Integer).valueOf(oneint).toString() + '/' + T(Integer).valueOf(oneint).toString()",
+				"1/1", true);
+
+		assertExpression(accessor, rootObject, "oneint", "1", true);
+		assertExpression(accessor, rootObject, "onestring", "1", true);
+
+		assertExpression(accessor, rootObject, "foo + foo", "barbar", true);
+		assertExpression(accessor, rootObject, "foo + onestring", "bar1", true);
+		assertExpression(accessor, rootObject, "foo + '/' + foo", "bar/bar", true);
+		assertExpression(resolver, accessor, false, rootObject, "path(foo,foo)", "bar/bar", true);
+
+		assertExpression(resolver, null, false, rootObject, "path('foo','bar')", "foo/bar", true);
+		assertExpression(resolver, accessor, false, rootObject, "path(headers.timestamp)", timestamp.toString(), true);
+		assertExpression(resolver, accessor, false, rootObject, "path(headers.timestamp,headers.timestamp)",
+				timestamp.toString() + "/" + timestamp.toString(), true);
+
+	}
+
+
+}

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/partition/DefaultPartitionStrategyPerfTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/partition/DefaultPartitionStrategyPerfTests.java
@@ -16,6 +16,10 @@
 package org.springframework.data.hadoop.store.partition;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.apache.hadoop.fs.Path;
 import org.junit.Test;
@@ -30,8 +34,6 @@ import org.springframework.expression.spel.SpelCompilerMode;
 import org.springframework.expression.spel.SpelParserConfiguration;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
-import org.springframework.messaging.Message;
-import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.util.StopWatch;
 
@@ -43,7 +45,7 @@ import org.springframework.util.StopWatch;
  */
 @ContextConfiguration(loader=HadoopDelegatingSmartContextLoader.class)
 @MiniHadoopCluster
-public class PartitionPerfTests extends AbstractStoreTests {
+public class DefaultPartitionStrategyPerfTests extends AbstractStoreTests {
 
 	private final int COUNT = 50000;
 //	private final int COUNT = 1000000;
@@ -109,12 +111,12 @@ public class PartitionPerfTests extends AbstractStoreTests {
 		Assume.group(TestGroup.PERFORMANCE);
 		String expression = "list(payload.split('\u0001')[0],{{'1TO5','APP1','APP2','APP3','APP4','APP5'},{'6TO10','APP6','APP7','APP8','APP9','APP10'}})";
 
-		@SuppressWarnings("unchecked")
-		Message<String>[] messages = new Message[10];
+		ArrayList<Map<String, Object>> messages = new ArrayList<Map<String,Object>>();
 		for (int i = 0; i<10; i++) {
 			String payload = "APP" + (i+1) + "\u0001" + "somedata";
-			Message<String> message = MessageBuilder.withPayload(payload).build();
-			messages[i] = message;
+			Map<String, Object> message = new HashMap<String, Object>();
+			message.put("payload", payload);
+			messages.add(message);
 		}
 
 		testPerformance("testLargeList", expression, messages);
@@ -139,12 +141,12 @@ public class PartitionPerfTests extends AbstractStoreTests {
 		Assume.group(TestGroup.PERFORMANCE);
 		String expression = "payload.split('\u0001')[0]";
 
-		@SuppressWarnings("unchecked")
-		Message<String>[] messages = new Message[1];
+		ArrayList<Map<String, Object>> messages = new ArrayList<Map<String,Object>>();
 		for (int i = 0; i<1; i++) {
 			String payload = "APP" + (i+1) + "\u0001" + "somedata";
-			Message<String> message = MessageBuilder.withPayload(payload).build();
-			messages[i] = message;
+			Map<String, Object> message = new HashMap<String, Object>();
+			message.put("payload", payload);
+			messages.add(message);
 		}
 
 		testPerformance("testWithPayloadSplit", expression, messages);
@@ -155,12 +157,12 @@ public class PartitionPerfTests extends AbstractStoreTests {
 		Assume.group(TestGroup.PERFORMANCE);
 		String expression = "list(payload.split('\u0001')[0],{{'1TO5','APP1'}})";
 
-		@SuppressWarnings("unchecked")
-		Message<String>[] messages = new Message[1];
+		ArrayList<Map<String, Object>> messages = new ArrayList<Map<String,Object>>();
 		for (int i = 0; i<1; i++) {
 			String payload = "APP" + (i+1) + "\u0001" + "somedata";
-			Message<String> message = MessageBuilder.withPayload(payload).build();
-			messages[i] = message;
+			Map<String, Object> message = new HashMap<String, Object>();
+			message.put("payload", payload);
+			messages.add(message);
 		}
 
 		testPerformance("testListWithPayloadSplit", expression, messages);
@@ -171,12 +173,12 @@ public class PartitionPerfTests extends AbstractStoreTests {
 		Assume.group(TestGroup.PERFORMANCE);
 		String expression = "list(payload,{{'1TO5','APP1'}})";
 
-		@SuppressWarnings("unchecked")
-		Message<String>[] messages = new Message[1];
+		ArrayList<Map<String, Object>> messages = new ArrayList<Map<String,Object>>();
 		for (int i = 0; i<1; i++) {
-			String payload = "APP" + (i+1);
-			Message<String> message = MessageBuilder.withPayload(payload).build();
-			messages[i] = message;
+			String payload = "APP" + (i+1) + "\u0001" + "somedata";
+			Map<String, Object> message = new HashMap<String, Object>();
+			message.put("payload", payload);
+			messages.add(message);
 		}
 
 		testPerformance("testListWithPayload", expression, messages);
@@ -196,7 +198,7 @@ public class PartitionPerfTests extends AbstractStoreTests {
 	@Test
 	public void testPartitioningWithDateFormat() throws IOException {
 		Assume.group(TestGroup.PERFORMANCE);
-		String expression = "dateFormat('yyyy/MM')";
+		String expression = "dateFormat('yyyy/MM',timestamp)";
 		testPerformance("testPartitioningWithDateFormat", expression);
 	}
 
@@ -206,14 +208,15 @@ public class PartitionPerfTests extends AbstractStoreTests {
 	@Test
 	public void testDateFormatAndListAndPayloadSplit() throws IOException {
 		Assume.group(TestGroup.PERFORMANCE);
-		String expression = "path(dateFormat('yyyy/MM/dd'),list(payload.split('\u0001')[0],{{'1TO5','APP1','APP2','APP3','APP4','APP5'},{'6TO10','APP6','APP7','APP8','APP9','APP10'}}))";
+		String expression = "path(dateFormat('yyyy/MM/dd',timestamp),list(payload.split('\u0001')[0],{{'1TO5','APP1','APP2','APP3','APP4','APP5'},{'6TO10','APP6','APP7','APP8','APP9','APP10'}}))";
 
-		@SuppressWarnings("unchecked")
-		Message<String>[] messages = new Message[10];
+		ArrayList<Map<String, Object>> messages = new ArrayList<Map<String,Object>>();
 		for (int i = 0; i<10; i++) {
 			String payload = "APP" + (i+1) + "\u0001" + "somedata";
-			Message<String> message = MessageBuilder.withPayload(payload).build();
-			messages[i] = message;
+			Map<String, Object> message = new HashMap<String, Object>();
+			message.put("payload", payload);
+			message.put("timestamp", 0);
+			messages.add(message);
 		}
 
 		testPerformance("testDateFormatAndListAndPayloadSplit", expression, messages);
@@ -224,12 +227,12 @@ public class PartitionPerfTests extends AbstractStoreTests {
 		Assume.group(TestGroup.PERFORMANCE);
 		String expression = "path(payload.split('\u0001')[0])";
 
-		@SuppressWarnings("unchecked")
-		Message<String>[] messages = new Message[10];
+		ArrayList<Map<String, Object>> messages = new ArrayList<Map<String,Object>>();
 		for (int i = 0; i<10; i++) {
 			String payload = "APP" + (i+1) + "\u0001" + "somedata";
-			Message<String> message = MessageBuilder.withPayload(payload).build();
-			messages[i] = message;
+			Map<String, Object> message = new HashMap<String, Object>();
+			message.put("payload", payload);
+			messages.add(message);
 		}
 
 		testPerformance("testUsePayload1", expression, messages);
@@ -240,12 +243,12 @@ public class PartitionPerfTests extends AbstractStoreTests {
 		Assume.group(TestGroup.PERFORMANCE);
 		String expression = "path(payload.split('-')[0])";
 
-		@SuppressWarnings("unchecked")
-		Message<String>[] messages = new Message[10];
+		ArrayList<Map<String, Object>> messages = new ArrayList<Map<String,Object>>();
 		for (int i = 0; i<10; i++) {
-			String payload = "APP" + (i+1) + "-somedata";
-			Message<String> message = MessageBuilder.withPayload(payload).build();
-			messages[i] = message;
+			String payload = "APP" + (i+1) + "\u0001" + "somedata";
+			Map<String, Object> message = new HashMap<String, Object>();
+			message.put("payload", payload);
+			messages.add(message);
 		}
 
 		testPerformance("testUsePayload2", expression, messages);
@@ -256,12 +259,12 @@ public class PartitionPerfTests extends AbstractStoreTests {
 		Assume.group(TestGroup.PERFORMANCE);
 		String expression = "path(payload)";
 
-		@SuppressWarnings("unchecked")
-		Message<String>[] messages = new Message[10];
+		ArrayList<Map<String, Object>> messages = new ArrayList<Map<String,Object>>();
 		for (int i = 0; i<10; i++) {
-			String payload = "APP" + (i+1);
-			Message<String> message = MessageBuilder.withPayload(payload).build();
-			messages[i] = message;
+			String payload = "APP" + (i+1) + "\u0001" + "somedata";
+			Map<String, Object> message = new HashMap<String, Object>();
+			message.put("payload", payload);
+			messages.add(message);
 		}
 
 		testPerformance("testUsePayload3", expression, messages);
@@ -272,65 +275,64 @@ public class PartitionPerfTests extends AbstractStoreTests {
 		Assume.group(TestGroup.PERFORMANCE);
 		String expression = "path(T(org.springframework.util.StringUtils).split(payload,'-')[0])";
 
-		@SuppressWarnings("unchecked")
-		Message<String>[] messages = new Message[10];
+		ArrayList<Map<String, Object>> messages = new ArrayList<Map<String,Object>>();
 		for (int i = 0; i<10; i++) {
 			String payload = "APP" + (i+1) + "-somedata";
-			Message<String> message = MessageBuilder.withPayload(payload).build();
-			messages[i] = message;
+			Map<String, Object> message = new HashMap<String, Object>();
+			message.put("payload", payload);
+			messages.add(message);
 		}
 
 		testPerformance("testUsePayload4", expression, messages);
 	}
 
 	private void testPerformance(String name, String expression) throws IOException {
-		Message<String> message = MessageBuilder.withPayload("dummy").build();
-
-		@SuppressWarnings("unchecked")
-		Message<String>[] messages = new Message[1];
-		messages[0] = message;
-
+		ArrayList<Map<String, Object>> messages = new ArrayList<Map<String,Object>>(1);
+		Map<String, Object> message = new HashMap<String, Object>();
+		message.put("payload", "dummy");
+		message.put("timestamp", 0);
+		messages.add(message);
 		testPerformance(name, expression, messages);
 	}
 
-	private void testPerformance(String name, String expression, Message<String>[] messages) throws IOException {
+	private void testPerformance(String name, String expression, List<Map<String, Object>> messages) throws IOException {
 		// customexecutor
-		MessagePartitionStrategy<String> strategy1 = new MessagePartitionStrategy<String>(expression,
+		DefaultPartitionStrategy<String> strategy1 = new DefaultPartitionStrategy<String>(expression,
 				new StandardEvaluationContext());
-		PartitionTextFileWriter<Message<?>> writer1 = new PartitionTextFileWriter<Message<?>>(getConfiguration(),
+		PartitionTextFileWriter<Map<String, Object>> writer1 = new PartitionTextFileWriter<Map<String, Object>>(getConfiguration(),
 				new Path(testDefaultPath, "1"), null, strategy1);
 
 		// reflection
-		MessagePartitionStrategy<String> strategy2 = new MessagePartitionStrategy<String>(expression,
+		DefaultPartitionStrategy<String> strategy2 = new DefaultPartitionStrategy<String>(expression,
 				new StandardEvaluationContext(), new SpelExpressionParser(new SpelParserConfiguration(SpelCompilerMode.OFF, null)));
-		PartitionTextFileWriter<Message<?>> writer2 = new PartitionTextFileWriter<Message<?>>(getConfiguration(),
+		PartitionTextFileWriter<Map<String, Object>> writer2 = new PartitionTextFileWriter<Map<String, Object>>(getConfiguration(),
 				new Path(testDefaultPath, "2"), null, strategy2);
 
 		// compile
-		MessagePartitionStrategy<String> strategy3 = new MessagePartitionStrategy<String>(expression,
+		DefaultPartitionStrategy<String> strategy3 = new DefaultPartitionStrategy<String>(expression,
 				new StandardEvaluationContext(), new SpelExpressionParser(new SpelParserConfiguration(SpelCompilerMode.IMMEDIATE, null)));
-		PartitionTextFileWriter<Message<?>> writer3 = new PartitionTextFileWriter<Message<?>>(getConfiguration(),
+		PartitionTextFileWriter<Map<String, Object>> writer3 = new PartitionTextFileWriter<Map<String, Object>>(getConfiguration(),
 				new Path(testDefaultPath, "3"), null, strategy3);
 
 		StopWatch sw = new StopWatch(name);
 
 		sw.start("customexecutor");
 		for (int i = 0; i<COUNT; i++) {
-			writer1.write(DATA10, messages[i%messages.length]);
+			writer1.write(DATA10, messages.get(i%messages.size()));
 		}
 		sw.stop();
 		writer1.close();
 
 		sw.start("reflection");
 		for (int i = 0; i<COUNT; i++) {
-			writer2.write(DATA10, messages[i%messages.length]);
+			writer2.write(DATA10, messages.get(i%messages.size()));
 		}
 		sw.stop();
 		writer2.close();
 
 		sw.start("compile");
 		for (int i = 0; i<COUNT; i++) {
-			writer3.write(DATA10, messages[i%messages.length]);
+			writer3.write(DATA10, messages.get(i%messages.size()));
 		}
 		sw.stop();
 		writer3.close();

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/partition/MessagePartitionStrategyPerfTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/partition/MessagePartitionStrategyPerfTests.java
@@ -1,0 +1,347 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.hadoop.store.partition;
+
+import java.io.IOException;
+
+import org.apache.hadoop.fs.Path;
+import org.junit.Test;
+import org.springframework.data.hadoop.store.AbstractStoreTests;
+import org.springframework.data.hadoop.store.output.PartitionTextFileWriter;
+import org.springframework.data.hadoop.store.output.TextFileWriter;
+import org.springframework.data.hadoop.test.context.HadoopDelegatingSmartContextLoader;
+import org.springframework.data.hadoop.test.context.MiniHadoopCluster;
+import org.springframework.data.hadoop.test.tests.Assume;
+import org.springframework.data.hadoop.test.tests.TestGroup;
+import org.springframework.expression.spel.SpelCompilerMode;
+import org.springframework.expression.spel.SpelParserConfiguration;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.util.StopWatch;
+
+/**
+ * Performance tests for store writers.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@ContextConfiguration(loader=HadoopDelegatingSmartContextLoader.class)
+@MiniHadoopCluster
+public class MessagePartitionStrategyPerfTests extends AbstractStoreTests {
+
+	private final int COUNT = 50000;
+//	private final int COUNT = 1000000;
+//	private final int COUNT = 1000;
+
+	/**
+	 * Getting baseline perf number for using a single writer and
+	 * no partitioning. We can compare all other tests to this number.
+	 */
+	@Test
+	public void testBaseline() throws IOException {
+		Assume.group(TestGroup.PERFORMANCE);
+		StopWatch sw = new StopWatch("testBaseline");
+		sw.start();
+		TextFileWriter writer = new TextFileWriter(getConfiguration(), testDefaultPath, null);
+		for (int i = 0; i<COUNT; i++) {
+			writer.write(DATA10);
+		}
+		sw.stop();
+		writer.close();
+		System.out.println(sw.prettyPrint());
+	}
+
+	/**
+	 * Using a dummy partition expression which simply makes sure that
+	 * we are using an expression for partitioning. We only get one
+	 * partition with this.
+	 */
+	@Test
+	public void testDummyPartitionExpressionStringConcat() throws IOException {
+		Assume.group(TestGroup.PERFORMANCE);
+		String expression = "'dummy' + '/' + 'partition'";
+		testPerformance("testDummyPartitionExpressionStringConcat", expression);
+	}
+
+	@Test
+	public void testDummyPartitionExpressionIntSum() throws IOException {
+		Assume.group(TestGroup.PERFORMANCE);
+		String expression = "1 + 1";
+		testPerformance("testDummyPartitionExpressionIntSum", expression);
+	}
+
+	/**
+	 * Same as {@link #testDummyPartitionExpressionStringConcat()} but using a path
+	 * function in an expression.
+	 */
+	@Test
+	public void testDummyPartitionWithPathFunction() throws IOException {
+		Assume.group(TestGroup.PERFORMANCE);
+		String expression = "path('dummy','partition')";
+		testPerformance("testDummyPartitionWithPathFunction", expression);
+	}
+
+	@Test
+	public void testPartitionWithHashRange() throws IOException {
+		Assume.group(TestGroup.PERFORMANCE);
+		String expression = "range(1,{3,5,10})";
+		testPerformance("testPartitionWithHashRange", expression);
+	}
+
+	@Test
+	public void testLargeList() throws IOException {
+		Assume.group(TestGroup.PERFORMANCE);
+		String expression = "list(payload.split('\u0001')[0],{{'1TO5','APP1','APP2','APP3','APP4','APP5'},{'6TO10','APP6','APP7','APP8','APP9','APP10'}})";
+
+		@SuppressWarnings("unchecked")
+		Message<String>[] messages = new Message[10];
+		for (int i = 0; i<10; i++) {
+			String payload = "APP" + (i+1) + "\u0001" + "somedata";
+			Message<String> message = MessageBuilder.withPayload(payload).build();
+			messages[i] = message;
+		}
+
+		testPerformance("testLargeList", expression, messages);
+	}
+
+	@Test
+	public void testListWithConstant() throws IOException {
+		Assume.group(TestGroup.PERFORMANCE);
+		String expression = "list('APP1',{{'1TO5','APP1'}})";
+		testPerformance("testListWithConstant", expression);
+	}
+
+	@Test
+	public void testPathAndListWithConstant() throws IOException {
+		Assume.group(TestGroup.PERFORMANCE);
+		String expression = "path(list('APP1',{{'1TO5','APP1'}}))";
+		testPerformance("testPathAndListWithConstant", expression);
+	}
+
+	@Test
+	public void testWithPayloadSplit() throws IOException {
+		Assume.group(TestGroup.PERFORMANCE);
+		String expression = "payload.split('\u0001')[0]";
+
+		@SuppressWarnings("unchecked")
+		Message<String>[] messages = new Message[1];
+		for (int i = 0; i<1; i++) {
+			String payload = "APP" + (i+1) + "\u0001" + "somedata";
+			Message<String> message = MessageBuilder.withPayload(payload).build();
+			messages[i] = message;
+		}
+
+		testPerformance("testWithPayloadSplit", expression, messages);
+	}
+
+	@Test
+	public void testListWithPayloadSplit() throws IOException {
+		Assume.group(TestGroup.PERFORMANCE);
+		String expression = "list(payload.split('\u0001')[0],{{'1TO5','APP1'}})";
+
+		@SuppressWarnings("unchecked")
+		Message<String>[] messages = new Message[1];
+		for (int i = 0; i<1; i++) {
+			String payload = "APP" + (i+1) + "\u0001" + "somedata";
+			Message<String> message = MessageBuilder.withPayload(payload).build();
+			messages[i] = message;
+		}
+
+		testPerformance("testListWithPayloadSplit", expression, messages);
+	}
+
+	@Test
+	public void testListWithPayload() throws IOException {
+		Assume.group(TestGroup.PERFORMANCE);
+		String expression = "list(payload,{{'1TO5','APP1'}})";
+
+		@SuppressWarnings("unchecked")
+		Message<String>[] messages = new Message[1];
+		for (int i = 0; i<1; i++) {
+			String payload = "APP" + (i+1);
+			Message<String> message = MessageBuilder.withPayload(payload).build();
+			messages[i] = message;
+		}
+
+		testPerformance("testListWithPayload", expression, messages);
+	}
+
+	@Test
+	public void testPartitionWithPathAndHashRange() throws IOException {
+		Assume.group(TestGroup.PERFORMANCE);
+		String expression = "path(range(1,{3,5,10}))";
+		testPerformance("testPartitionWithPathAndHashRange", expression);
+	}
+
+	/**
+	 * Using an internal dataFormat function for partition path. Uses only
+	 * one partition.
+	 */
+	@Test
+	public void testPartitioningWithDateFormat() throws IOException {
+		Assume.group(TestGroup.PERFORMANCE);
+		String expression = "dateFormat('yyyy/MM')";
+		testPerformance("testPartitioningWithDateFormat", expression);
+	}
+
+	/**
+	 * Using dateFormat, list function with a stripping list id from a payload.
+	 */
+	@Test
+	public void testDateFormatAndListAndPayloadSplit() throws IOException {
+		Assume.group(TestGroup.PERFORMANCE);
+		String expression = "path(dateFormat('yyyy/MM/dd'),list(payload.split('\u0001')[0],{{'1TO5','APP1','APP2','APP3','APP4','APP5'},{'6TO10','APP6','APP7','APP8','APP9','APP10'}}))";
+
+		@SuppressWarnings("unchecked")
+		Message<String>[] messages = new Message[10];
+		for (int i = 0; i<10; i++) {
+			String payload = "APP" + (i+1) + "\u0001" + "somedata";
+			Message<String> message = MessageBuilder.withPayload(payload).build();
+			messages[i] = message;
+		}
+
+		testPerformance("testDateFormatAndListAndPayloadSplit", expression, messages);
+	}
+
+	@Test
+	public void testUsePayload1() throws IOException {
+		Assume.group(TestGroup.PERFORMANCE);
+		String expression = "path(payload.split('\u0001')[0])";
+
+		@SuppressWarnings("unchecked")
+		Message<String>[] messages = new Message[10];
+		for (int i = 0; i<10; i++) {
+			String payload = "APP" + (i+1) + "\u0001" + "somedata";
+			Message<String> message = MessageBuilder.withPayload(payload).build();
+			messages[i] = message;
+		}
+
+		testPerformance("testUsePayload1", expression, messages);
+	}
+
+	@Test
+	public void testUsePayload2() throws IOException {
+		Assume.group(TestGroup.PERFORMANCE);
+		String expression = "path(payload.split('-')[0])";
+
+		@SuppressWarnings("unchecked")
+		Message<String>[] messages = new Message[10];
+		for (int i = 0; i<10; i++) {
+			String payload = "APP" + (i+1) + "-somedata";
+			Message<String> message = MessageBuilder.withPayload(payload).build();
+			messages[i] = message;
+		}
+
+		testPerformance("testUsePayload2", expression, messages);
+	}
+
+	@Test
+	public void testUsePayload3() throws IOException {
+		Assume.group(TestGroup.PERFORMANCE);
+		String expression = "path(payload)";
+
+		@SuppressWarnings("unchecked")
+		Message<String>[] messages = new Message[10];
+		for (int i = 0; i<10; i++) {
+			String payload = "APP" + (i+1);
+			Message<String> message = MessageBuilder.withPayload(payload).build();
+			messages[i] = message;
+		}
+
+		testPerformance("testUsePayload3", expression, messages);
+	}
+
+	@Test
+	public void testUsePayload4() throws IOException {
+		Assume.group(TestGroup.PERFORMANCE);
+		String expression = "path(T(org.springframework.util.StringUtils).split(payload,'-')[0])";
+
+		@SuppressWarnings("unchecked")
+		Message<String>[] messages = new Message[10];
+		for (int i = 0; i<10; i++) {
+			String payload = "APP" + (i+1) + "-somedata";
+			Message<String> message = MessageBuilder.withPayload(payload).build();
+			messages[i] = message;
+		}
+
+		testPerformance("testUsePayload4", expression, messages);
+	}
+
+	private void testPerformance(String name, String expression) throws IOException {
+		Message<String> message = MessageBuilder.withPayload("dummy").build();
+
+		@SuppressWarnings("unchecked")
+		Message<String>[] messages = new Message[1];
+		messages[0] = message;
+
+		testPerformance(name, expression, messages);
+	}
+
+	private void testPerformance(String name, String expression, Message<String>[] messages) throws IOException {
+		// customexecutor
+		MessagePartitionStrategy<String> strategy1 = new MessagePartitionStrategy<String>(expression,
+				new StandardEvaluationContext());
+		PartitionTextFileWriter<Message<?>> writer1 = new PartitionTextFileWriter<Message<?>>(getConfiguration(),
+				new Path(testDefaultPath, "1"), null, strategy1);
+
+		// reflection
+		MessagePartitionStrategy<String> strategy2 = new MessagePartitionStrategy<String>(expression,
+				new StandardEvaluationContext(), new SpelExpressionParser(new SpelParserConfiguration(SpelCompilerMode.OFF, null)));
+		PartitionTextFileWriter<Message<?>> writer2 = new PartitionTextFileWriter<Message<?>>(getConfiguration(),
+				new Path(testDefaultPath, "2"), null, strategy2);
+
+		// compile
+		MessagePartitionStrategy<String> strategy3 = new MessagePartitionStrategy<String>(expression,
+				new StandardEvaluationContext(), new SpelExpressionParser(new SpelParserConfiguration(SpelCompilerMode.IMMEDIATE, null)));
+		PartitionTextFileWriter<Message<?>> writer3 = new PartitionTextFileWriter<Message<?>>(getConfiguration(),
+				new Path(testDefaultPath, "3"), null, strategy3);
+
+		StopWatch sw = new StopWatch(name);
+
+		sw.start("customexecutor");
+		for (int i = 0; i<COUNT; i++) {
+			writer1.write(DATA10, messages[i%messages.length]);
+		}
+		sw.stop();
+		writer1.close();
+
+		sw.start("reflection");
+		for (int i = 0; i<COUNT; i++) {
+			writer2.write(DATA10, messages[i%messages.length]);
+		}
+		sw.stop();
+		writer2.close();
+
+		sw.start("compile");
+		for (int i = 0; i<COUNT; i++) {
+			writer3.write(DATA10, messages[i%messages.length]);
+		}
+		sw.stop();
+		writer3.close();
+
+		System.out.println("Expression: " + expression);
+		System.out.println(sw.prettyPrint());
+	}
+
+	@org.springframework.context.annotation.Configuration
+	static class Config {
+		// just empty to survive without xml configs
+	}
+
+}


### PR DESCRIPTION
- Change DefaultPartitionStrategy and its downstream classes
  to use spel compiler.
- Added new MapPartitionKeyPropertyAccessor to make normal
  MapAccessor functionality compilable.
