### PR TITLE
SHDP-436 Add exit wait to poller task

### DIFF
--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/AbstractPartitionDataStoreWriter.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/AbstractPartitionDataStoreWriter.java
@@ -399,7 +399,11 @@ public abstract class AbstractPartitionDataStoreWriter<T, K> extends LifecycleOb
 		// sync with writer create in write()
 		synchronized (writers) {
 			DataStoreWriter<T> writer = writers.remove(path);
-			log.info("Removing writer=[" + writer + "]");
+			if (writer != null) {
+				log.info("Removed writer=[" + writer + "]");
+			} else {
+				log.info("Writer with path=[" + path + "] didn't exist anymore");
+			}
 		}
 	}
 

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/support/PollingTaskSupport.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/support/PollingTaskSupport.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,13 @@
 package org.springframework.data.hadoop.store.support;
 
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.Trigger;
@@ -35,6 +39,8 @@ import org.springframework.util.Assert;
  */
 public abstract class PollingTaskSupport<T> {
 
+	private static final Log log = LogFactory.getLog(PollingTaskSupport.class);
+
 	/** Trigger for polling task */
 	private volatile Trigger trigger;
 
@@ -49,6 +55,9 @@ public abstract class PollingTaskSupport<T> {
 
 	/** Spring task executor */
 	private TaskExecutor taskExecutor;
+
+	/** Timeout to wait results when stopping*/
+	private long stopWaitResultsTimeout = 0;
 
 	/**
 	 * Instantiates a new polling task support. On default a simple {@code PeriodicTrigger} is used.
@@ -109,6 +118,19 @@ public abstract class PollingTaskSupport<T> {
 	 */
 	public void stop() {
 		if (runningTask != null) {
+			if (stopWaitResultsTimeout > 0) {
+				try {
+					log.info("Waiting result for " + stopWaitResultsTimeout + " millis.");
+					Object result = runningTask.get(stopWaitResultsTimeout, TimeUnit.MILLISECONDS);
+					log.info("Result is " + result);
+				} catch (InterruptedException e) {
+					log.warn("Got interrupted waiting result", e);
+				} catch (ExecutionException e) {
+					log.error("Got error waiting result", e);
+				} catch (TimeoutException e) {
+					log.error("Got timeout waiting result", e);
+				}
+			}
 			runningTask.cancel(true);
 		}
 		runningTask = null;
@@ -121,6 +143,17 @@ public abstract class PollingTaskSupport<T> {
 	 */
 	public void setTrigger(Trigger trigger) {
 		this.trigger = trigger;
+	}
+
+	/**
+	 * Sets the stop wait results timeout. Value is set as millis
+	 * and if it is more than zero, stopping is done with call
+	 * to running task get with a timeout.
+	 *
+	 * @param stopWaitResultsTimeout the new stop wait results timeout
+	 */
+	public void setStopWaitResultsTimeout(long stopWaitResultsTimeout) {
+		this.stopWaitResultsTimeout = stopWaitResultsTimeout;
 	}
 
 	/**

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/support/StoreObjectSupport.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/support/StoreObjectSupport.java
@@ -78,6 +78,7 @@ public abstract class StoreObjectSupport extends LifecycleObjectSupport {
 		if (idleTimeout > 0) {
 			idleTrigger = new IdleTimeoutTrigger(idleTimeout);
 			idlePoller = new IdleTimeoutPoller(getTaskScheduler(), getTaskExecutor(), idleTrigger);
+			idlePoller.setStopWaitResultsTimeout(10000);
 			idlePoller.init();
 		}
 	}

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/output/PartitionTextFileWriterSmokeTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/output/PartitionTextFileWriterSmokeTests.java
@@ -15,11 +15,15 @@
  */
 package org.springframework.data.hadoop.store.output;
 
+import static org.hamcrest.CoreMatchers.everyItem;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.endsWith;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 
@@ -86,6 +90,7 @@ public class PartitionTextFileWriterSmokeTests extends AbstractStoreTests {
 		Thread.sleep(3000);
 
 		Map<Path, DataStoreWriter<String>> writers = TestUtils.readField("writers", writer);
+		TestUtils.printLsR(PATH, getConfiguration());
 		assertThat(writers.size(), is(0));
 
 		writer.flush();
@@ -94,6 +99,12 @@ public class PartitionTextFileWriterSmokeTests extends AbstractStoreTests {
 		// assuming items in DATA09ARRAY have same length
 		assertThat(getTotalWritten(), is((long) count * (DATA10.length() + 1) * threads * iterations));
 
+		@SuppressWarnings("resource")
+		FsShell shell = new FsShell(getConfiguration());
+		Collection<FileStatus> files = shell.ls(true, PATH);
+		Collection<String> names = statusesToNames(files);
+		assertThat(names, everyItem(not(endsWith("tmp"))));
+
 	}
 
 	private long getTotalWritten() {
@@ -101,12 +112,21 @@ public class PartitionTextFileWriterSmokeTests extends AbstractStoreTests {
 		FsShell shell = new FsShell(hadoopConfiguration);
 		long total = 0;
 		for (FileStatus s : shell.ls(true, PATH)) {
-			System.out.println(s);
 			if (s.isFile()) {
 				total += s.getLen();
 			}
 		}
 		return total;
+	}
+
+	private static Collection<String> statusesToNames(Collection<FileStatus> statuses) {
+		Collection<String> names = new ArrayList<String>();
+		for (FileStatus s : statuses) {
+			String p = s.getPath().toString();
+			int index = p.indexOf('/', 8);
+			names.add(p.substring(index));
+		}
+		return names;
 	}
 
 	private void doConcurrentWrites(final PartitionTextFileWriter<String> writer, int threadCount, final int writeCount) {

--- a/spring-hadoop-store/src/test/resources/log4j.properties
+++ b/spring-hadoop-store/src/test/resources/log4j.properties
@@ -2,6 +2,6 @@ log4j.rootCategory=WARN, stdout
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} %5p %40.40c:%4L - %m%n
+log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} [%t] %5p %40.40c:%4L - %m%n
 
 log4j.category.org.springframework.data.hadoop.store=INFO


### PR DESCRIPTION
- These fixes should make it better in cases where
  background task is doing rename operation or something
  else which needs to finish. Now during a lifecycle stop
  we can define if result will get requested which should
  be enough for current operation to finish.
