### PR TITLE
SHDP-437 Allow to define CompressionType in datasets

### DIFF
--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/DatasetDefinition.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/DatasetDefinition.java
@@ -18,6 +18,7 @@ package org.springframework.data.hadoop.store.dataset;
 
 import org.apache.avro.Schema;
 import org.apache.avro.reflect.ReflectData;
+import org.kitesdk.data.CompressionType;
 import org.kitesdk.data.Format;
 import org.kitesdk.data.Formats;
 import org.kitesdk.data.PartitionStrategy;
@@ -28,9 +29,10 @@ import org.springframework.util.Assert;
  * Class to define the options for a {@link org.kitesdk.data.Dataset}
  *
  * @author Thomas Risberg
+ * @author Janne Valkealahti
  * @since 2.0
  */
-public class DatasetDefinition{
+public class DatasetDefinition {
 
 	private Class<?> targetClass;
 
@@ -41,6 +43,8 @@ public class DatasetDefinition{
 	private PartitionStrategy partitionStrategy;
 
 	private Integer writerCacheSize;
+
+	private CompressionType compressionType;
 
 	public DatasetDefinition() {
 		this(null, true, Formats.AVRO.getName());
@@ -96,6 +100,15 @@ public class DatasetDefinition{
 		this.writerCacheSize = writerCacheSize;
 	}
 
+	public void setCompressionType(String compressionType) {
+		Assert.notNull(compressionType, "The compression type can't be null");
+		try {
+			this.compressionType = CompressionType.forName(compressionType);
+		} catch (IllegalArgumentException e) {
+			throw new StoreException("Invalid compression type '" + compressionType + "' specified", e);
+		}
+	}
+
 	public Class<?> getTargetClass() {
 		return targetClass;
 	}
@@ -114,6 +127,10 @@ public class DatasetDefinition{
 
 	public Integer getWriterCacheSize() {
 		return writerCacheSize;
+	}
+
+	public CompressionType getCompressionType() {
+		return compressionType;
 	}
 
 	public Schema getSchema(Class<?> datasetClass) {

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/DatasetUtils.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/DatasetUtils.java
@@ -34,16 +34,37 @@ import java.util.List;
  * {@link org.kitesdk.data.DatasetWriter}s
  *
  * @author Thomas Risberg
+ * @author Janne Valkealahti
  * @since 2.0
  */
 public abstract class DatasetUtils {
 
 	private final static Log log = LogFactory.getLog(DatasetUtils.class);
 
+	/**
+	 * Gets the dataset name. This method simply delegates to
+	 * {@link Class#getSimpleName()} and gets a lower case name.
+	 *
+	 * @param <T> the generic class type
+	 * @param clazz the clazz
+	 * @return the dataset name
+	 */
 	public static <T> String getDatasetName(Class<T> clazz) {
 		return clazz.getSimpleName().toLowerCase();
 	}
 
+	/**
+	 * Gets a {@link Dataset} using a {@link DatasetRepositoryFactory},
+	 * {@link DatasetDefinition}, pojo class and a record class. {@link Dataset}
+	 * is created if it doesn't exist.
+	 *
+	 * @param <T> the generic record class type
+	 * @param dsFactory the dataset repository factory
+	 * @param datasetDefinition the dataset definition
+	 * @param pojoClass the pojo class
+	 * @param recordClass the record class
+	 * @return the dataset
+	 */
 	public static <T> Dataset<T> getOrCreateDataset(DatasetRepositoryFactory dsFactory, DatasetDefinition datasetDefinition,
 													Class<?> pojoClass, Class<T> recordClass) {
 		String repoName = getDatasetName(pojoClass);
@@ -73,6 +94,7 @@ public abstract class DatasetUtils {
 				descriptor = new DatasetDescriptor.Builder()
 						.schema(schema)
 						.format(datasetDefinition.getFormat())
+						.compressionType(datasetDefinition.getCompressionType())
 						.build();
 			}
 			else {
@@ -82,6 +104,7 @@ public abstract class DatasetUtils {
 				DatasetDescriptor.Builder ddBuilder = new DatasetDescriptor.Builder()
 						.schema(schema)
 						.format(datasetDefinition.getFormat())
+						.compressionType(datasetDefinition.getCompressionType())
 						.partitionStrategy(datasetDefinition.getPartitionStrategy());
 				if (datasetDefinition.getWriterCacheSize() != null) {
 					ddBuilder = ddBuilder.property(FileSystemProperties.WRITER_CACHE_SIZE_PROP,
@@ -97,8 +120,17 @@ public abstract class DatasetUtils {
 		return dataset;
 	}
 
-	public static <T> Dataset<T> getDataset(DatasetRepositoryFactory dsFactory, Class<T> clazz) {
-		String repoName = getDatasetName(clazz);
+	/**
+	 * Gets the dataset using a {@link DatasetRepositoryFactory} and
+	 * a pojo class. Passed class is a same used in {@link #getOrCreateDataset "pojoClass"}
+	 *
+	 * @param <T> the generic type
+	 * @param dsFactory the ds factory
+	 * @param pojoClass the pojo class
+	 * @return the dataset
+	 */
+	public static <T> Dataset<T> getDataset(DatasetRepositoryFactory dsFactory, Class<T> pojoClass) {
+		String repoName = getDatasetName(pojoClass);
 		return dsFactory.getDatasetRepository().load(dsFactory.getNamespace(), repoName);
 	}
 }

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/DatasetCompressionTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/DatasetCompressionTests.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.hadoop.store.dataset;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Date;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kitesdk.data.CompressionType;
+import org.kitesdk.data.Dataset;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.hadoop.store.DataStoreWriter;
+import org.springframework.data.hadoop.test.context.HadoopDelegatingSmartContextLoader;
+import org.springframework.data.hadoop.test.context.MiniHadoopCluster;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(loader=HadoopDelegatingSmartContextLoader.class, classes = DatasetCompressionTests.EmptyConfig.class)
+@MiniHadoopCluster
+public class DatasetCompressionTests {
+
+	@Autowired
+	private ApplicationContext context;
+
+	@Autowired
+	org.apache.hadoop.conf.Configuration configuration;
+
+	@Test
+	public void testDefaultAvroCodecIsSnappy() throws IOException {
+		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
+		ctx.setParent(context);
+		ctx.register(AvroSnappyConfig.class);
+		ctx.refresh();
+
+		DatasetRepositoryFactory factory = ctx.getBean(DatasetRepositoryFactory.class);
+		AvroPojoDatasetStoreWriter<TestPojo> writer = new AvroPojoDatasetStoreWriter<TestPojo>(TestPojo.class, factory);
+
+		DatasetOperations datasetOperations = new DatasetTemplate(factory);
+		Class<TestPojo> recordClass = TestPojo.class;
+
+		TestPojo pojo = new TestPojo();
+		pojo.setId(22L);
+		pojo.setName("Sven");
+		pojo.setBirthDate(new Date());
+		doAssertSimpleWrite(writer, datasetOperations, recordClass, AvroSnappyConfig.PATH, AvroSnappyConfig.NAMESPACE, pojo);
+
+		Dataset<TestPojo> dataset = DatasetUtils.getDataset(factory, recordClass);
+		assertThat(dataset.getDescriptor().getCompressionType(), is(CompressionType.Snappy));
+
+		ctx.close();
+	}
+
+	@Test
+	public void testAvroBzip2Codec() throws IOException {
+		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
+		ctx.setParent(context);
+		ctx.register(AvroBzip2CodecConfig.class);
+		ctx.refresh();
+
+		DatasetRepositoryFactory factory = ctx.getBean(DatasetRepositoryFactory.class);
+		DatasetDefinition definition = ctx.getBean(DatasetDefinition.class);
+		AvroPojoDatasetStoreWriter<TestPojo> writer = new AvroPojoDatasetStoreWriter<TestPojo>(TestPojo.class, factory, definition);
+
+		DatasetOperations datasetOperations = new DatasetTemplate(factory);
+		Class<TestPojo> recordClass = TestPojo.class;
+
+		TestPojo pojo = new TestPojo();
+		pojo.setId(22L);
+		pojo.setName("Sven");
+		pojo.setBirthDate(new Date());
+		doAssertSimpleWrite(writer, datasetOperations, recordClass, AvroBzip2CodecConfig.PATH, AvroBzip2CodecConfig.NAMESPACE, pojo);
+
+		Dataset<TestPojo> dataset = DatasetUtils.getDataset(factory, recordClass);
+		assertThat(dataset.getDescriptor().getCompressionType(), is(CompressionType.Bzip2));
+
+		ctx.close();
+	}
+
+	@Test
+	public void testDefaultParquetCodecIsSnappy() throws IOException {
+		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
+		ctx.setParent(context);
+		ctx.register(ParquetSnappyConfig.class);
+		ctx.refresh();
+
+		DatasetRepositoryFactory factory = ctx.getBean(DatasetRepositoryFactory.class);
+		ParquetDatasetStoreWriter<SimplePojo> writer = new ParquetDatasetStoreWriter<SimplePojo>(SimplePojo.class, factory);
+
+		DatasetOperations datasetOperations = new DatasetTemplate(factory);
+		Class<SimplePojo> recordClass = SimplePojo.class;
+
+		SimplePojo pojo = new SimplePojo();
+		pojo.setId(22L);
+		pojo.setName("Sven");
+		pojo.setBirthDate(new Date().getTime());
+		doAssertSimpleWrite(writer, datasetOperations, recordClass, ParquetSnappyConfig.PATH, ParquetSnappyConfig.NAMESPACE, pojo);
+
+		Dataset<SimplePojo> dataset = DatasetUtils.getDataset(factory, recordClass);
+		assertThat(dataset.getDescriptor().getCompressionType(), is(CompressionType.Snappy));
+
+		ctx.close();
+	}
+
+	@Test
+	public void testParquetDeflateCodec() throws IOException {
+		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
+		ctx.setParent(context);
+		ctx.register(ParquetDeflateCodecConfig.class);
+		ctx.refresh();
+
+		DatasetRepositoryFactory factory = ctx.getBean(DatasetRepositoryFactory.class);
+		DatasetDefinition definition = ctx.getBean(DatasetDefinition.class);
+		ParquetDatasetStoreWriter<SimplePojo> writer = new ParquetDatasetStoreWriter<SimplePojo>(SimplePojo.class, factory, definition);
+
+		DatasetOperations datasetOperations = new DatasetTemplate(factory);
+		Class<SimplePojo> recordClass = SimplePojo.class;
+
+		SimplePojo pojo = new SimplePojo();
+		pojo.setId(22L);
+		pojo.setName("Sven");
+		pojo.setBirthDate(new Date().getTime());
+		doAssertSimpleWrite(writer, datasetOperations, recordClass, ParquetDeflateCodecConfig.PATH, ParquetDeflateCodecConfig.NAMESPACE, pojo);
+
+		Dataset<SimplePojo> dataset = DatasetUtils.getDataset(factory, recordClass);
+		assertThat(dataset.getDescriptor().getCompressionType(), is(CompressionType.Deflate));
+
+		ctx.close();
+	}
+
+	private <T> void doAssertSimpleWrite(DataStoreWriter<T> writer, DatasetOperations datasetOperations,
+			Class<T> recordClass, String path, String namespace, T pojo) throws IOException {
+		writer.write(pojo);
+		writer.flush();
+		writer.close();
+		FileSystem fs = FileSystem.get(configuration);
+		assertTrue("Dataset path created", fs.exists(new Path(path)));
+		assertTrue("Dataset storage created",
+				fs.exists(new Path(path + "/" + namespace + "/" + DatasetUtils.getDatasetName(recordClass))));
+		assertTrue("Dataset metadata created",
+				fs.exists(new Path(path + "/" + namespace + "/" + DatasetUtils.getDatasetName(recordClass) + "/.metadata")));
+		Collection<T> results = datasetOperations.read(recordClass);
+		assertEquals(1, results.size());
+		assertThat(results.iterator().next(), instanceOf(recordClass));
+	}
+
+	@Configuration
+	static class AvroSnappyConfig {
+
+		final static String PATH = "/tmp/DatasetCompressionTests/testDefaultAvroCodecIsSnappy";
+		final static String NAMESPACE = "testDefaultAvroCodecIsSnappy";
+
+		@Autowired
+		org.apache.hadoop.conf.Configuration configuration;
+
+		@Bean
+		public DatasetRepositoryFactory datasetRepositoryFactory() {
+			DatasetRepositoryFactory factory = new DatasetRepositoryFactory();
+			factory.setConf(configuration);
+			factory.setBasePath(PATH);
+			factory.setNamespace(NAMESPACE);
+			return factory;
+		}
+
+		@Bean
+		public DatasetTemplate datasetTemplate() {
+			DatasetTemplate template = new DatasetTemplate();
+			template.setDatasetRepositoryFactory(datasetRepositoryFactory());
+			return template;
+		}
+
+	}
+
+	@Configuration
+	static class AvroBzip2CodecConfig {
+
+		final static String PATH = "/tmp/DatasetCompressionTests/testAvroBzip2Codec";
+		final static String NAMESPACE = "testAvroBzip2Codec";
+
+		@Autowired
+		org.apache.hadoop.conf.Configuration configuration;
+
+		@Bean
+		public DatasetRepositoryFactory datasetRepositoryFactory() {
+			DatasetRepositoryFactory factory = new DatasetRepositoryFactory();
+			factory.setConf(configuration);
+			factory.setBasePath(PATH);
+			factory.setNamespace(NAMESPACE);
+			return factory;
+		}
+
+		@Bean
+		public DatasetTemplate datasetTemplate() {
+			DatasetTemplate template = new DatasetTemplate();
+			template.setDatasetRepositoryFactory(datasetRepositoryFactory());
+			template.setDefaultDatasetDefinition(datasetDefinition());
+			return template;
+		}
+
+		@Bean
+		public DatasetDefinition datasetDefinition() {
+			DatasetDefinition definition = new DatasetDefinition();
+			definition.setCompressionType("bzip2");
+			return definition;
+		}
+
+	}
+
+	@Configuration
+	static class ParquetSnappyConfig {
+
+		final static String PATH = "/tmp/DatasetCompressionTests/testDefaultParquetCodecIsSnappy";
+		final static String NAMESPACE = "testDefaultParquetCodecIsSnappy";
+
+		@Autowired
+		org.apache.hadoop.conf.Configuration configuration;
+
+		@Bean
+		public DatasetRepositoryFactory datasetRepositoryFactory() {
+			DatasetRepositoryFactory factory = new DatasetRepositoryFactory();
+			factory.setConf(configuration);
+			factory.setBasePath(PATH);
+			factory.setNamespace(NAMESPACE);
+			return factory;
+		}
+
+		@Bean
+		public DatasetTemplate datasetTemplate() {
+			DatasetTemplate template = new DatasetTemplate();
+			template.setDatasetRepositoryFactory(datasetRepositoryFactory());
+			return template;
+		}
+
+	}
+
+	@Configuration
+	static class ParquetDeflateCodecConfig {
+
+		final static String PATH = "/tmp/DatasetCompressionTests/testParquetDeflateCodec";
+		final static String NAMESPACE = "testParquetDeflateCodec";
+
+		@Autowired
+		org.apache.hadoop.conf.Configuration configuration;
+
+		@Bean
+		public DatasetRepositoryFactory datasetRepositoryFactory() {
+			DatasetRepositoryFactory factory = new DatasetRepositoryFactory();
+			factory.setConf(configuration);
+			factory.setBasePath(PATH);
+			factory.setNamespace(NAMESPACE);
+			return factory;
+		}
+
+		@Bean
+		public DatasetTemplate datasetTemplate() {
+			DatasetTemplate template = new DatasetTemplate();
+			template.setDatasetRepositoryFactory(datasetRepositoryFactory());
+			template.setDefaultDatasetDefinition(datasetDefinition());
+			return template;
+		}
+
+		@Bean
+		public DatasetDefinition datasetDefinition() {
+			DatasetDefinition definition = new DatasetDefinition(false, "parquet");
+			definition.setCompressionType("deflate");
+			return definition;
+		}
+
+	}
+
+	@Configuration
+	static class EmptyConfig {
+	}
+
+}


### PR DESCRIPTION
- Added compressionType to DatasetDefinition and pass it
  to kite in DatasetUtils.
- Few tests which checks used codec and does
  a simple read/write.
- Some polishing for formatting and javadocs
