### PR TITLE
SHDP-439 Add support for graceful yarn app shutdown

### DIFF
--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/am/BatchAppmaster.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/am/BatchAppmaster.java
@@ -164,4 +164,13 @@ public class BatchAppmaster extends AbstractBatchAppmaster implements YarnAppmas
 
 	}
 
+	@Override
+	protected void doStop() {
+		// TODO we override stop here for AbstractAppmaster not
+		//      to call notifyCompleted() because we currently need to call
+		//      it at the end of submitApplication(). should do a little
+		//      refactoring to play nice with lifecycle.
+		finishAppmaster();
+	}
+
 }

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnShutdownCommand.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnShutdownCommand.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.yarn.boot.cli;
+
+import java.util.Properties;
+
+import org.springframework.util.Assert;
+import org.springframework.yarn.boot.app.YarnShutdownApplication;
+
+import joptsimple.OptionSet;
+import joptsimple.OptionSpec;
+
+/**
+ * Command instructing a graceful application shutdown.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class YarnShutdownCommand extends AbstractApplicationCommand {
+
+	public final static String DEFAULT_COMMAND = "shutdown";
+
+	public final static String DEFAULT_DESC = "Shutdown application";
+
+	/**
+	 * Instantiates a new yarn app shutdown command using a default command name,
+	 * command description and option handler.
+	 */
+	public YarnShutdownCommand() {
+		super(DEFAULT_COMMAND, DEFAULT_DESC, new ShutdownOptionHandler());
+	}
+
+	/**
+	 * Instantiates a new yarn app shutdown command using a default command name,
+	 * command description.
+	 *
+	 * @param handler the handler
+	 */
+	public YarnShutdownCommand(ShutdownOptionHandler handler) {
+		super(DEFAULT_COMMAND, DEFAULT_DESC, handler);
+	}
+
+	/**
+	 * Instantiates a new yarn app shutdown command using a default command name and
+	 * command description.
+	 *
+	 * @param name the command name
+	 * @param description the command description
+	 * @param handler the handler
+	 */
+	public YarnShutdownCommand(String name, String description, ShutdownOptionHandler handler) {
+		super(name, description, handler);
+	}
+
+	public static class ShutdownOptionHandler extends ApplicationOptionHandler<String> {
+
+		private OptionSpec<String> applicationIdOption;
+
+		@Override
+		protected final void options() {
+			this.applicationIdOption = option(CliSystemConstants.OPTIONS_APPLICATION_ID,
+					CliSystemConstants.DESC_APPLICATION_ID).withRequiredArg();
+		}
+
+		@Override
+		protected void runApplication(OptionSet options) throws Exception {
+			String appId = options.valueOf(applicationIdOption);
+			Assert.hasText(appId, "Application Id must be defined");
+			YarnShutdownApplication app = new YarnShutdownApplication();
+			Properties appProperties = new Properties();
+			appProperties.setProperty("spring.yarn.internal.YarnShutdownApplication.applicationId", appId);
+			app.appProperties(appProperties);
+			handleApplicationRun(app);
+		}
+
+		public OptionSpec<String> getApplicationIdOption() {
+			return applicationIdOption;
+		}
+
+	}
+
+}

--- a/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnShutdownCommandTests.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnShutdownCommandTests.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.yarn.boot.cli;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import joptsimple.OptionSet;
+
+import org.junit.Test;
+import org.springframework.yarn.boot.cli.YarnShutdownCommand.ShutdownOptionHandler;
+
+/**
+ * Tests for {@link YarnShutdownCommand}.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class YarnShutdownCommandTests {
+
+	@Test
+	public void testDefaultOptionHelp() {
+		YarnShutdownCommand command = new YarnShutdownCommand();
+		assertThat(command.getHelp(), containsString("-a, --application-id"));
+	}
+
+	@Test
+	public void testShouldNotFail() throws Exception {
+		NoRunShutdownOptionHandler handler = new NoRunShutdownOptionHandler();
+		YarnShutdownCommand command = new YarnShutdownCommand(handler);
+		command.run("-a", "foo");
+		assertThat(handler.appId, is("foo"));
+	}
+
+	private static class NoRunShutdownOptionHandler extends ShutdownOptionHandler {
+
+		String appId;
+
+		@Override
+		protected void runApplication(OptionSet options) throws Exception {
+			appId = options.valueOf(getApplicationIdOption());
+		}
+
+	}
+
+}

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/YarnAppmasterAutoConfiguration.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/YarnAppmasterAutoConfiguration.java
@@ -50,7 +50,9 @@ import org.springframework.yarn.am.grid.support.ProjectionData;
 import org.springframework.yarn.am.grid.support.ProjectionDataRegistry;
 import org.springframework.yarn.batch.support.YarnJobLauncher;
 import org.springframework.yarn.boot.actuate.endpoint.YarnContainerClusterEndpoint;
+import org.springframework.yarn.boot.actuate.endpoint.YarnContainerRegisterEndpoint;
 import org.springframework.yarn.boot.actuate.endpoint.mvc.YarnContainerClusterMvcEndpoint;
+import org.springframework.yarn.boot.actuate.endpoint.mvc.YarnContainerRegisterMvcEndpoint;
 import org.springframework.yarn.boot.condition.ConditionalOnYarnAppmaster;
 import org.springframework.yarn.boot.properties.SpringHadoopProperties;
 import org.springframework.yarn.boot.properties.SpringYarnAppmasterLaunchContextProperties;
@@ -302,7 +304,7 @@ public class YarnAppmasterAutoConfiguration {
 	@Configuration
 	@EnableConfigurationProperties({ SpringYarnAppmasterProperties.class })
 	@ConditionalOnExpression("${spring.yarn.endpoints.containercluster.enabled:false}")
-	public static class EndPointConfig {
+	public static class ContainerClusterEndPointConfig {
 
 		@Autowired
 		private SpringYarnAppmasterProperties syap;
@@ -317,6 +319,24 @@ public class YarnAppmasterAutoConfiguration {
 		@ConditionalOnBean(YarnContainerClusterEndpoint.class)
 		public YarnContainerClusterMvcEndpoint yarnContainerClusterMvcEndpoint(YarnContainerClusterEndpoint delegate) {
 			return new YarnContainerClusterMvcEndpoint(delegate);
+		}
+
+	}
+
+	@Configuration
+	@ConditionalOnExpression("${spring.yarn.endpoints.containerregister.enabled:false}")
+	public static class ContainerRegisterEndPointConfig {
+
+		@Bean
+		@ConditionalOnMissingBean
+		public YarnContainerRegisterEndpoint yarnContainerRegisterEndpoint() {
+			return new YarnContainerRegisterEndpoint();
+		}
+
+		@Bean
+		@ConditionalOnBean(YarnContainerRegisterEndpoint.class)
+		public YarnContainerRegisterMvcEndpoint yarnContainerRegisterMvcEndpoint(YarnContainerRegisterEndpoint delegate) {
+			return new YarnContainerRegisterMvcEndpoint(delegate);
 		}
 
 	}

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/actuate/endpoint/YarnContainerRegisterEndpoint.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/actuate/endpoint/YarnContainerRegisterEndpoint.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.yarn.boot.actuate.endpoint;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.endpoint.AbstractEndpoint;
+import org.springframework.boot.actuate.endpoint.Endpoint;
+import org.springframework.yarn.event.ContainerRegisterEvent;
+import org.springframework.yarn.event.YarnEventPublisher;
+
+/**
+ * {@link Endpoint} handling graceful shutdown of YARN application.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class YarnContainerRegisterEndpoint extends AbstractEndpoint<Map<String, Object>> {
+
+	public final static String ENDPOINT_ID = "yarn_containerregister";
+
+	private static final Log log = LogFactory.getLog(YarnContainerRegisterEndpoint.class);
+
+	private YarnEventPublisher yarnEventPublisher;
+
+	/**
+	 * Instantiates a new yarn container register endpoint.
+	 */
+	public YarnContainerRegisterEndpoint() {
+		super(ENDPOINT_ID);
+	}
+
+	@Override
+	public Map<String, Object> invoke() {
+		return Collections.<String, Object> singletonMap("message",
+				"Use POST to report yourself");
+	}
+
+	/**
+	 * Do a registration of a container id and its tracking url. This
+	 * will initiate an {@link ContainerRegisterEvent} via
+	 * {@link YarnEventPublisher} if enabled.
+	 *
+	 * @param containerId the container id
+	 * @param trackUrl the track url
+	 */
+	public void register(String containerId, String trackUrl) {
+		if (yarnEventPublisher != null) {
+			yarnEventPublisher.publishEvent(new ContainerRegisterEvent(this, containerId, trackUrl));
+		}
+	}
+
+	/**
+	 * Sets the yarn event publisher.
+	 *
+	 * @param yarnEventPublisher the new yarn event publisher
+	 */
+	@Autowired(required=false)
+	public void setYarnEventPublisher(YarnEventPublisher yarnEventPublisher) {
+		log.debug("Setting yarnEventPublisher=[" + yarnEventPublisher + "]");
+		this.yarnEventPublisher = yarnEventPublisher;
+	}
+
+}

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/actuate/endpoint/mvc/YarnContainerRegisterMvcEndpoint.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/actuate/endpoint/mvc/YarnContainerRegisterMvcEndpoint.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.yarn.boot.actuate.endpoint.mvc;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.springframework.boot.actuate.endpoint.mvc.EndpointMvcAdapter;
+import org.springframework.boot.actuate.endpoint.mvc.MvcEndpoint;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.yarn.boot.actuate.endpoint.YarnContainerRegisterEndpoint;
+import org.springframework.yarn.boot.actuate.endpoint.mvc.domain.ContainerRegisterResource;
+
+/**
+ * A custom {@link MvcEndpoint} adding specific rest API used to
+ * handle graceful YARN application shutdown.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class YarnContainerRegisterMvcEndpoint extends EndpointMvcAdapter {
+
+	private final YarnContainerRegisterEndpoint delegate;
+
+	/**
+	 * Instantiates a new yarn container register mvc endpoint.
+	 *
+	 * @param delegate the delegate endpoint
+	 */
+	public YarnContainerRegisterMvcEndpoint(YarnContainerRegisterEndpoint delegate) {
+		super(delegate);
+		this.delegate = delegate;
+	}
+
+	@RequestMapping(method = RequestMethod.GET)
+	@ResponseBody
+	@Override
+	public Object invoke() {
+		if (!getDelegate().isEnabled()) {
+			return new ResponseEntity<Map<String, String>>(Collections.singletonMap(
+					"message", "This endpoint is disabled"), HttpStatus.NOT_FOUND);
+		}
+		return super.invoke();
+	}
+
+	@RequestMapping(method = RequestMethod.POST)
+	public HttpEntity<Void> register(@RequestBody ContainerRegisterResource request) {
+		delegate.register(request.getContainerId(), request.getTrackUrl());
+		HttpHeaders responseHeaders = new HttpHeaders();
+		return new ResponseEntity<Void>(responseHeaders, HttpStatus.ACCEPTED);
+	}
+
+}

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/actuate/endpoint/mvc/domain/ContainerRegisterResource.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/actuate/endpoint/mvc/domain/ContainerRegisterResource.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.yarn.boot.actuate.endpoint.mvc.domain;
+
+public class ContainerRegisterResource {
+
+	private String containerId;
+
+	private String trackUrl;
+
+	public ContainerRegisterResource() {
+	}
+
+	public ContainerRegisterResource(String containerId, String trackUrl) {
+		this.containerId = containerId;
+		this.trackUrl = trackUrl;
+	}
+
+	public String getContainerId() {
+		return containerId;
+	}
+
+	public void setContainerId(String containerId) {
+		this.containerId = containerId;
+	}
+
+	public String getTrackUrl() {
+		return trackUrl;
+	}
+
+	public void setTrackUrl(String trackUrl) {
+		this.trackUrl = trackUrl;
+	}
+
+}

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/YarnShutdownApplication.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/YarnShutdownApplication.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.yarn.boot.app;
+
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.hadoop.yarn.api.records.ApplicationReport;
+import org.apache.hadoop.yarn.util.ConverterUtils;
+import org.springframework.boot.actuate.autoconfigure.EndpointAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.EndpointMBeanExportAutoConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
+import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.EmbeddedServletContainerAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.WebMvcAutoConfiguration;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.yarn.boot.SpringApplicationCallback;
+import org.springframework.yarn.boot.SpringApplicationTemplate;
+import org.springframework.yarn.boot.support.SpringYarnBootUtils;
+import org.springframework.yarn.client.YarnClient;
+
+/**
+ * A Boot application which is used to shutdown YARN application gracefully.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@Configuration
+@EnableAutoConfiguration(exclude = { EmbeddedServletContainerAutoConfiguration.class, WebMvcAutoConfiguration.class,
+		JmxAutoConfiguration.class, BatchAutoConfiguration.class, JmxAutoConfiguration.class,
+		EndpointMBeanExportAutoConfiguration.class, EndpointAutoConfiguration.class })
+public class YarnShutdownApplication extends AbstractClientApplication<String, YarnShutdownApplication> {
+
+	public String run() {
+		return run(new String[0]);
+	}
+
+	@Override
+	public String run(String... args) {
+		SpringApplicationBuilder builder = new SpringApplicationBuilder();
+		builder.web(false);
+		builder.sources(YarnShutdownApplication.class, OperationProperties.class);
+		SpringYarnBootUtils.addSources(builder, sources.toArray(new Object[0]));
+		SpringYarnBootUtils.addProfiles(builder, profiles.toArray(new String[0]));
+		SpringYarnBootUtils.addApplicationListener(builder, appProperties);
+
+		SpringApplicationTemplate template = new SpringApplicationTemplate(builder);
+		return template.execute(new SpringApplicationCallback<String>() {
+
+			@Override
+			public String runWithSpringApplication(ApplicationContext context) throws Exception {
+				OperationProperties operationProperties = context.getBean(OperationProperties.class);
+				ApplicationId applicationId = ConverterUtils.toApplicationId(operationProperties.getApplicationId());
+				YarnClient client = context.getBean(YarnClient.class);
+				ApplicationReport report = client.getApplicationReport(applicationId);
+				String trackingUrl = report.getOriginalTrackingUrl();
+
+				RestTemplate restTemplate = new RestTemplate(new HttpComponentsClientHttpRequestFactory());
+				restTemplate.postForObject(trackingUrl + "/shutdown", null, Void.class);
+
+				return "shutdown requested";
+			}
+
+		}, args);
+
+	}
+
+	@Override
+	protected YarnShutdownApplication getThis() {
+		return this;
+	}
+
+	@ConfigurationProperties(value = "spring.yarn.internal.YarnShutdownApplication")
+	public static class OperationProperties {
+		String applicationId;
+		public void setApplicationId(String applicationId) {
+			this.applicationId = applicationId;
+		}
+		public String getApplicationId() {
+			return applicationId;
+		}
+	}
+
+}

--- a/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/actuate/endpoint/mvc/YarnContainerRegisterMvcEndpointTests.java
+++ b/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/actuate/endpoint/mvc/YarnContainerRegisterMvcEndpointTests.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.yarn.boot.actuate.endpoint.mvc;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.isEmptyString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.autoconfigure.EndpointWebMvcAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.ManagementServerPropertiesAutoConfiguration;
+import org.springframework.boot.autoconfigure.hateoas.HypermediaAutoConfiguration;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.yarn.am.StaticEventingAppmaster;
+import org.springframework.yarn.am.YarnAppmaster;
+import org.springframework.yarn.boot.actuate.endpoint.YarnContainerRegisterEndpoint;
+import org.springframework.yarn.event.AbstractYarnEvent;
+import org.springframework.yarn.event.ContainerRegisterEvent;
+import org.springframework.yarn.event.DefaultYarnEventPublisher;
+import org.springframework.yarn.event.YarnEventPublisher;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = { YarnContainerRegisterMvcEndpointTests.TestConfiguration.class })
+@WebAppConfiguration
+@DirtiesContext(classMode=ClassMode.AFTER_EACH_TEST_METHOD)
+public class YarnContainerRegisterMvcEndpointTests {
+
+	private final static String BASE = "/" + YarnContainerRegisterEndpoint.ENDPOINT_ID;
+
+	@Autowired
+	private WebApplicationContext context;
+
+	private MockMvc mvc;
+
+	private TestYarnAppmaster appmaster;
+
+	@Before
+	public void setUp() {
+		mvc = MockMvcBuilders.webAppContextSetup(context).build();
+		appmaster = (TestYarnAppmaster) context.getBean(YarnAppmaster.class);
+	}
+
+	@Test
+	public void testHomeEmpty() throws Exception {
+		mvc.
+			perform(get(BASE)).
+			andExpect(status().isOk()).
+			andExpect(content().string(not(isEmptyString()))).
+			andExpect(jsonPath("$.*", hasSize(1))).
+			andExpect(jsonPath("$.message", containsString("Use POST")));
+	}
+
+	@Test
+	public void testHomeReport() throws Exception {
+		String content = "{\"containerId\":\"container_1360089121174_0011_01_000001\",\"trackUrl\":\"bar\"}";
+		mvc.
+			perform(post(BASE).content(content).contentType(MediaType.APPLICATION_JSON)).
+			andExpect(status().is(202));
+
+		assertThat(appmaster.events.size(), is(1));
+	}
+
+	@Import({ EndpointWebMvcAutoConfiguration.class, ManagementServerPropertiesAutoConfiguration.class,
+			HypermediaAutoConfiguration.class })
+	@EnableWebMvc
+	@Configuration
+	public static class TestConfiguration {
+
+		@Bean
+		public YarnContainerRegisterEndpoint endpoint() {
+			return new YarnContainerRegisterEndpoint();
+		}
+
+		@Bean
+		public YarnContainerRegisterMvcEndpoint mvcEndpoint() {
+			return new YarnContainerRegisterMvcEndpoint(endpoint());
+		}
+
+		@Bean
+		public YarnAppmaster appMaster() {
+			TestYarnAppmaster appmaster = new TestYarnAppmaster();
+			return appmaster;
+		}
+
+		@Bean
+		public YarnEventPublisher yarnEventPublisher() {
+			return new DefaultYarnEventPublisher();
+		}
+
+	}
+
+	protected static class TestYarnAppmaster extends StaticEventingAppmaster {
+
+		List<ContainerRegisterEvent> events = new ArrayList<ContainerRegisterEvent>();
+
+		@Override
+		public void onApplicationEvent(AbstractYarnEvent event) {
+
+			if (event instanceof ContainerRegisterEvent) {
+				events.add((ContainerRegisterEvent) event);
+			}
+
+			super.onApplicationEvent(event);
+		}
+		@Override
+		protected void onInit() throws Exception {
+			setConfiguration(new org.apache.hadoop.conf.Configuration());
+			super.onInit();
+		}
+		@Override
+		protected void doStart() {
+		}
+		@Override
+		protected void doStop() {
+		}
+	}
+
+}

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/YarnSystemConstants.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/YarnSystemConstants.java
@@ -56,6 +56,9 @@ public class YarnSystemConstants {
 	/** Default bean id for Yarn event publisher. */
 	public static final String DEFAULT_ID_EVENT_PUBLISHER = "yarnEventPublisher";
 
+	/** Default bean id for Yarn container shutdown. */
+	public static final String DEFAULT_CONTAINER_SHUTDOWN = "yarnContainerShutdown";
+
 	/** Default bean id for appmaster service client. */
 	public static final String DEFAULT_ID_AMSERVICE_CLIENT = "yarnAmserviceClient";
 
@@ -70,6 +73,9 @@ public class YarnSystemConstants {
 
 	/** Default name of container context file. */
 	public static final String DEFAULT_CONTEXT_FILE_CONTAINER = "container-context.xml";
+
+	/** Default env variable for track url. */
+	public static final String AMSERVICE_TRACKURL = "SHDP_AMSERVICE_TRACKURL";
 
 	/** Default env variable for amservice port. */
 	public static final String AMSERVICE_PORT = "SHDP_AMSERVICE_PORT";

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/AbstractEventingAppmaster.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/AbstractEventingAppmaster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,16 +15,28 @@
  */
 package org.springframework.yarn.am;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.yarn.api.records.Container;
+import org.apache.hadoop.yarn.api.records.ContainerId;
+import org.apache.hadoop.yarn.api.records.ContainerLaunchContext;
 import org.apache.hadoop.yarn.api.records.ContainerStatus;
+import org.apache.hadoop.yarn.util.ConverterUtils;
 import org.springframework.context.ApplicationListener;
+import org.springframework.util.StringUtils;
+import org.springframework.yarn.YarnSystemConstants;
+import org.springframework.yarn.am.container.AbstractLauncher;
+import org.springframework.yarn.am.container.ContainerRegisterInfo;
+import org.springframework.yarn.am.container.ContainerShutdown;
 import org.springframework.yarn.event.AbstractYarnEvent;
 import org.springframework.yarn.event.ContainerAllocationEvent;
 import org.springframework.yarn.event.ContainerCompletedEvent;
 import org.springframework.yarn.event.ContainerLaunchRequestFailedEvent;
 import org.springframework.yarn.event.ContainerLaunchedEvent;
+import org.springframework.yarn.event.ContainerRegisterEvent;
 
 /**
  * Base implementation of application master where life-cycle
@@ -49,16 +61,45 @@ public abstract class AbstractEventingAppmaster extends AbstractServicesAppmaste
 
 	private static final Log log = LogFactory.getLog(AbstractEventingAppmaster.class);
 
+	private final Map<ContainerId, Container> runningContainers = new HashMap<ContainerId, Container>();
+
+	private final Map<Container, ContainerRegisterInfo> registeredContainers = new HashMap<Container, ContainerRegisterInfo>();
+
+	@Override
+	protected void onInit() throws Exception {
+		super.onInit();
+		if (getLauncher() instanceof AbstractLauncher) {
+			((AbstractLauncher) getLauncher()).addInterceptor(new AddTrackServiceContainerLaunchInterceptor(
+					getAppmasterTrackService()));
+		}
+	}
+
 	@Override
 	public void onApplicationEvent(AbstractYarnEvent event) {
 		if (event instanceof ContainerAllocationEvent) {
 			onContainerAllocated(((ContainerAllocationEvent) event).getContainer());
 		} else if (event instanceof ContainerLaunchedEvent) {
-			onContainerLaunched(((ContainerLaunchedEvent) event).getContainer());
+			Container container = ((ContainerLaunchedEvent) event).getContainer();
+			runningContainers.put(container.getId(), container);
+			onContainerLaunched(container);
 		} else if (event instanceof ContainerLaunchRequestFailedEvent) {
 			onContainerLaunchRequestFailed(((ContainerLaunchRequestFailedEvent) event).getContainer());
 		} else if (event instanceof ContainerCompletedEvent) {
-			onContainerCompleted(((ContainerCompletedEvent) event).getContainerStatus());
+			ContainerStatus containerStatus = ((ContainerCompletedEvent) event).getContainerStatus();
+			onContainerCompleted(containerStatus);
+			Container container = runningContainers.remove(containerStatus.getContainerId());
+			if (container != null) {
+				registeredContainers.remove(container);
+			}
+		} else if (event instanceof ContainerRegisterEvent) {
+			ContainerRegisterEvent e = (ContainerRegisterEvent) event;
+			ContainerId containerId = ConverterUtils.toContainerId(e.getContainerId());
+			Container container = runningContainers.get(containerId);
+			if (container != null) {
+				registeredContainers.put(container, new ContainerRegisterInfo(e.getTrackUrl()));
+			} else {
+				log.warn("Could not find matching running container=[" + container + "] for containerId=[" + containerId + "]");
+			}
 		}
 	}
 
@@ -108,6 +149,59 @@ public abstract class AbstractEventingAppmaster extends AbstractServicesAppmaste
 		if (log.isDebugEnabled()) {
 			log.debug("onContainerCompleted:" + status);
 		}
+	}
+
+	@Override
+	protected boolean shutdownContainers() {
+		ContainerShutdown shutdowner = getContainerShutdown();
+		if (shutdowner != null) {
+			log.info("Using a ContainerShutdown registered in context [" + shutdowner + "]");
+			shutdowner.shutdown(getRegisteredContainers());
+		}
+		else {
+			log.info("Shutting down remaining containers: "
+					+ StringUtils.collectionToCommaDelimitedString(runningContainers.values()));
+			for (Container container : runningContainers.values()) {
+				try {
+					log.info("Shutting down container " + container);
+					getCmTemplate(container).stopContainers();
+				} catch (Exception e) {
+					log.warn("Got error stopping container " + container);
+				}
+			}
+		}
+		return true;
+	}
+
+	protected Map<Container, ContainerRegisterInfo> getRegisteredContainers() {
+		return registeredContainers;
+	}
+
+	/**
+	 * Interceptor adding container env variable for appmaster track service.
+	 */
+	private class AddTrackServiceContainerLaunchInterceptor implements ContainerLauncherInterceptor {
+
+		private final AppmasterTrackService appmasterTrackService;
+
+		AddTrackServiceContainerLaunchInterceptor(AppmasterTrackService appmasterTrackService) {
+			this.appmasterTrackService = appmasterTrackService;
+		}
+
+		@Override
+		public ContainerLaunchContext preLaunch(Container container, ContainerLaunchContext context) {
+			if (appmasterTrackService != null && StringUtils.hasText(appmasterTrackService.getTrackUrl())) {
+				String address = appmasterTrackService.getTrackUrl();
+				log.debug("Adding " + YarnSystemConstants.AMSERVICE_TRACKURL + "=" + address
+						+ " to container launch context");
+				Map<String, String> environment = new HashMap<String, String>(context.getEnvironment());
+				environment.put(YarnSystemConstants.AMSERVICE_TRACKURL, address);
+				context.setEnvironment(environment);
+				return context;
+			}
+			return context;
+		}
+
 	}
 
 }

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/cluster/AbstractContainerClusterAppmaster.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/cluster/AbstractContainerClusterAppmaster.java
@@ -35,10 +35,7 @@ import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
-import org.springframework.yarn.YarnSystemException;
 import org.springframework.yarn.am.AbstractEventingAppmaster;
-import org.springframework.yarn.am.AppmasterCmOperations;
-import org.springframework.yarn.am.AppmasterCmTemplate;
 import org.springframework.yarn.am.ContainerLauncherInterceptor;
 import org.springframework.yarn.am.allocate.AbstractAllocator;
 import org.springframework.yarn.am.allocate.ContainerAllocateData;
@@ -335,16 +332,6 @@ public abstract class AbstractContainerClusterAppmaster extends AbstractEventing
 
 	protected void killContainer(Container container) {
 		killQueue.add(container);
-	}
-
-	protected AppmasterCmOperations getCmTemplate(Container container) {
-		try {
-			AppmasterCmTemplate template = new AppmasterCmTemplate(getConfiguration(), container);
-			template.afterPropertiesSet();
-			return template;
-		} catch (Exception e) {
-			throw new YarnSystemException("Unable to create AppmasterCmTemplate", e);
-		}
 	}
 
 	/**

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/container/ContainerRegisterInfo.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/container/ContainerRegisterInfo.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.yarn.am.container;
+
+/**
+ * Domain class for keeping container register information together.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class ContainerRegisterInfo {
+
+	private String trackUrl;
+
+	/**
+	 * Instantiates a new container register info.
+	 */
+	public ContainerRegisterInfo() {
+	}
+
+	/**
+	 * Instantiates a new container register info.
+	 *
+	 * @param trackUrl the track url
+	 */
+	public ContainerRegisterInfo(String trackUrl) {
+		this.trackUrl = trackUrl;
+	}
+
+	/**
+	 * Gets the track url.
+	 *
+	 * @return the track url
+	 */
+	public String getTrackUrl() {
+		return trackUrl;
+	}
+
+	/**
+	 * Sets the track url.
+	 *
+	 * @param trackUrl the new track url
+	 */
+	public void setTrackUrl(String trackUrl) {
+		this.trackUrl = trackUrl;
+	}
+
+
+}

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/container/ContainerShutdown.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/container/ContainerShutdown.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.yarn.am.container;
+
+import java.util.Map;
+
+import org.apache.hadoop.yarn.api.records.Container;
+
+/**
+ * Generic strategy interface to shutdown containers. Implementor can
+ * choose how containers are brought down which may either happen
+ * by killing via node manager or i.e. via boot shutdown endpoint
+ * if that is known in a info structure.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public interface ContainerShutdown {
+
+	/**
+	 * Shutdown containers.
+	 *
+	 * @param containers the containers
+	 * @return true, if shutdown is considered successful
+	 */
+	boolean shutdown(Map<Container, ContainerRegisterInfo> containers);
+
+}

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/event/ContainerRegisterEvent.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/event/ContainerRegisterEvent.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.yarn.event;
+
+import org.apache.hadoop.yarn.api.records.Container;
+
+/**
+ * Generic event representing that {@link Container} has been registered. This
+ * event is usually sent into context via boot endpoint handling registering
+ * http posts from a YARN containers.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@SuppressWarnings("serial")
+public class ContainerRegisterEvent extends AbstractYarnEvent {
+
+	private String containerId;
+
+	private String trackUrl;
+
+	/**
+	 * Instantiates a new container register event.
+	 *
+	 * @param source the source
+	 * @param containerId the container id
+	 * @param trackUrl the track url
+	 */
+	public ContainerRegisterEvent(Object source, String containerId, String trackUrl) {
+		super(source);
+		this.containerId = containerId;
+		this.trackUrl = trackUrl;
+	}
+
+	/**
+	 * Gets the container id.
+	 *
+	 * @return the container id
+	 */
+	public String getContainerId() {
+		return containerId;
+	}
+
+	/**
+	 * Gets the track url.
+	 *
+	 * @return the track url
+	 */
+	public String getTrackUrl() {
+		return trackUrl;
+	}
+
+	@Override
+	public String toString() {
+		return "ContainerRegisterEvent [containerId=" + containerId + ", trackUrl=" + trackUrl + "]";
+	}
+
+}

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/YarnContextUtils.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/YarnContextUtils.java
@@ -24,6 +24,7 @@ import org.springframework.util.Assert;
 import org.springframework.yarn.YarnSystemConstants;
 import org.springframework.yarn.am.AppmasterService;
 import org.springframework.yarn.am.AppmasterTrackService;
+import org.springframework.yarn.am.container.ContainerShutdown;
 import org.springframework.yarn.event.YarnEventPublisher;
 
 /**
@@ -139,6 +140,17 @@ public class YarnContextUtils {
 	 */
 	public static YarnEventPublisher getEventPublisher(BeanFactory beanFactory) {
 		return getBeanOfType(beanFactory, YarnSystemConstants.DEFAULT_ID_EVENT_PUBLISHER, YarnEventPublisher.class);
+	}
+
+	/**
+	 * Return the {@link ContainerShutdown} bean whose name is "yarnContainerShutdown" if
+	 * available.
+	 *
+	 * @param beanFactory BeanFactory for lookup, must not be null.
+	 * @return yarn container shutdown
+	 */
+	public static ContainerShutdown getContainerShutdown(BeanFactory beanFactory) {
+		return getBeanOfType(beanFactory, YarnSystemConstants.DEFAULT_CONTAINER_SHUTDOWN, ContainerShutdown.class);
 	}
 
 	/**


### PR DESCRIPTION
- First stage changes
- This now brings a base support for allowing boot based
  yarn app to shut itself down. Configuration is not yet
  fully automated in terms of auto-configuration but
  allows you to define custom beans on your app side
  to do shutdown cleanly.
- Add ContainerShutdown interface to allow external beans
  to shutdown containers.
- Add YarnContainerRegisterMvcEndpoint which container
  can use to register itself i.e. telling its
  shutdown boot endpoint.
- Add YarnShutdownCommand which can use boot shutdown
  endpoint to tell appmaster to go down.
- Second stage brings more auto-configuration changes
  to make things easier.
