### PR TITLE
SHDP-436 Adding counter measures for closing writers

### DIFF
--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/support/StoreObjectSupport.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/support/StoreObjectSupport.java
@@ -78,7 +78,6 @@ public abstract class StoreObjectSupport extends LifecycleObjectSupport {
 		if (idleTimeout > 0) {
 			idleTrigger = new IdleTimeoutTrigger(idleTimeout);
 			idlePoller = new IdleTimeoutPoller(getTaskScheduler(), getTaskExecutor(), idleTrigger);
-			idlePoller.setStopWaitResultsTimeout(10000);
 			idlePoller.init();
 		}
 	}


### PR DESCRIPTION
- Added explicit `closed` flag in AbstractPartitionDataStoreWriter
  indicating a writer is closed and should not be used anymore.
  This now follows how writer should work after close() is called
  or context lifecycle stop has been initiated.
- Removed idlePoller result waiting in StoreObjectSupport
  which just never worked to let scheduled task to finish.
  That caused more trouble than it was supposed to fix.
- Few more smoke and context closing tests.
