### PR TITLE
SHDP-443 Support ListenableFuture in YarnComponent

### DIFF
--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/YarnSystemException.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/YarnSystemException.java
@@ -71,4 +71,14 @@ public class YarnSystemException extends UncategorizedDataAccessException {
 		super(message, e);
 	}
 
+	/**
+	 * Constructs a general YarnSystemException.
+	 *
+	 * @param message the message
+	 * @param cause the throwable cause
+	 */
+	public YarnSystemException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
 }

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/AbstractYarnContainer.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/AbstractYarnContainer.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.springframework.yarn.listener.CompositeContainerStateListener;
 import org.springframework.yarn.listener.ContainerStateListener;
 import org.springframework.yarn.listener.ContainerStateListener.ContainerState;
+import org.springframework.yarn.support.LifecycleObjectSupport;
 
 /**
  * Base implementation of {@link YarnContainer} providing
@@ -33,7 +34,7 @@ import org.springframework.yarn.listener.ContainerStateListener.ContainerState;
  * @author Janne Valkealahti
  *
  */
-public abstract class AbstractYarnContainer implements LongRunningYarnContainer, YarnContainerRuntime {
+public abstract class AbstractYarnContainer extends LifecycleObjectSupport implements LongRunningYarnContainer, YarnContainerRuntime {
 
 	private final static Log log = LogFactory.getLog(AbstractYarnContainer.class);
 
@@ -62,6 +63,16 @@ public abstract class AbstractYarnContainer implements LongRunningYarnContainer,
 	@Override
 	public void setParameters(Properties parameters) {
 		this.parameters = parameters;
+	}
+
+	@Override
+	public void addContainerStateListener(ContainerStateListener listener) {
+		stateListener.register(listener);
+	}
+
+	@Override
+	public boolean isWaitCompleteState() {
+		return false;
 	}
 
 	/**
@@ -108,16 +119,6 @@ public abstract class AbstractYarnContainer implements LongRunningYarnContainer,
 	 */
 	public Properties getParameters() {
 		return parameters;
-	}
-
-	@Override
-	public void addContainerStateListener(ContainerStateListener listener) {
-		stateListener.register(listener);
-	}
-
-	@Override
-	public boolean isWaitCompleteState() {
-		return false;
 	}
 
 	/**

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/ContainerHandlersResultsProcessor.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/ContainerHandlersResultsProcessor.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.yarn.container;
+
+import java.util.List;
+import java.util.concurrent.Future;
+
+import org.springframework.util.concurrent.ListenableFuture;
+
+/**
+ * Strategy interface for handling a processing of results
+ * resolved from {@link ContainerHandler}s.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+interface ContainerHandlersResultsProcessor {
+
+	/**
+	 * Adding list of results for processing.
+	 *
+	 * @param results the results
+	 */
+	void process(List<Object> results);
+
+	/**
+	 * Gets the final result wrapped in {@link ResultHolder} containing
+	 * actual results and possible {@link Exception}.
+	 *
+	 * @return the result
+	 */
+	ResultHolder getResult();
+
+	/**
+	 * Cancel all {@link Future}s.
+	 */
+	void cancel();
+
+	/**
+	 * Checks if all {@link ListenableFuture}s have completed
+	 * its callbacks.
+	 *
+	 * @return true, if listenables are done
+	 */
+	boolean isListenablesDone();
+
+	/**
+	 * Sets the listenables complete listener. Existing listener
+	 * if set will be replaced.
+	 *
+	 * @param listener the new listenables complete listener
+	 */
+	void setListenablesCompleteListener(ListenablesComplete listener);
+
+	/**
+	 * Results wrapper having a list of results and possible exception.
+	 */
+	interface ResultHolder {
+		List<Object> getResults();
+		Exception getException();
+	}
+
+	/**
+	 * Interface to listen completion event when {@link ListenableFuture}s,
+	 * if any, have completed its callbacks.
+	 */
+	interface ListenablesComplete {
+
+		/**
+		 * This complete method will be called when all
+		 * {@link ListenableFuture}s have completed its
+		 * callbacks.
+		 */
+		void complete();
+	}
+
+}

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/DefaultContainerHandlersResultsProcessor.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/DefaultContainerHandlersResultsProcessor.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.yarn.container;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.util.concurrent.ListenableFuture;
+import org.springframework.util.concurrent.ListenableFutureCallback;
+import org.springframework.yarn.YarnSystemException;
+
+/**
+ * Default implementation of {@link ContainerHandlersResultsProcessor}.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+class DefaultContainerHandlersResultsProcessor implements ContainerHandlersResultsProcessor {
+
+	private static final Log log = LogFactory.getLog(DefaultContainerHandlersResultsProcessor.class);
+
+	private final List<Result> wrappedResults = new ArrayList<Result>();
+
+	private final AtomicInteger activeListenables = new AtomicInteger();
+
+	private Exception runtimeException = null;
+
+	private ListenablesComplete listener;
+
+	@Override
+	public void process(List<Object> results) {
+		for (Object result : results) {
+			wrappedResults.add(new Result(result));
+			if (result instanceof ListenableFuture<?>) {
+				activeListenables.incrementAndGet();
+			}
+		}
+
+		for (final Result wrappedResult : wrappedResults) {
+			if (wrappedResult.result instanceof ListenableFuture<?>) {
+				((ListenableFuture<?>) wrappedResult.result).addCallback(new ListenableFutureCallback<Object>() {
+
+					@Override
+					public void onSuccess(Object result) {
+						if (log.isDebugEnabled()) {
+							log.info("onSuccess for " + wrappedResult + " with result=[" + result + "]");
+						}
+						wrappedResult.setResult(result);
+						activeListenables.decrementAndGet();
+						mayNotifyListener();
+					}
+
+					@Override
+					public void onFailure(Throwable t) {
+						if (log.isDebugEnabled()) {
+							log.info("onFailure for " + wrappedResult + " with throwable=[" + t + "]");
+						}
+						runtimeException = new YarnSystemException("error", t);
+						activeListenables.decrementAndGet();
+						mayNotifyListener();
+					}
+
+				});
+
+			}
+		}
+
+	}
+
+	@Override
+	public ResultHolder getResult() {
+		final List<Object> res = new ArrayList<Object>();
+		for (Result r : wrappedResults) {
+			try {
+				res.add(r.getResult());
+			} catch (Exception e) {
+				log.debug("Future get() resulted error", e);
+			}
+		}
+		return new ResultHolder() {
+
+			@Override
+			public List<Object> getResults() {
+				return res;
+			}
+
+			@Override
+			public Exception getException() {
+				return runtimeException;
+			}
+		};
+	}
+
+	@Override
+	public void cancel() {
+		for (final Result wrappedResult : wrappedResults) {
+			try {
+				log.info("Cancelling " + wrappedResult);
+				wrappedResult.cancelIfFuture();
+			} catch (Exception e) {
+				log.error("error in cancel", e);
+			}
+		}
+	}
+
+	@Override
+	public boolean isListenablesDone() {
+		return activeListenables.get() == 0;
+	}
+
+	@Override
+	public void setListenablesCompleteListener(ListenablesComplete listener) {
+		this.listener = listener;
+	}
+
+	private void mayNotifyListener() {
+		if (activeListenables.get() == 0) {
+			if (listener != null) {
+				listener.complete();
+			}
+		}
+	}
+
+	/**
+	 * Wrapped for result object to make it easier to handle
+	 * result as a {@link Future}.
+	 */
+	private static class Result {
+
+		Object result;
+
+		Result(Object result) {
+			this.result = result;
+		}
+
+		/**
+		 * Request a cancel if result is a {@link Future}.
+		 */
+		void cancelIfFuture() {
+			if (result instanceof Future<?>) {
+				((Future<?>)result).cancel(true);
+			}
+		}
+
+		/**
+		 * Gets the result. If result is a future this
+		 * method delegates to {@link Future#get()}.
+		 *
+		 * @return the result
+		 */
+		Object getResult() {
+			if (result instanceof Future<?>) {
+				Future<?> f = (Future<?>)result;
+				try {
+					return f.get();
+				} catch (CancellationException e) {
+				} catch (InterruptedException e) {
+				} catch (ExecutionException e) {
+					return new YarnSystemException("Future throwed error", e.getCause());
+				}
+				return null;
+			} else {
+				return result;
+			}
+		}
+
+		/**
+		 * Sets the result.
+		 *
+		 * @param result the new result
+		 */
+		void setResult(Object result) {
+			this.result = result;
+		}
+
+	}
+
+}

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/DefaultYarnContainer.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/DefaultYarnContainer.java
@@ -18,20 +18,22 @@ package org.springframework.yarn.container;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
-import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextClosedEvent;
 import org.springframework.core.OrderComparator;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
+import org.springframework.util.concurrent.ListenableFuture;
+import org.springframework.yarn.container.ContainerHandlersResultsProcessor.ListenablesComplete;
+import org.springframework.yarn.container.ContainerHandlersResultsProcessor.ResultHolder;
 import org.springframework.yarn.listener.ContainerStateListener.ContainerState;
 
 /**
@@ -40,56 +42,50 @@ import org.springframework.yarn.listener.ContainerStateListener.ContainerState;
  * @author Janne Valkealahti
  *
  */
-public class DefaultYarnContainer extends AbstractYarnContainer implements BeanFactoryAware {
+public class DefaultYarnContainer extends AbstractYarnContainer implements ApplicationListener<ContextClosedEvent> {
 
 	private final static Log log = LogFactory.getLog(DefaultYarnContainer.class);
 
-	private ListableBeanFactory beanFactory;
+	private final ContainerHandlersResultsProcessor processor = new DefaultContainerHandlersResultsProcessor();
+
+	private final AtomicBoolean endNotified = new AtomicBoolean();
+
+	private volatile boolean contextClosing = false;
 
 	@Override
 	protected void runInternal() {
-		log.info("runInternal");
-		Exception runtimeException = null;
-		List<Object> results = new ArrayList<Object>();
+
+		processor.setListenablesCompleteListener(new ListenablesComplete() {
+			@Override
+			public void complete() {
+				log.info("Got ListenablesComplete complete notification");
+				if (!contextClosing) {
+					ResultHolder result = processor.getResult();
+					log.info("About to notifyEndState from a listener callback");
+					notifyEndState(result.getResults(), result.getException());
+				}
+			}
+		});
 
 		try {
-			Map<String, ContainerHandler> handlers = beanFactory.getBeansOfType(ContainerHandler.class);
-			List<ContainerHandler> orderHandlers = orderHandlers(handlers);
-			for (ContainerHandler handler : orderHandlers) {
-				results.add(handler.handle(this));
-			}
+			handleResults(getContainerHandlerResults(getContainerHandlers()));
 		} catch (Exception e) {
-			runtimeException = e;
-			log.error("Error handling container", e);
-		}
-
-		try {
-			results = waitFutures(results);
-		} catch (Exception e) {
-			runtimeException = e;
-			log.error("Error handling futures", e);
-		}
-
-		log.info("Container state based on method results=[" + StringUtils.arrayToCommaDelimitedString(results.toArray())
-				+ "] runtimeException=[" + runtimeException + "]");
-
-		if (runtimeException != null) {
-			notifyContainerState(ContainerState.FAILED, runtimeException);
-		} else if (!isEmptyValues(results)) {
-			if (results.size() == 1) {
-				notifyContainerState(ContainerState.COMPLETED, results.get(0));
-			} else {
-				notifyContainerState(ContainerState.COMPLETED, results);
-			}
-		} else {
-			notifyCompleted();
+			log.info("About to notifyEndState from catched exception", e);
+			notifyEndState(new ArrayList<Object>(), e);
 		}
 	}
 
 	@Override
-	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
-		Assert.isInstanceOf(ListableBeanFactory.class, beanFactory, "Beanfactory must be of type ListableBeanFactory");
-		this.beanFactory = (ListableBeanFactory) beanFactory;
+	protected void doStop() {
+		log.info("Stopping DefaultYarnContainer and cancelling Futures");
+		// need to cancel pending futures
+
+		processor.cancel();
+		if (contextClosing) {
+			ResultHolder result = processor.getResult();
+			log.info("About to notifyEndState from doStop because contextClosing=" + contextClosing);
+			notifyEndState(result.getResults(), result.getException());
+		}
 	}
 
 	@Override
@@ -99,46 +95,12 @@ public class DefaultYarnContainer extends AbstractYarnContainer implements BeanF
 		return true;
 	}
 
-	/**
-	 * Returns ordered list of {@link ContainerHandler}s.
-	 *
-	 * @param handlers the handlers
-	 * @return the list ordered list
-	 */
-	private List<ContainerHandler> orderHandlers(Map<String, ContainerHandler> handlers) {
-		List<ContainerHandler> handlersList = new ArrayList<ContainerHandler>(handlers.values());
-		OrderComparator comparator = new OrderComparator();
-		Collections.sort(handlersList, comparator);
-		return handlersList;
+	@Override
+	public void onApplicationEvent(ContextClosedEvent event) {
+		log.info("Setting contextClosing flag because of ContextClosedEvent");
+		contextClosing = true;
 	}
 
-	/**
-	 * Iterates list and replaces Future values with
-	 * a real ones.
-	 *
-	 * @param results the results to iterate
-	 * @return the modified list
-     * @throws ExecutionException if the computation threw an exception
-     * @throws InterruptedException if the current thread was interrupted while waiting
-	 */
-	private List<Object> waitFutures(List<Object> results) throws InterruptedException, ExecutionException {
-		ListIterator<Object> iterator = results.listIterator();
-		while (iterator.hasNext()) {
-			Object result = (Object) iterator.next();
-			if (result instanceof Future<?>) {
-				iterator.set(((Future<?>) result).get());
-			}
-		}
-		return results;
-	}
-
-	/**
-	 * Checks if list contains just null objects or
-	 * empty strings.
-	 *
-	 * @param results the results
-	 * @return true, if is empty values
-	 */
 	private boolean isEmptyValues(List<Object> results) {
 		for (Object o : results) {
 			if (o != null) {
@@ -152,6 +114,73 @@ public class DefaultYarnContainer extends AbstractYarnContainer implements BeanF
 			}
 		}
 		return true;
+	}
+
+	private void notifyEndState(List<Object> results, Exception runtimeException) {
+		if (endNotified.getAndSet(true)) {
+			log.warn("We already notified end state, discarding this");
+			return;
+		}
+		log.info("Container state based on method results=[" + StringUtils.arrayToCommaDelimitedString(results.toArray())
+				+ "] runtimeException=[" + runtimeException + "]");
+		if (runtimeException != null) {
+			notifyContainerState(ContainerState.FAILED, runtimeException);
+		} else if (!isEmptyValues(results)) {
+			if (results.size() == 1) {
+				notifyContainerState(ContainerState.COMPLETED, results.get(0));
+			} else {
+				notifyContainerState(ContainerState.COMPLETED, results);
+			}
+		} else {
+			notifyCompleted();
+		}
+	}
+
+	/**
+	 * Handles results by delegating to results processor.
+	 *
+	 * @param results the results
+	 */
+	private void handleResults(List<Object> results) {
+		processor.process(results);
+		if (processor.isListenablesDone()) {
+			ResultHolder result = processor.getResult();
+			log.info("About to notifyEndState from handleResults because processor is done with listenables");
+			notifyEndState(result.getResults(), result.getException());
+		}
+	}
+
+	/**
+	 * Gets the container handler results. This will resolve result objects
+	 * from a {@link ContainerHandler}s by calling its {@link ContainerHandler#handle(YarnContainerRuntime)}
+	 * methods. Result may be null in case of void method, {@link Exception},
+	 * {@link Future}, {@link ListenableFuture} or any other arbitrary {@link Object}.
+	 *
+	 * @param containerHandlers the container handlers
+	 * @return the container handler results
+	 */
+	private List<Object> getContainerHandlerResults(List<ContainerHandler> containerHandlers) {
+		List<Object> results = new ArrayList<Object>();
+		for (ContainerHandler handler : containerHandlers) {
+			results.add(handler.handle(this));
+		}
+		return results;
+	}
+
+	/**
+	 * Resolves all {@link ContainerHandler} beans from a bean factory. Returned
+	 * list is sorted using {@link OrderComparator}.
+	 *
+	 * @return the container handlers
+	 */
+	private List<ContainerHandler> getContainerHandlers() {
+		BeanFactory bf = getBeanFactory();
+		Assert.state(bf instanceof ListableBeanFactory, "Bean factory must be instance of ListableBeanFactory");
+		Map<String, ContainerHandler> handlers = ((ListableBeanFactory)bf).getBeansOfType(ContainerHandler.class);
+		List<ContainerHandler> handlersList = new ArrayList<ContainerHandler>(handlers.values());
+		OrderComparator comparator = new OrderComparator();
+		Collections.sort(handlersList, comparator);
+		return handlersList;
 	}
 
 }

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/container/DefaultYarnContainerTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/container/DefaultYarnContainerTests.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.yarn.container;
 
+import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.is;
@@ -31,6 +32,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.scheduling.annotation.AsyncResult;
+import org.springframework.util.concurrent.ListenableFuture;
+import org.springframework.util.concurrent.SettableListenableFuture;
 import org.springframework.yarn.annotation.OnContainerStart;
 import org.springframework.yarn.annotation.YarnComponent;
 import org.springframework.yarn.config.annotation.SpringYarnAnnotationPostProcessor;
@@ -56,6 +59,7 @@ public class DefaultYarnContainerTests {
 		container.addContainerStateListener(new ContainerStateListener() {
 			@Override
 			public void state(ContainerState state, Object exit) {
+				stateWrapper.count.incrementAndGet();
 				stateWrapper.state = state;
 				stateWrapper.exit = exit;
 			}
@@ -65,6 +69,7 @@ public class DefaultYarnContainerTests {
 		assertThat(stateWrapper.state, is(ContainerState.COMPLETED));
 		assertThat(stateWrapper.exit, instanceOf(Integer.class));
 		assertThat((Integer)stateWrapper.exit, is(0));
+		assertThat(stateWrapper.count.get(), is(1));
 
 		context.stop();
 	}
@@ -79,6 +84,7 @@ public class DefaultYarnContainerTests {
 		container.addContainerStateListener(new ContainerStateListener() {
 			@Override
 			public void state(ContainerState state, Object exit) {
+				stateWrapper.count.incrementAndGet();
 				stateWrapper.state = state;
 				stateWrapper.exit = exit;
 			}
@@ -88,6 +94,7 @@ public class DefaultYarnContainerTests {
 		assertThat(stateWrapper.state, is(ContainerState.COMPLETED));
 		assertThat(stateWrapper.exit, instanceOf(Boolean.class));
 		assertThat((Boolean)stateWrapper.exit, is(true));
+		assertThat(stateWrapper.count.get(), is(1));
 
 		context.stop();
 	}
@@ -102,6 +109,7 @@ public class DefaultYarnContainerTests {
 		container.addContainerStateListener(new ContainerStateListener() {
 			@Override
 			public void state(ContainerState state, Object exit) {
+				stateWrapper.count.incrementAndGet();
 				stateWrapper.state = state;
 				stateWrapper.exit = exit;
 			}
@@ -111,6 +119,7 @@ public class DefaultYarnContainerTests {
 		assertThat(stateWrapper.state, is(ContainerState.COMPLETED));
 		assertThat(stateWrapper.exit, instanceOf(Integer.class));
 		assertThat((Integer)stateWrapper.exit, is(10));
+		assertThat(stateWrapper.count.get(), is(1));
 
 		context.stop();
 	}
@@ -125,6 +134,7 @@ public class DefaultYarnContainerTests {
 		container.addContainerStateListener(new ContainerStateListener() {
 			@Override
 			public void state(ContainerState state, Object exit) {
+				stateWrapper.count.incrementAndGet();
 				stateWrapper.state = state;
 				stateWrapper.exit = exit;
 			}
@@ -133,6 +143,7 @@ public class DefaultYarnContainerTests {
 		container.run();
 		assertThat(stateWrapper.state, is(ContainerState.FAILED));
 		assertThat(stateWrapper.exit, instanceOf(Exception.class));
+		assertThat(stateWrapper.count.get(), is(1));
 
 		context.stop();
 	}
@@ -147,6 +158,7 @@ public class DefaultYarnContainerTests {
 		container.addContainerStateListener(new ContainerStateListener() {
 			@Override
 			public void state(ContainerState state, Object exit) {
+				stateWrapper.count.incrementAndGet();
 				stateWrapper.state = state;
 				stateWrapper.exit = exit;
 			}
@@ -156,6 +168,7 @@ public class DefaultYarnContainerTests {
 		assertThat(stateWrapper.state, is(ContainerState.COMPLETED));
 		assertThat(stateWrapper.exit, instanceOf(String.class));
 		assertThat((String)stateWrapper.exit, is("UNKNOWN"));
+		assertThat(stateWrapper.count.get(), is(1));
 
 		context.stop();
 	}
@@ -170,6 +183,7 @@ public class DefaultYarnContainerTests {
 		container.addContainerStateListener(new ContainerStateListener() {
 			@Override
 			public void state(ContainerState state, Object exit) {
+				stateWrapper.count.incrementAndGet();
 				stateWrapper.state = state;
 				stateWrapper.exit = exit;
 			}
@@ -179,6 +193,7 @@ public class DefaultYarnContainerTests {
 		assertThat(stateWrapper.state, is(ContainerState.COMPLETED));
 		assertThat(stateWrapper.exit, instanceOf(Integer.class));
 		assertThat((Integer)stateWrapper.exit, is(0));
+		assertThat(stateWrapper.count.get(), is(1));
 
 		TestBean1 testBean1 = context.getBean(TestBean1.class);
 		TestBean7 testBean7 = context.getBean(TestBean7.class);
@@ -198,6 +213,7 @@ public class DefaultYarnContainerTests {
 		container.addContainerStateListener(new ContainerStateListener() {
 			@Override
 			public void state(ContainerState state, Object exit) {
+				stateWrapper.count.incrementAndGet();
 				stateWrapper.state = state;
 				stateWrapper.exit = exit;
 			}
@@ -207,6 +223,7 @@ public class DefaultYarnContainerTests {
 		assertThat(stateWrapper.state, is(ContainerState.COMPLETED));
 		assertThat(stateWrapper.exit, instanceOf(Integer.class));
 		assertThat((Integer)stateWrapper.exit, is(0));
+		assertThat(stateWrapper.count.get(), is(1));
 
 		TestBean5 testBean5 = context.getBean(TestBean5.class);
 		assertThat(testBean5.called1, is(true));
@@ -225,6 +242,7 @@ public class DefaultYarnContainerTests {
 		container.addContainerStateListener(new ContainerStateListener() {
 			@Override
 			public void state(ContainerState state, Object exit) {
+				stateWrapper.count.incrementAndGet();
 				stateWrapper.state = state;
 				stateWrapper.exit = exit;
 			}
@@ -234,6 +252,7 @@ public class DefaultYarnContainerTests {
 		assertThat(stateWrapper.state, is(ContainerState.COMPLETED));
 		assertThat(stateWrapper.exit, instanceOf(Integer.class));
 		assertThat((Integer)stateWrapper.exit, is(0));
+		assertThat(stateWrapper.count.get(), is(1));
 
 		TestBean1 testBean1 = context.getBean(TestBean1.class);
 		TestBean7 testBean7 = context.getBean(TestBean7.class);
@@ -256,6 +275,7 @@ public class DefaultYarnContainerTests {
 		container.addContainerStateListener(new ContainerStateListener() {
 			@Override
 			public void state(ContainerState state, Object exit) {
+				stateWrapper.count.incrementAndGet();
 				stateWrapper.state = state;
 				stateWrapper.exit = exit;
 			}
@@ -265,6 +285,7 @@ public class DefaultYarnContainerTests {
 		assertThat(stateWrapper.state, is(ContainerState.COMPLETED));
 		assertThat(stateWrapper.exit, instanceOf(Integer.class));
 		assertThat((Integer)stateWrapper.exit, is(0));
+		assertThat(stateWrapper.count.get(), is(1));
 
 		TestBean8 testBean8 = context.getBean(TestBean8.class);
 		TestBean9 testBean9 = context.getBean(TestBean9.class);
@@ -294,6 +315,7 @@ public class DefaultYarnContainerTests {
 		container.addContainerStateListener(new ContainerStateListener() {
 			@Override
 			public void state(ContainerState state, Object exit) {
+				stateWrapper.count.incrementAndGet();
 				stateWrapper.state = state;
 				stateWrapper.exit = exit;
 			}
@@ -303,6 +325,7 @@ public class DefaultYarnContainerTests {
 		assertThat(stateWrapper.state, is(ContainerState.COMPLETED));
 		assertThat(stateWrapper.exit, instanceOf(Integer.class));
 		assertThat((Integer)stateWrapper.exit, is(0));
+		assertThat(stateWrapper.count.get(), is(1));
 
 		TestBean10 testBean10 = context.getBean(TestBean10.class);
 		assertThat(testBean10.called1, is(true));
@@ -325,6 +348,7 @@ public class DefaultYarnContainerTests {
 		container.addContainerStateListener(new ContainerStateListener() {
 			@Override
 			public void state(ContainerState state, Object exit) {
+				stateWrapper.count.incrementAndGet();
 				stateWrapper.state = state;
 				stateWrapper.exit = exit;
 			}
@@ -335,6 +359,7 @@ public class DefaultYarnContainerTests {
 		assertThat(stateWrapper.exit, instanceOf(List.class));
 		assertThat((Integer)((List<?>)stateWrapper.exit).get(9), is(1));
 		assertThat((Integer)((List<?>)stateWrapper.exit).get(11), is(2));
+		assertThat(stateWrapper.count.get(), is(1));
 
 		TestBean8 testBean8 = context.getBean(TestBean8.class);
 		TestBean9 testBean9 = context.getBean(TestBean9.class);
@@ -379,6 +404,7 @@ public class DefaultYarnContainerTests {
 		container.addContainerStateListener(new ContainerStateListener() {
 			@Override
 			public void state(ContainerState state, Object exit) {
+				stateWrapper.count.incrementAndGet();
 				stateWrapper.state = state;
 				stateWrapper.exit = exit;
 			}
@@ -387,6 +413,7 @@ public class DefaultYarnContainerTests {
 		container.run();
 		assertThat(stateWrapper.state, is(ContainerState.COMPLETED));
 		assertThat(stateWrapper.exit, instanceOf(List.class));
+		assertThat(stateWrapper.count.get(), is(1));
 		assertThat((Integer)((List<?>)stateWrapper.exit).get(0), is(1));
 		assertThat((Integer)((List<?>)stateWrapper.exit).get(1), nullValue());
 		assertThat((Integer)((List<?>)stateWrapper.exit).get(2), is(2));
@@ -401,6 +428,72 @@ public class DefaultYarnContainerTests {
 		assertThat(testBean12.order3, is(2));
 
 		context.stop();
+	}
+
+	@Test
+	public void testListenableFutureValues() {
+		@SuppressWarnings("resource")
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(BaseConfig.class, ListenableFutureValuesConfig.class);
+		DefaultYarnContainer container = context.getBean(DefaultYarnContainer.class);
+		final StateWrapper stateWrapper = new StateWrapper();
+
+		container.addContainerStateListener(new ContainerStateListener() {
+			@Override
+			public void state(ContainerState state, Object exit) {
+				stateWrapper.count.incrementAndGet();
+				stateWrapper.state = state;
+				stateWrapper.exit = exit;
+			}
+		});
+
+		container.run();
+		assertThat(stateWrapper.state, is(ContainerState.COMPLETED));
+		assertThat(stateWrapper.exit, instanceOf(List.class));
+		assertThat(stateWrapper.count.get(), is(1));
+		assertThat((Integer)((List<?>)stateWrapper.exit).size(), is(3));
+		assertThat((Integer)((List<?>)stateWrapper.exit).get(0), anyOf(is(1), nullValue()));
+		assertThat((Integer)((List<?>)stateWrapper.exit).get(1), anyOf(is(1), nullValue()));
+		assertThat((Integer)((List<?>)stateWrapper.exit).get(2), anyOf(is(1), nullValue()));
+
+		TestBean13 testBean13 = context.getBean(TestBean13.class);
+		assertThat(testBean13.called1, is(true));
+		assertThat(testBean13.called2, is(true));
+		assertThat(testBean13.called3, is(true));
+
+		context.stop();
+	}
+
+	@Test
+	public void testCatchInterruptTaskFuture() {
+		@SuppressWarnings("resource")
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(BaseConfig.class, CatchInterruptTaskFutureConfig.class);
+		DefaultYarnContainer container = context.getBean(DefaultYarnContainer.class);
+		final StateWrapper stateWrapper = new StateWrapper();
+
+		container.addContainerStateListener(new ContainerStateListener() {
+			@Override
+			public void state(ContainerState state, Object exit) {
+				stateWrapper.count.incrementAndGet();
+				stateWrapper.state = state;
+				stateWrapper.exit = exit;
+			}
+		});
+
+		container.run();
+		// we've not got any results yet
+		assertThat(stateWrapper.state, nullValue());
+		assertThat(stateWrapper.exit, nullValue());
+		assertThat(stateWrapper.count.get(), is(0));
+
+		TestBean14 testBean14 = context.getBean(TestBean14.class);
+		assertThat(testBean14.called1, is(true));
+		assertThat(testBean14.called2, is(true));
+		assertThat(testBean14.future1.interrupted, is(false));
+		assertThat(testBean14.future2.interrupted, is(false));
+
+		context.stop();
+		assertThat(testBean14.future1.interrupted, is(true));
+		assertThat(testBean14.future2.interrupted, is(true));
 	}
 
 	@Configuration
@@ -553,6 +646,22 @@ public class DefaultYarnContainerTests {
 		@Bean
 		TestBean12 testBean12() {
 			return new TestBean12(executionOrder);
+		}
+	}
+
+	@Configuration
+	static class ListenableFutureValuesConfig {
+		@Bean
+		TestBean13 testBean13() {
+			return new TestBean13();
+		}
+	}
+
+	@Configuration
+	static class CatchInterruptTaskFutureConfig {
+		@Bean
+		TestBean14 testBean14() {
+			return new TestBean14();
 		}
 	}
 
@@ -817,9 +926,66 @@ public class DefaultYarnContainerTests {
 		}
 	}
 
+	@YarnComponent
+	private static class TestBean13 {
+
+		boolean called1 = false;
+		boolean called2 = false;
+		boolean called3 = false;
+
+		@OnContainerStart
+		public void test1() {
+			called1 = true;
+		}
+
+		@OnContainerStart
+		public ListenableFuture<Integer> test2() {
+			called2 = true;
+			return new AsyncResult<Integer>(1);
+		}
+
+		@OnContainerStart
+		public ListenableFuture<Integer> test3() {
+			called3 = true;
+			return new AsyncResult<Integer>(1);
+		}
+	}
+
+	@YarnComponent
+	private static class TestBean14 {
+
+		boolean called1 = false;
+		boolean called2 = false;
+		CatchInterruptTaskFuture future1 = new CatchInterruptTaskFuture();
+		CatchInterruptTaskFuture future2 = new CatchInterruptTaskFuture();
+
+		@OnContainerStart
+		public ListenableFuture<Integer> test1() {
+			called1 = true;
+			return future1;
+		}
+
+		@OnContainerStart
+		public ListenableFuture<Integer> test2() {
+			called2 = true;
+			return future2;
+		}
+	}
+
 	private static class StateWrapper {
 		ContainerState state;
 		Object exit;
+		AtomicInteger count = new AtomicInteger();
+	}
+
+	private static class CatchInterruptTaskFuture extends SettableListenableFuture<Integer> {
+
+		boolean interrupted = false;
+
+		@Override
+		protected void interruptTask() {
+			interrupted = true;
+		}
 	}
 
 }

--- a/spring-yarn/spring-yarn-core/src/test/resources/log4j.properties
+++ b/spring-yarn/spring-yarn-core/src/test/resources/log4j.properties
@@ -2,7 +2,7 @@ log4j.rootCategory=INFO, stdout
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} %5p %t %c{2} - %m%n
+log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} %5p %t %c{2} [%t] - %m%n
 
 log4j.category.org.springframework.hadoop.test=DEBUG
 log4j.category.org.springframework.batch=TRACE


### PR DESCRIPTION
- Rewrite DefaultYarnContainer and separate some new
  functionality into separate classe, namely
  DefaultContainerHandlersResultsProcessor and its
  interface ContainerHandlersResultsProcessor.
- AbstractYarnContainer now extends LifecycleObjectSupport
  and polished it a little.
