### PR TITLE
SHDP-447 PartitionTextFileWriter doesn't stop TextFileWriter

### DIFF
--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/PartitionTextFileWriter.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/PartitionTextFileWriter.java
@@ -58,6 +58,7 @@ public class PartitionTextFileWriter<K> extends AbstractPartitionDataStoreWriter
 				// close() to writer
 				destroyWriter(path);
 				super.close();
+				stop();
 			}
 		};
 		if (getBeanFactory() != null) {

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/TextFileWriter.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/TextFileWriter.java
@@ -134,7 +134,7 @@ public class TextFileWriter extends AbstractDataStreamWriter implements DataStor
 	@Override
 	protected void handleIdleTimeout() {
 		try {
-			log.info("Idle timeout detected for this writer, closing stream");
+			log.info("Idle timeout detected for this writer=[" + this +  "], closing stream");
 			flush();
 			close();
 		} catch (IOException e) {

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/support/OutputStoreObjectSupport.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/support/OutputStoreObjectSupport.java
@@ -263,6 +263,7 @@ public abstract class OutputStoreObjectSupport extends StoreObjectSupport {
 	 * @param path the path to rename
 	 */
 	protected void renameFile(Path path) {
+		log.debug("renameFile called with path=[" + path + "]");
 		// bail out if there's no in-writing settings
 		if (!StringUtils.hasText(prefix) && !StringUtils.hasText(suffix)) {
 			return;
@@ -281,6 +282,7 @@ public abstract class OutputStoreObjectSupport extends StoreObjectSupport {
 			boolean succeed;
 			try {
 				fs.delete(toPath, false);
+				log.info("Renaming path=[" + path + "] toPath=[" + toPath + "]");
 				succeed = fs.rename(path, toPath);
 			} catch (Exception e) {
 				throw new StoreException("Failed renaming from " + path + " to " + toPath, e);


### PR DESCRIPTION
- Added lifecycle stop() call when TextFileWriter close() is called
  which should stop running tasks in underlying writer.
- Added one new smoke test to catch this bug.
- Little more logging which should help if trouble returns.
