### PR TITLE
SHDP-439 Add support for graceful yarn app shutdown

### DIFF
--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/YarnAppmasterAutoConfiguration.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/YarnAppmasterAutoConfiguration.java
@@ -42,6 +42,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.yarn.YarnSystemConstants;
 import org.springframework.yarn.am.AppmasterTrackService;
 import org.springframework.yarn.am.YarnAppmaster;
+import org.springframework.yarn.am.container.ContainerShutdown;
 import org.springframework.yarn.am.grid.GridProjectionFactory;
 import org.springframework.yarn.am.grid.GridProjectionFactoryLocator;
 import org.springframework.yarn.am.grid.support.DefaultGridProjectionFactory;
@@ -71,6 +72,7 @@ import org.springframework.yarn.boot.support.BootLocalResourcesSelector;
 import org.springframework.yarn.boot.support.BootLocalResourcesSelector.Mode;
 import org.springframework.yarn.boot.support.BootMultiLocalResourcesSelector;
 import org.springframework.yarn.boot.support.EmbeddedAppmasterTrackService;
+import org.springframework.yarn.boot.support.EndpointContainerShutdown;
 import org.springframework.yarn.boot.support.SpringYarnBootUtils;
 import org.springframework.yarn.config.annotation.EnableYarn;
 import org.springframework.yarn.config.annotation.EnableYarn.Enable;
@@ -337,6 +339,13 @@ public class YarnAppmasterAutoConfiguration {
 		@ConditionalOnBean(YarnContainerRegisterEndpoint.class)
 		public YarnContainerRegisterMvcEndpoint yarnContainerRegisterMvcEndpoint(YarnContainerRegisterEndpoint delegate) {
 			return new YarnContainerRegisterMvcEndpoint(delegate);
+		}
+
+		@ConditionalOnExpression("${endpoints.shutdown.enabled:false}")
+		@Bean(name=YarnSystemConstants.DEFAULT_CONTAINER_SHUTDOWN)
+		public ContainerShutdown containerShutdown() {
+			// only enable if boot shutdown is functional
+			return new EndpointContainerShutdown();
 		}
 
 	}

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/YarnContainerAutoConfiguration.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/YarnContainerAutoConfiguration.java
@@ -34,6 +34,7 @@ import org.springframework.yarn.boot.properties.SpringYarnContainerProperties;
 import org.springframework.yarn.boot.properties.SpringYarnEnvProperties;
 import org.springframework.yarn.boot.properties.SpringYarnProperties;
 import org.springframework.yarn.boot.support.ContainerLauncherRunner;
+import org.springframework.yarn.boot.support.ContainerRegistrar;
 import org.springframework.yarn.config.annotation.EnableYarn;
 import org.springframework.yarn.config.annotation.EnableYarn.Enable;
 import org.springframework.yarn.config.annotation.SpringYarnConfigurerAdapter;
@@ -79,6 +80,22 @@ public class YarnContainerAutoConfiguration {
 		public String customContainerClass() {
 			// class reference would fail if not in classpath
 			return "org.springframework.yarn.batch.container.DefaultBatchYarnContainer";
+		}
+
+	}
+
+	@Configuration
+	@ConditionalOnExpression("${endpoints.shutdown.enabled:false}")
+	@EnableConfigurationProperties({ SpringYarnEnvProperties.class })
+	public static class ContainerRegistrarConfig {
+
+		@Autowired
+		private SpringYarnEnvProperties syep;
+
+		@Bean
+		public ContainerRegistrar containerRegistrar() {
+			// only enable if boot shutdown is functional
+			return new ContainerRegistrar(syep.getTrackUrl(), syep.getContainerId());
 		}
 
 	}

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/SpringYarnEnvProperties.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/SpringYarnEnvProperties.java
@@ -31,6 +31,8 @@ public class SpringYarnEnvProperties {
 	private String fs;
 	private String rm;
 	private String scheduler;
+	private String trackUrl;
+	private String containerId;
 
 	/**
 	 * Gets the value of environment variable <code>SHDP_HD_FS</code>.
@@ -85,6 +87,44 @@ public class SpringYarnEnvProperties {
 	 */
 	public void setSHDP_HD_SCHEDULER(String scheduler) {
 		this.scheduler = scheduler;
+	}
+
+	/**
+	 * Gets the value of environment variable <code>SHDP_AMSERVICE_TRACKURL</code>.
+	 *
+	 * @return the value of <code>SHDP_AMSERVICE_TRACKURL</code> or <code>null</code>
+	 */
+	public String getTrackUrl() {
+		return trackUrl;
+	}
+
+	/**
+	 * Sets the value from an environment variable
+	 * <code>SHDP_AMSERVICE_TRACKURL</code>.
+	 *
+	 * @param trackUrl track url
+	 */
+	public void setSHDP_AMSERVICE_TRACKURL(String trackUrl) {
+		this.trackUrl = trackUrl;
+	}
+
+	/**
+	 * Gets the value of environment variable <code>SHDP_CONTAINERID</code>.
+	 *
+	 * @return the value of <code>SHDP_CONTAINERID</code> or <code>null</code>
+	 */
+	public String getContainerId() {
+		return containerId;
+	}
+
+	/**
+	 * Sets the value from an environment variable
+	 * <code>SHDP_CONTAINERID</code>.
+	 *
+	 * @param containerId container id
+	 */
+	public void setSHDP_CONTAINERID(String containerId) {
+		this.containerId = containerId;
 	}
 
 }

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/support/ContainerRegistrar.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/support/ContainerRegistrar.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.yarn.boot.support;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.boot.context.embedded.EmbeddedServletContainerInitializedEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.yarn.boot.actuate.endpoint.mvc.domain.ContainerRegisterResource;
+import org.springframework.yarn.support.LifecycleObjectSupport;
+import org.springframework.yarn.support.NetworkUtils;
+
+/**
+ * Component which registers itself with container registrar boot endpoint.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class ContainerRegistrar extends LifecycleObjectSupport implements
+		ApplicationListener<EmbeddedServletContainerInitializedEvent> {
+
+	private static final Log log = LogFactory.getLog(ContainerRegistrar.class);
+
+	private String trackUrl;
+
+	private String containerId;
+
+	/**
+	 * Instantiates a new container registrar.
+	 *
+	 * @param trackUrl the track url
+	 * @param containerId the container id
+	 */
+	public ContainerRegistrar(String trackUrl, String containerId) {
+		this.trackUrl = trackUrl;
+		this.containerId = containerId;
+	}
+
+	@Override
+	public void onApplicationEvent(EmbeddedServletContainerInitializedEvent event) {
+		String namespace = event.getApplicationContext().getNamespace();
+		if ("management".equals(namespace)) {
+			return;
+		}
+
+		int port = event.getEmbeddedServletContainer().getPort();
+		try {
+			// TODO: need to integrate auth
+			// TODO: need to handle proper network address
+			RestTemplate restTemplate = new RestTemplate(new HttpComponentsClientHttpRequestFactory());
+			String url = "http://" + NetworkUtils.getDefaultAddress() + ":" + port;
+			ContainerRegisterResource request = new ContainerRegisterResource(containerId, url);
+			log.info("Registering containerId=[" + containerId + "] with url=[" + url + "]");
+			restTemplate.postForObject(trackUrl + "/yarn_containerregister", request, Object.class);
+		} catch (Exception e) {
+			log.warn("Error registering with appmaster", e);
+		}
+
+	}
+
+}

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/support/EndpointContainerShutdown.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/support/EndpointContainerShutdown.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.yarn.boot.support;
+
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.yarn.api.records.Container;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.yarn.am.container.ContainerRegisterInfo;
+import org.springframework.yarn.am.container.ContainerShutdown;
+
+/**
+ * {@link ContainerShutdown} implementation which uses boot shutdown
+ * rest endpoint to notify context close.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class EndpointContainerShutdown implements ContainerShutdown {
+
+	private static final Log log = LogFactory.getLog(EndpointContainerShutdown.class);
+
+	@Override
+	public boolean shutdown(Map<Container, ContainerRegisterInfo> containers) {
+		log.info("Shutting down containers using boot shutdown endpoint");
+		RestTemplate restTemplate = new RestTemplate(new HttpComponentsClientHttpRequestFactory());
+		boolean ok = true;
+		for (Entry<Container, ContainerRegisterInfo> entry : containers.entrySet()) {
+			Container c = entry.getKey();
+			ContainerRegisterInfo i = entry.getValue();
+			String url = i.getTrackUrl() + "/shutdown";
+			log.info("Shutting down container=[" + c + "] using url=[" + url + "]");
+			try {
+				// TODO: need to integrate auth
+				restTemplate.postForObject(url, null, Void.class);
+			} catch (Exception e) {
+				log.warn("Error shutting down container=[" + c + "]");
+				ok = false;
+			}
+		}
+		return ok;
+	}
+
+}


### PR DESCRIPTION
- Second stage changes
- Add boot auto-configuration for logic around
  shutdown endpoints. Functionality is disabled
  on default just like in boot.
- New ContainerRegistrar on container.
- New EndpointContainerShutdown on appmaster
