### PR TITLE
SHDP-449 Add FsShell boot auto-configuration

### DIFF
--- a/spring-hadoop-boot/src/main/java/org/springframework/data/hadoop/boot/HadoopFsShellAutoConfiguration.java
+++ b/spring-hadoop-boot/src/main/java/org/springframework/data/hadoop/boot/HadoopFsShellAutoConfiguration.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.hadoop.boot;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.hadoop.HadoopSystemConstants;
+import org.springframework.data.hadoop.config.annotation.EnableHadoop;
+import org.springframework.data.hadoop.fs.FsShell;
+
+/**
+ * Boot auto-configuration for {@link FsShell}.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@Configuration
+@ConditionalOnClass(EnableHadoop.class)
+@ConditionalOnMissingBean(FsShell.class)
+@AutoConfigureAfter(HadoopAutoConfiguration.class)
+public class HadoopFsShellAutoConfiguration {
+
+	@Autowired
+	private org.apache.hadoop.conf.Configuration configuration;
+
+	@Bean(name = HadoopSystemConstants.DEFAULT_ID_FSSHELL)
+	@ConditionalOnExpression("${spring.hadoop.fsshell.enabled:true}")
+	public FsShell fsShell() {
+		return new FsShell(configuration);
+	}
+
+}

--- a/spring-hadoop-boot/src/main/resources/META-INF/spring.factories
+++ b/spring-hadoop-boot/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,4 @@
 # Auto Configure
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-org.springframework.data.hadoop.boot.HadoopAutoConfiguration
+org.springframework.data.hadoop.boot.HadoopAutoConfiguration,\
+org.springframework.data.hadoop.boot.HadoopFsShellAutoConfiguration

--- a/spring-hadoop-boot/src/test/java/org/springframework/data/hadoop/boot/HadoopFsShellAutoConfigurationTests.java
+++ b/spring-hadoop-boot/src/test/java/org/springframework/data/hadoop/boot/HadoopFsShellAutoConfigurationTests.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.hadoop.boot;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+import org.junit.After;
+import org.junit.Test;
+import org.springframework.boot.test.EnvironmentTestUtils;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.data.hadoop.HadoopSystemConstants;
+
+/**
+ * Tests for {@link HadoopFsShellAutoConfiguration}.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class HadoopFsShellAutoConfigurationTests {
+
+	private ConfigurableApplicationContext context;
+
+	@After
+	public void close() {
+		if (context != null) {
+			context.close();
+		}
+	}
+
+	@Test
+	public void testDefault() throws Exception {
+		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
+		this.context = ctx;
+		ctx.register(HadoopAutoConfiguration.class, HadoopFsShellAutoConfiguration.class);
+		ctx.refresh();
+		assertNotNull(context.getBean(HadoopSystemConstants.DEFAULT_ID_FSSHELL));
+	}
+
+	@Test
+	public void testEnabled() throws Exception {
+		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(ctx, "spring.hadoop.fsshell.enabled:true");
+		this.context = ctx;
+		ctx.register(HadoopAutoConfiguration.class, HadoopFsShellAutoConfiguration.class);
+		ctx.refresh();
+		assertNotNull(context.getBean(HadoopSystemConstants.DEFAULT_ID_FSSHELL));
+	}
+
+	@Test
+	public void testDisabled() throws Exception {
+		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(ctx, "spring.hadoop.fsshell.enabled:false");
+		this.context = ctx;
+		ctx.register(HadoopAutoConfiguration.class, HadoopFsShellAutoConfiguration.class);
+		ctx.refresh();
+		assertThat(context.containsBean(HadoopSystemConstants.DEFAULT_ID_FSSHELL), is(false));
+	}
+
+}

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/HadoopSystemConstants.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/HadoopSystemConstants.java
@@ -32,4 +32,7 @@ public abstract class HadoopSystemConstants {
 	/** Default bean id for hadoop configuration. */
 	public static final String DEFAULT_ID_CONFIGURATION = "hadoopConfiguration";
 
+	/** Default bean id for hadoop fsshell. */
+	public static final String DEFAULT_ID_FSSHELL = "hadoopFsShell";
+
 }


### PR DESCRIPTION
- FsShell created automatically with bean `hadoopFsShell`.
- Can be turned of by setting property
  `spring.hadoop.fsshell.enabled` false.
- Is configured after HadoopAutoConfiguration so that
  dependant hadoop Configuration is build on correct order.
