### PR TITLE
SHDP-356 Remove unsupported lzo codecs.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -359,6 +359,18 @@ configure(javaProjects()) {
 		}
 	}
 
+	if (project.hasProperty('testJavaLibraryPath')) {
+		test {
+			systemProperty "java.library.path", "${testJavaLibraryPath}"
+		}
+	}
+
+	if (project.hasProperty('testJavaClasspath')) {
+		dependencies {
+			testRuntime files("${testJavaClasspath}")
+		}
+	}
+
 	forceDependencyVersions(it, 'cdh5')
 
 	sourceCompatibility=1.6

--- a/docs/src/reference/docbook/reference/store.xml
+++ b/docs/src/reference/docbook/reference/store.xml
@@ -558,12 +558,19 @@ public class CustomerPartitionKeyResolver implements PartitionKeyResolver<String
           <para><emphasis>BZIP2</emphasis> - <classname>org.apache.hadoop.io.compress.BZip2Codec</classname></para>
         </listitem>
         <listitem>
-          <para><emphasis>LZO</emphasis> - <classname>com.hadoop.compression.lzo.LzoCodec</classname> (non-splittable)</para>
+          <para><emphasis>LZO</emphasis> - <classname>com.hadoop.compression.lzo.LzoCodec</classname></para>
         </listitem>
         <listitem>
-          <para><emphasis>SLZO</emphasis> - <classname>com.hadoop.compression.lzo.LzoCodec</classname> (splittable)</para>
+          <para><emphasis>LZOP</emphasis> - <classname>com.hadoop.compression.lzo.LzopCodec</classname></para>
         </listitem>
       </itemizedlist>
+
+      <note>
+        <para>Lzo based compression codecs doesn't exist in maven dependencies due to licensing
+        restrictions and need for native libraries. Order to use it add codec classes to classpath
+        and its native libs using <emphasis>java.library.path</emphasis>.
+        </para>
+      </note>
 
     </section>
 

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/codec/Codecs.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/codec/Codecs.java
@@ -55,32 +55,15 @@ public enum Codecs {
 	 */
 	BZIP2(new DefaultCodecInfo(BZip2Codec.class.getName(), true, "bz2"), "BZIP2"),
 
-	// TODO: should we do like DelegatingLzoCodecInfo for resolving
-	// these at runtime. Anyway only one can be present
-	// at any given time!
 	/**
-	 * Non-splittable {@code LzoCodec}. This codec should be based on implementation from
-	 * http://code.google.com/p/hadoop-gpl-compression.
+	 * Non-splittable {@code LzoCodec}.
 	 */
 	LZO(new DefaultCodecInfo("com.hadoop.compression.lzo.LzoCodec", false, "lzo"), "LZO"),
 
 	/**
-	 * Splittable {@code LzoCodec}. This codec should be based on implementation from
-	 * http://github.com/kevinweil/hadoop-lzo.
+	 * Non-splittable {@code LzopCodec}.
 	 */
-	SLZO(new DefaultCodecInfo("com.hadoop.compression.lzo.LzoCodec", true, "slzo"), "SLZO"),
-
-	/**
-	 * Non-splittable {@code LzopCodec}. This codec should be based on implementation from
-	 * http://code.google.com/p/hadoop-gpl-compression.
-	 */
-	LZOP(new DefaultCodecInfo("com.hadoop.compression.lzo.LzopCodec", false, "lzop"), "LZOP"),
-
-	/**
-	 * Splittable {@code LzoCodec}. This codec should be based on implementation from
-	 * http://github.com/kevinweil/hadoop-lzo.
-	 */
-	SLZOP(new DefaultCodecInfo("com.hadoop.compression.lzo.LzopCodec", true, "slzop"), "SLZOP");
+	LZOP(new DefaultCodecInfo("com.hadoop.compression.lzo.LzopCodec", false, "lzop"), "LZOP");
 
 	private final CodecInfo codec;
 

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TextFileStoreTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TextFileStoreTests.java
@@ -35,6 +35,7 @@ import org.springframework.data.hadoop.store.strategy.naming.StaticFileNamingStr
 import org.springframework.data.hadoop.store.strategy.rollover.SizeRolloverStrategy;
 import org.springframework.data.hadoop.test.context.HadoopDelegatingSmartContextLoader;
 import org.springframework.data.hadoop.test.context.MiniHadoopCluster;
+import org.springframework.data.hadoop.test.tests.Assume;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
@@ -91,6 +92,22 @@ public class TextFileStoreTests extends AbstractStoreTests {
 
 		TextFileReader reader = new TextFileReader(getConfiguration(), testDefaultPath,
 				Codecs.BZIP2.getCodecInfo());
+		TestUtils.readDataAndAssert(reader, DATA09ARRAY);
+	}
+
+	@Test
+	public void testWriteReadManyLinesWithLzo() throws IOException {
+		// Add lzo and native libs with project properties to run this test
+		// because we can't include anything automatically
+		// -PtestJavaLibraryPath=/tmp/lzo/native
+		// -PtestJavaClasspath=/tmp/lzo/lib/hadoop-lzo-0.4.17.jar
+		Assume.codecExists(Codecs.LZO.getCodecInfo().getCodecClass());
+		TextFileWriter writer = new TextFileWriter(getConfiguration(), testDefaultPath,
+				Codecs.LZO.getCodecInfo());
+		TestUtils.writeData(writer, DATA09ARRAY);
+
+		TextFileReader reader = new TextFileReader(getConfiguration(), testDefaultPath,
+				Codecs.LZO.getCodecInfo());
 		TestUtils.readDataAndAssert(reader, DATA09ARRAY);
 	}
 


### PR DESCRIPTION
- Removed twitter based codecs because those anyway
  are same.
- Removed not for splittable/non-splittable because
  although lzo from twitter is supposed to be splittable
  it is not on a stream/file level.
- Added test which can be run if needed classes
  and libs are on classpath.
