### PR TITLE
SHDP-440 Fix anomalies in DefaultAllocateCountTracker

### DIFF
--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/allocate/DefaultAllocateCountTrackerTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/allocate/DefaultAllocateCountTrackerTests.java
@@ -16,11 +16,25 @@
 package org.springframework.yarn.am.allocate;
 
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.yarn.api.records.Container;
+import org.apache.hadoop.yarn.api.records.ContainerId;
+import org.apache.hadoop.yarn.api.records.NodeId;
+import org.apache.hadoop.yarn.api.records.Priority;
+import org.apache.hadoop.yarn.api.records.Resource;
+import org.apache.hadoop.yarn.util.RackResolver;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
+import org.springframework.yarn.MockUtils;
+import org.springframework.yarn.TestUtils;
 import org.springframework.yarn.am.allocate.DefaultAllocateCountTracker.AllocateCountInfo;
 
 /**
@@ -31,9 +45,21 @@ import org.springframework.yarn.am.allocate.DefaultAllocateCountTracker.Allocate
  */
 public class DefaultAllocateCountTrackerTests {
 
+	@Before
+	public void setup() throws Exception {
+		// try to fix some hadoop static init usage
+		// do it again after a test
+		TestUtils.setField("initCalled", new RackResolver(), false);
+	}
+
+	@After
+	public void clean() throws Exception {
+		TestUtils.setField("initCalled", new RackResolver(), false);
+	}
+	
 	@Test
 	public void testOneAny() {
-		DefaultAllocateCountTracker tracker = new DefaultAllocateCountTracker(new Configuration());
+		DefaultAllocateCountTracker tracker = getTracker();
 		ContainerAllocateData containerAllocateData = new ContainerAllocateData();
 		containerAllocateData.addAny(1);
 		tracker.addContainers(containerAllocateData);
@@ -47,23 +73,23 @@ public class DefaultAllocateCountTrackerTests {
 
 	@Test
 	public void testOneHost() {
-		DefaultAllocateCountTracker tracker = new DefaultAllocateCountTracker(new Configuration());
+		DefaultAllocateCountTracker tracker = getTracker();
 		ContainerAllocateData containerAllocateData = new ContainerAllocateData();
-		containerAllocateData.addHosts("host1", 1);
+		containerAllocateData.addHosts("hostX", 1);
 		tracker.addContainers(containerAllocateData);
 		AllocateCountInfo allocateCounts = tracker.getAllocateCounts();
 		assertThat(allocateCounts, notNullValue());
 		assertThat(allocateCounts.anysInfo.size(), is(1));
 		assertThat(allocateCounts.anysInfo.get("*"), is(2));
 		assertThat(allocateCounts.hostsInfo.size(), is(1));
-		assertThat(allocateCounts.hostsInfo.get("host1"), is(1));
+		assertThat(allocateCounts.hostsInfo.get("hostX"), is(1));
 		assertThat(allocateCounts.racksInfo.size(), is(1));
 		assertThat(allocateCounts.racksInfo.get("/default-rack"), is(1));
 	}
 
 	@Test
 	public void testOneRack() {
-		DefaultAllocateCountTracker tracker = new DefaultAllocateCountTracker(new Configuration());
+		DefaultAllocateCountTracker tracker = getTracker();
 		ContainerAllocateData containerAllocateData = new ContainerAllocateData();
 		containerAllocateData.addRacks("/default-rack", 1);
 		tracker.addContainers(containerAllocateData);
@@ -78,19 +104,208 @@ public class DefaultAllocateCountTrackerTests {
 
 	@Test
 	public void testOneHostOneRack() {
-		DefaultAllocateCountTracker tracker = new DefaultAllocateCountTracker(new Configuration());
+		DefaultAllocateCountTracker tracker = getTracker();
 		ContainerAllocateData containerAllocateData = new ContainerAllocateData();
-		containerAllocateData.addHosts("host1", 1);
+		containerAllocateData.addHosts("hostX", 1);
 		containerAllocateData.addRacks("/default-rack", 1);
 		tracker.addContainers(containerAllocateData);
 		AllocateCountInfo allocateCounts = tracker.getAllocateCounts();
 		assertThat(allocateCounts, notNullValue());
 		assertThat(allocateCounts.anysInfo.size(), is(1));
-		assertThat(allocateCounts.anysInfo.get("*"), is(2));
+		assertThat(allocateCounts.anysInfo.get("*"), is(3));
 		assertThat(allocateCounts.hostsInfo.size(), is(1));
-		assertThat(allocateCounts.hostsInfo.get("host1"), is(1));
+		assertThat(allocateCounts.hostsInfo.get("hostX"), is(1));
 		assertThat(allocateCounts.racksInfo.size(), is(1));
-		assertThat(allocateCounts.racksInfo.get("/default-rack"), is(1));
+		assertThat(allocateCounts.racksInfo.get("/default-rack"), is(2));
+	}
+
+	@Test
+	public void testMultiAddHosts() {
+		DefaultAllocateCountTracker tracker = getTracker();
+		
+		ContainerAllocateData containerAllocateData = new ContainerAllocateData();
+		containerAllocateData.addHosts("host1", 1);
+		tracker.addContainers(containerAllocateData);
+
+		containerAllocateData = new ContainerAllocateData();
+		containerAllocateData.addHosts("host1", 2);
+		tracker.addContainers(containerAllocateData);
+		
+		AllocateCountInfo allocateCounts = tracker.getAllocateCounts();
+		assertThat(allocateCounts, notNullValue());
+		assertThat(allocateCounts.anysInfo.size(), is(1));
+		assertThat(allocateCounts.anysInfo.get("*"), is(6));
+		assertThat(allocateCounts.hostsInfo.size(), is(1));
+		assertThat(allocateCounts.hostsInfo.get("host1"), is(3));
+		assertThat(allocateCounts.racksInfo.size(), is(1));
+		assertThat(allocateCounts.racksInfo.get("/rack1"), is(3));
+	}
+
+	@Test
+	public void testMultiHostsAndRacks() {
+		DefaultAllocateCountTracker tracker = getTracker();
+		
+		ContainerAllocateData containerAllocateData = new ContainerAllocateData();
+		containerAllocateData.addHosts("host1", 1);
+		tracker.addContainers(containerAllocateData);
+
+		containerAllocateData = new ContainerAllocateData();
+		containerAllocateData.addHosts("host1", 2);
+		tracker.addContainers(containerAllocateData);
+
+		containerAllocateData = new ContainerAllocateData();
+		containerAllocateData.addRacks("/rack1", 1);
+		tracker.addContainers(containerAllocateData);
+		
+		AllocateCountInfo allocateCounts = tracker.getAllocateCounts();
+		assertThat(allocateCounts, notNullValue());
+		assertThat(allocateCounts.anysInfo.size(), is(1));
+		assertThat(allocateCounts.anysInfo.get("*"), is(7));
+		assertThat(allocateCounts.hostsInfo.size(), is(1));
+		assertThat(allocateCounts.hostsInfo.get("host1"), is(3));
+		assertThat(allocateCounts.racksInfo.size(), is(1));
+		assertThat(allocateCounts.racksInfo.get("/rack1"), is(4));
+	}
+
+	@Test
+	public void testHostsAndRacksInSameData() {
+		DefaultAllocateCountTracker tracker = getTracker();
+		
+		ContainerAllocateData containerAllocateData = new ContainerAllocateData();
+		containerAllocateData.addHosts("host1", 1);
+		containerAllocateData.addHosts("host1", 2);
+		containerAllocateData.addRacks("/rack1", 1);
+		tracker.addContainers(containerAllocateData);
+		
+		AllocateCountInfo allocateCounts = tracker.getAllocateCounts();
+		assertThat(allocateCounts, notNullValue());
+		assertThat(allocateCounts.anysInfo.size(), is(1));
+		assertThat(allocateCounts.anysInfo.get("*"), is(7));
+		assertThat(allocateCounts.hostsInfo.size(), is(1));
+		assertThat(allocateCounts.hostsInfo.get("host1"), is(3));
+		assertThat(allocateCounts.racksInfo.size(), is(1));
+		assertThat(allocateCounts.racksInfo.get("/rack1"), is(4));
+	}
+	
+	@Test
+	public void testOneAnyProcessing() throws Exception {
+		DefaultAllocateCountTracker tracker = getTracker();
+		
+		ContainerAllocateData containerAllocateData = new ContainerAllocateData();
+		containerAllocateData.addAny(1);
+		tracker.addContainers(containerAllocateData);
+		
+		Container container = getMockContainer("hostX");
+
+		AtomicInteger pendingAny = TestUtils.readField("pendingAny", tracker);
+		AtomicInteger requestedAny = TestUtils.readField("requestedAny", tracker);
+		assertThat(pendingAny.get(), is(1));
+		assertThat(requestedAny.get(), is(0));
+		
+		tracker.getAllocateCounts();
+		pendingAny = TestUtils.readField("pendingAny", tracker);
+		requestedAny = TestUtils.readField("requestedAny", tracker);
+		assertThat(pendingAny.get(), is(0));
+		assertThat(requestedAny.get(), is(1));
+		
+		tracker.processAllocatedContainer(container);
+		pendingAny = TestUtils.readField("pendingAny", tracker);
+		requestedAny = TestUtils.readField("requestedAny", tracker);
+		assertThat(pendingAny.get(), is(0));
+		assertThat(requestedAny.get(), is(0));
+	}
+	
+	@Test
+	public void testOneRackProcessing() throws Exception {
+		DefaultAllocateCountTracker tracker = getTracker();
+		
+		ContainerAllocateData containerAllocateData = new ContainerAllocateData();
+		containerAllocateData.addRacks("/default-rack", 1);
+		tracker.addContainers(containerAllocateData);
+		
+		Map<String, AtomicInteger> pendingRacks = TestUtils.readField("pendingRacks", tracker);
+		Map<String, AtomicInteger> requestedRacks = TestUtils.readField("requestedRacks", tracker);
+		assertThat(pendingRacks.get("/default-rack").get(), is(1));
+		assertThat(requestedRacks.get("/default-rack"), nullValue());
+
+		Container container = getMockContainer("hostX");
+		
+		tracker.getAllocateCounts();
+		pendingRacks = TestUtils.readField("pendingRacks", tracker);
+		requestedRacks = TestUtils.readField("requestedRacks", tracker);
+		assertThat(pendingRacks.get("/default-rack").get(), is(0));
+		assertThat(requestedRacks.get("/default-rack").get(), is(1));
+
+		tracker.processAllocatedContainer(container);
+		pendingRacks = TestUtils.readField("pendingRacks", tracker);
+		requestedRacks = TestUtils.readField("requestedRacks", tracker);
+		assertThat(pendingRacks.get("/default-rack").get(), is(0));
+		assertThat(requestedRacks.get("/default-rack").get(), is(0));
+	}
+	
+	@Test
+	public void testMixedHostRackProcessing() throws Exception {
+		DefaultAllocateCountTracker tracker = getTracker();
+		
+		ContainerAllocateData containerAllocateData = new ContainerAllocateData();
+		containerAllocateData.addRacks("/rack1", 1);
+		containerAllocateData.addHosts("host2", 1);
+		tracker.addContainers(containerAllocateData);
+
+		Map<String, AtomicInteger> pendingRacks = TestUtils.readField("pendingRacks", tracker);
+		Map<String, AtomicInteger> requestedRacks = TestUtils.readField("requestedRacks", tracker);
+		Map<String, AtomicInteger> pendingHosts = TestUtils.readField("pendingHosts", tracker);
+		Map<String, AtomicInteger> requestedHosts = TestUtils.readField("requestedHosts", tracker);
+		assertThat(pendingRacks.get("/rack1").get(), is(1));
+		assertThat(requestedRacks.get("/rack1"), nullValue());
+		assertThat(pendingHosts.get("host2").get(), is(1));
+		assertThat(requestedHosts.get("host2"), nullValue());
+
+		tracker.getAllocateCounts();
+		pendingRacks = TestUtils.readField("pendingRacks", tracker);
+		requestedRacks = TestUtils.readField("requestedRacks", tracker);
+		pendingHosts = TestUtils.readField("pendingHosts", tracker);
+		requestedHosts = TestUtils.readField("requestedHosts", tracker);
+		assertThat(pendingRacks.get("/rack1").get(), is(0));
+		assertThat(requestedRacks.get("/rack1").get(), is(1));
+		assertThat(pendingHosts.get("host2").get(), is(0));
+		assertThat(requestedHosts.get("host2").get(), is(1));
+
+		Container container = getMockContainer("host2");
+		tracker.processAllocatedContainer(container);
+		pendingRacks = TestUtils.readField("pendingRacks", tracker);
+		requestedRacks = TestUtils.readField("requestedRacks", tracker);
+		pendingHosts = TestUtils.readField("pendingHosts", tracker);
+		requestedHosts = TestUtils.readField("requestedHosts", tracker);
+		assertThat(pendingRacks.get("/rack1").get(), is(0));
+		assertThat(requestedRacks.get("/rack1").get(), is(1));
+		assertThat(pendingHosts.get("host2").get(), is(0));
+		assertThat(requestedHosts.get("host2").get(), is(0));
+		
+		container = getMockContainer("host1");
+		tracker.processAllocatedContainer(container);
+		pendingRacks = TestUtils.readField("pendingRacks", tracker);
+		requestedRacks = TestUtils.readField("requestedRacks", tracker);
+		pendingHosts = TestUtils.readField("pendingHosts", tracker);
+		requestedHosts = TestUtils.readField("requestedHosts", tracker);
+		assertThat(pendingRacks.get("/rack1").get(), is(0));
+		assertThat(requestedRacks.get("/rack1").get(), is(0));
+		assertThat(pendingHosts.get("host2").get(), is(0));
+		assertThat(requestedHosts.get("host2").get(), is(0));
+	}
+	
+	private static Container getMockContainer(String host) {
+		ContainerId containerId = MockUtils.getMockContainerId(MockUtils.getMockApplicationAttemptId(0, 0), 0);
+		NodeId nodeId = MockUtils.getMockNodeId(host, 0);
+		Priority priority = MockUtils.getMockPriority(0);
+		Resource resource = MockUtils.getMockResource(0, 0);
+		return MockUtils.getMockContainer(containerId, nodeId, resource, priority);		
+	}
+	
+	private DefaultAllocateCountTracker getTracker() {
+		Configuration configuration = new Configuration();
+		configuration.set("net.topology.node.switch.mapping.impl", "org.springframework.yarn.am.grid.support.TestDNSToSwitchMapping");
+		return new DefaultAllocateCountTracker(configuration);
 	}
 
 }

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/allocate/DefaultContainerAllocatorTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/allocate/DefaultContainerAllocatorTests.java
@@ -274,46 +274,20 @@ public class DefaultContainerAllocatorTests {
 
 		ContainerAllocateData data = new ContainerAllocateData();
 		data.addRacks("/default-rack", 2);
-		data.addHosts("host1", 1);
+		data.addHosts("hostX", 1);
 		allocator.allocateContainers(data);
 
 		List<ResourceRequest> createRequests = TestUtils.callMethod("createRequests", allocator);
 		assertThat(createRequests, notNullValue());
 		assertThat(createRequests.size(), is(5));
 
-		ResourceRequest req;
-		req = createRequests.get(0);
-		assertThat(req.getResourceName(), is("host1"));
-		assertThat(req.getPriority().getPriority(), is(0));
-		assertThat(req.getNumContainers(), is(1));
-		assertThat(req.getRelaxLocality(), is(true));
-
-		req = createRequests.get(1);
-		assertThat(req.getResourceName(), is("/default-rack"));
-		assertThat(req.getPriority().getPriority(), is(0));
-		assertThat(req.getNumContainers(), is(1));
-		assertThat(req.getRelaxLocality(), is(false));
-
-		req = createRequests.get(2);
-		assertThat(req.getResourceName(), is("*"));
-		assertThat(req.getPriority().getPriority(), is(0));
-		assertThat(req.getNumContainers(), is(2));
-		assertThat(req.getRelaxLocality(), is(false));
-
-		req = createRequests.get(3);
-		assertThat(req.getResourceName(), is("/default-rack"));
-		assertThat(req.getPriority().getPriority(), is(1));
-		assertThat(req.getNumContainers(), is(2));
-		assertThat(req.getRelaxLocality(), is(true));
-
-		req = createRequests.get(4);
-		assertThat(req.getResourceName(), is("*"));
-		assertThat(req.getPriority().getPriority(), is(1));
-		assertThat(req.getNumContainers(), is(2));
-		assertThat(req.getRelaxLocality(), is(false));
-
+		assertThat(matchRequest(createRequests, "hostX", 0, 1, true), notNullValue());
+		assertThat(matchRequest(createRequests, "/default-rack", 0, 1, false), notNullValue());
+		assertThat(matchRequest(createRequests, "*", 0, 2, false), notNullValue());
+		assertThat(matchRequest(createRequests, "/default-rack", 1, 2, true), notNullValue());
+		assertThat(matchRequest(createRequests, "*", 1, 2, false), notNullValue());
 	}
-
+	
 	@Test
 	public void testAnyAndHostLocalityRequests() throws Exception {
 		DefaultContainerAllocator allocator = new DefaultContainerAllocator();
@@ -411,4 +385,15 @@ public class DefaultContainerAllocatorTests {
 		}
 	}
 
+	private static ResourceRequest matchRequest(List<ResourceRequest> createRequests, String name, int priority,
+			int containers, boolean relax) {
+		for (ResourceRequest r : createRequests) {
+			if (r.getResourceName().equals(name) && r.getPriority().getPriority() == priority
+					&& r.getNumContainers() == containers && r.getRelaxLocality() == relax) {
+				return r;
+			}
+		}
+		return null;
+	}	
+	
 }

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/grid/support/TestDNSToSwitchMapping.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/grid/support/TestDNSToSwitchMapping.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.yarn.am.grid.support;
 
 import java.util.ArrayList;
@@ -5,6 +20,12 @@ import java.util.List;
 
 import org.apache.hadoop.net.DNSToSwitchMapping;
 
+/**
+ * Custom rack resolver to get expected result for rack resolving.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
 public class TestDNSToSwitchMapping implements DNSToSwitchMapping {
 
 	@Override
@@ -17,6 +38,8 @@ public class TestDNSToSwitchMapping implements DNSToSwitchMapping {
 				racks.add("/rack2");
 			} else if (name.startsWith("host3")) {
 				racks.add("/rack3");
+			} else {
+				racks.add("/default-rack");
 			}
 		}
 		return racks;


### PR DESCRIPTION
- Fix some wrong type of tracking for mix of racks and hosts.
- Also adresses SHDP-441.
- NOTE: we don't actually get trouble with these bugs, afaik,
  because internally we use different DefaultAllocateCountTrackers
  for mixed hosts and racks due to fact that with yarn those
  cannot be mixed on an allocation request level. Anyway, it's good
  to fix these small problems.
