### PR TITLE
SHDP-352 Enhance Dataset Writer and Create Reader class

### DIFF
--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/AbstractDatasetStoreReader.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/AbstractDatasetStoreReader.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2014-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.hadoop.store.dataset;
+
+import java.io.IOException;
+
+import org.kitesdk.data.DatasetReader;
+import org.springframework.data.hadoop.store.DataStoreReader;
+import org.springframework.data.hadoop.store.StoreException;
+import org.springframework.util.Assert;
+
+/**
+ * An abstract {@code DataStoreReader} to be extended for providing Dataset reading
+ * capabilities for specific use cases.
+ * 
+ * @author Janne Valkealahti
+ *
+ * @param <T> the type of entity to read
+ * @param <R> the type of entity in reader
+ * 
+ */
+public abstract class AbstractDatasetStoreReader<T, R> implements DataStoreReader<T> {
+
+	private Class<T> entityClass;
+
+	private DatasetRepositoryFactory datasetRepositoryFactory;
+
+	private DatasetDefinition datasetDefinition;
+
+	protected volatile DatasetReader<R> reader;
+
+	private boolean closed = false;
+
+	/**
+	 * Instantiates a new abstract dataset store reader.
+	 *
+	 * @param entityClass the entity class
+	 * @param datasetRepositoryFactory the dataset repository factory
+	 * @param datasetDefinition the dataset definition
+	 */
+	protected AbstractDatasetStoreReader(Class<T> entityClass, DatasetRepositoryFactory datasetRepositoryFactory,
+			DatasetDefinition datasetDefinition) {
+		Assert.notNull(entityClass, "You must specify 'entityClass'");
+		Assert.notNull(datasetRepositoryFactory, "You must provide a 'datasetRepositoryFactory'");
+		Assert.notNull(datasetDefinition, "You must provide a 'datasetDefinition'");
+		this.entityClass = entityClass;
+		this.datasetRepositoryFactory = datasetRepositoryFactory;
+		this.datasetDefinition = datasetDefinition;
+	}
+
+	@Override
+	public T read() throws IOException {
+		if (closed) {
+			throw new StoreException("Reader is already closed");
+		}
+		if (reader == null) {
+			reader = createReader();
+		}
+		if (reader.hasNext()) {
+			return convertEntity(reader.next());
+		} else {
+			return null;
+		}
+	}
+
+	@Override
+	public void close() throws IOException {
+		if (reader != null) {
+			reader.close();
+			reader = null;
+			closed = true;
+		}
+	}
+
+	/**
+	 * Gets the entity class.
+	 *
+	 * @return the entity class
+	 */
+	protected Class<T> getEntityClass() {
+		return entityClass;
+	}
+
+	/**
+	 * Gets the dataset repository factory.
+	 *
+	 * @return the dataset repository factory
+	 */
+	protected DatasetRepositoryFactory getDatasetRepositoryFactory() {
+		return datasetRepositoryFactory;
+	}
+
+	/**
+	 * Gets the dataset definition.
+	 *
+	 * @return the dataset definition
+	 */
+	protected DatasetDefinition getDatasetDefinition() {
+		return datasetDefinition;
+	}
+	
+	/**
+	 * Convert entity used by a reading into a entity
+	 * returned.
+	 * 
+	 * @param entity the entity 
+	 * @return the converted entity
+	 */
+	protected abstract T convertEntity(R entity);
+	
+	/**
+	 * Creates a {@link DatasetReader}.
+	 *
+	 * @return the dataset reader
+	 */
+	protected abstract DatasetReader<R> createReader();
+
+}

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/AbstractDatasetStoreWriter.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/AbstractDatasetStoreWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,9 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.hadoop.store.dataset;
 
+import java.io.IOException;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.kitesdk.data.DatasetWriter;
 import org.springframework.data.hadoop.store.DataStoreWriter;
 import org.springframework.util.Assert;
 
@@ -24,15 +28,26 @@ import org.springframework.util.Assert;
  * capabilities for specific use cases.
  *
  * @author Thomas Risberg
-
+ * @author Janne Valkealahti
+ *
+ * @param <T> the type of entity to write
+ * @param <R> the type of entity in writer
+ *
  */
-public abstract class AbstractDatasetStoreWriter<T> implements DataStoreWriter<T> {
+public abstract class AbstractDatasetStoreWriter<T, R> extends DatasetStoreObjectSupport implements DataStoreWriter<T> {
 
-	protected Class<T> entityClass;
+	private static final Log log = LogFactory.getLog(AbstractDatasetStoreWriter.class);
 
-	protected DatasetRepositoryFactory datasetRepositoryFactory;
+	private Class<T> entityClass;
 
-	protected DatasetDefinition datasetDefinition;
+	private DatasetRepositoryFactory datasetRepositoryFactory;
+
+	private DatasetDefinition datasetDefinition;
+
+	private DatasetWriter<R> writer;
+	
+	/** Sync lock for writer creation */
+	private final Object lock = new Object();
 
 	/**
 	 * Instantiates a new {@code DataStoreWriter} for writing to a {@code org.kitesdk.data.Dataset}.
@@ -41,7 +56,8 @@ public abstract class AbstractDatasetStoreWriter<T> implements DataStoreWriter<T
 	 * @param datasetRepositoryFactory the {@code DatasetRepositoryFactory} to be used for the writer
 	 * @param datasetDefinition the {@code DatasetDefinition} to be used for the writer
 	 */
-	protected AbstractDatasetStoreWriter(Class<T> entityClass, DatasetRepositoryFactory datasetRepositoryFactory, DatasetDefinition datasetDefinition) {
+	protected AbstractDatasetStoreWriter(Class<T> entityClass, DatasetRepositoryFactory datasetRepositoryFactory,
+			DatasetDefinition datasetDefinition) {
 		Assert.notNull(entityClass, "You must specify 'entityClass'");
 		Assert.notNull(datasetRepositoryFactory, "You must provide a 'datasetRepositoryFactory'");
 		Assert.notNull(datasetDefinition, "You must provide a 'datasetDefinition'");
@@ -49,5 +65,91 @@ public abstract class AbstractDatasetStoreWriter<T> implements DataStoreWriter<T
 		this.datasetRepositoryFactory = datasetRepositoryFactory;
 		this.datasetDefinition = datasetDefinition;
 	}
+
+	@Override
+	public void write(T entity) throws IOException {
+		if (writer == null) {
+			synchronized (lock) {
+				if (writer == null) {
+					writer = createWriter();					
+				}
+			}
+		}
+		writer.write(convertEntity(entity));
+		resetIdleTimeout();
+	}
+
+	@Override
+	public void flush() throws IOException {
+		if (log.isDebugEnabled()) {
+			log.debug("Flushing writer " + writer);
+		}
+		if (writer != null) {
+			writer.flush();
+		}
+	}
+
+	@Override
+	public void close() throws IOException {
+		if (log.isDebugEnabled()) {
+			log.debug("Closing writer " + writer);
+		}
+		if (writer != null) {
+			writer.close();
+			writer = null;
+		}
+	}
+	
+	@Override
+	protected void handleIdleTimeout() {
+		log.info("Idle timeout detected, closing writer");
+		try {
+			close();
+		} catch (IOException e) {
+		}
+	}
+	
+	/**
+	 * Convert entity to be written into a entity used
+	 * by a writer.
+	 * 
+	 * @param entity the entity 
+	 * @return the converted entity
+	 */
+	protected abstract R convertEntity(T entity);
+
+	/**
+	 * Gets the entity class.
+	 *
+	 * @return the entity class
+	 */
+	protected Class<T> getEntityClass() {
+		return entityClass;
+	}
+
+	/**
+	 * Gets the dataset repository factory.
+	 *
+	 * @return the dataset repository factory
+	 */
+	protected DatasetRepositoryFactory getDatasetRepositoryFactory() {
+		return datasetRepositoryFactory;
+	}
+
+	/**
+	 * Gets the dataset definition.
+	 *
+	 * @return the dataset definition
+	 */
+	protected DatasetDefinition getDatasetDefinition() {
+		return datasetDefinition;
+	}
+
+	/**
+	 * Creates a {@link DatasetWriter}.
+	 *
+	 * @return the dataset writer
+	 */
+	protected abstract DatasetWriter<R> createWriter();
 
 }

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/AvroPojoDatasetStoreReader.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/AvroPojoDatasetStoreReader.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.hadoop.store.dataset;
+
+import org.kitesdk.data.Dataset;
+import org.kitesdk.data.DatasetReader;
+
+/**
+ * A {@code DataStoreReader} for reading Datasets using the Parquet format.
+ * 
+ * @author Janne Valkealahti
+ *
+ * @param <T> the type of entity to write
+ * 
+ */
+public class AvroPojoDatasetStoreReader<T> extends AbstractDatasetStoreReader<T, T> {
+
+	public AvroPojoDatasetStoreReader(Class<T> entityClass, DatasetRepositoryFactory datasetRepositoryFactory,
+			DatasetDefinition datasetDefinition) {
+		super(entityClass, datasetRepositoryFactory, datasetDefinition);
+	}
+
+	@Override
+	protected T convertEntity(T entity) {
+		return entity;
+	}
+
+	@Override
+	protected DatasetReader<T> createReader() {
+		Dataset<T> dataset = DatasetUtils.getOrCreateDataset(getDatasetRepositoryFactory(), getDatasetDefinition(),
+		getEntityClass(), getEntityClass());
+		return dataset.newReader();
+	}
+		
+
+}

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/DatasetStoreObjectSupport.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/DatasetStoreObjectSupport.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.hadoop.store.dataset;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.data.hadoop.store.support.IdleTimeoutTrigger;
+import org.springframework.data.hadoop.store.support.LifecycleObjectSupport;
+import org.springframework.data.hadoop.store.support.PollingTaskSupport;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.Trigger;
+
+/**
+ * Support class adding timeout poller functionality.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class DatasetStoreObjectSupport extends LifecycleObjectSupport {
+
+	private static final Log log = LogFactory.getLog(DatasetStoreObjectSupport.class);
+
+	/** Poller checking idle timeouts */
+	private IdleTimeoutPoller idlePoller;
+
+	/** Trigger in poller */
+	private volatile IdleTimeoutTrigger idleTrigger;
+
+	/**
+	 * In millis last idle time reset. We explicitly use negative value to indicate reset state
+	 * because we can't use long max value which would flip if adding something. We reset this
+	 * state when idle timeout happens so that we can wait next idle time.
+	 */
+	private volatile long lastIdle = Long.MIN_VALUE;
+
+	/** In millis an idle timeout for writer/reader. */
+	private volatile long idleTimeout;
+
+	@Override
+	protected void onInit() throws Exception {
+		// if we have timeout, enable polling by creating it
+		if (idleTimeout > 0) {
+			idleTrigger = new IdleTimeoutTrigger(idleTimeout);
+			idlePoller = new IdleTimeoutPoller(getTaskScheduler(), getTaskExecutor(), idleTrigger);
+			idlePoller.init();
+		}
+	}
+
+	@Override
+	protected void doStart() {
+		if (idlePoller != null) {
+			idlePoller.start();
+		}
+	}
+
+	@Override
+	protected void doStop() {
+		if (idlePoller != null) {
+			idlePoller.stop();
+		}
+		idlePoller = null;
+	}
+
+	/**
+	 * Sets the idle timeout.
+	 *
+	 * @param idleTimeout the new idle timeout
+	 */
+	public void setIdleTimeout(long idleTimeout) {
+		this.idleTimeout = idleTimeout;
+	}
+
+	/**
+	 * Reset idle timeout.
+	 */
+	public void resetIdleTimeout() {
+		lastIdle = System.currentTimeMillis();
+	}
+
+	/**
+	 * Handle idle timeout. This method should be overriden
+	 * to be notified of idle timeouts. Default implementation
+	 * doesn't do anything.
+	 */
+	protected void handleIdleTimeout() {
+	}
+
+	/**
+	 * Poller which checks idle timeout by last write and closes a writer if timeout has occurred.
+	 */
+	private class IdleTimeoutPoller extends PollingTaskSupport<Boolean> {
+
+		public IdleTimeoutPoller(TaskScheduler taskScheduler, TaskExecutor taskExecutor, Trigger trigger) {
+			super(taskScheduler, taskExecutor, trigger);
+		}
+
+		@Override
+		protected Boolean doPoll() {
+			if (log.isDebugEnabled()) {
+				log.debug("Polling idle timeout with idleTimeout=" + idleTimeout + " lastIdle=" + lastIdle);
+			}
+			// return true if we've been idle too long
+			return idleTimeout > 0 && lastIdle > 0 && lastIdle + idleTimeout < System.currentTimeMillis();
+		}
+
+		@Override
+		protected void onPollResult(Boolean result) {
+			if (result) {
+				try {
+					if (log.isDebugEnabled()) {
+						log.debug("Idle timeout detected, calling handleIdleTimeout()");
+					}
+					handleIdleTimeout();
+				} catch (Exception e) {
+					// TODO: handle error
+					log.error("error closing", e);
+				} finally {
+					// reset lastIdle so we can wait new timeout
+					lastIdle = Long.MIN_VALUE;
+				}
+			}
+		}
+
+	}
+
+}

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/DatasetTemplate.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/DatasetTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.hadoop.store.dataset;
 
 import java.io.IOException;
@@ -34,6 +33,7 @@ import org.kitesdk.data.RefinableView;
 import org.springframework.beans.BeanWrapper;
 import org.springframework.beans.PropertyAccessorFactory;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.data.hadoop.store.DataStoreWriter;
 import org.springframework.data.hadoop.store.StoreException;
 import org.springframework.util.Assert;
 
@@ -260,7 +260,7 @@ public class DatasetTemplate implements InitializingBean, DatasetOperations {
 		@SuppressWarnings("unchecked")
 		Class<T> pojoClass = (Class<T>) records.iterator().next().getClass();
 		DatasetDefinition datasetDefinition = getDatasetDefinitionToUseFor(pojoClass);
-		AbstractDatasetStoreWriter<T> writer;
+		DataStoreWriter<T> writer;
 		if (Formats.PARQUET.getName().equals(datasetDefinition.getFormat().getName())) {
 			writer = new ParquetDatasetStoreWriter<T>(pojoClass, dsFactory, datasetDefinition);
 		} else {

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/ParquetDatasetStoreReader.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/ParquetDatasetStoreReader.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.hadoop.store.dataset;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.kitesdk.data.Dataset;
+import org.kitesdk.data.DatasetReader;
+import org.springframework.beans.BeanWrapper;
+import org.springframework.beans.BeanWrapperImpl;
+
+/**
+ * A {@code DataStoreReader} for reading Datasets using the Parquet format.
+ * 
+ * @author Janne Valkealahti
+ *
+ * @param <T> the type of entity to read
+ * 
+ */
+public class ParquetDatasetStoreReader<T> extends AbstractDatasetStoreReader<T, GenericRecord> {
+
+	protected volatile Schema schema;
+	
+	/**
+	 * Instantiates a new parquet dataset store reader.
+	 *
+	 * @param entityClass the entity class
+	 * @param datasetRepositoryFactory the dataset repository factory
+	 * @param datasetDefinition the dataset definition
+	 */
+	public ParquetDatasetStoreReader(Class<T> entityClass, DatasetRepositoryFactory datasetRepositoryFactory,
+			DatasetDefinition datasetDefinition) {
+		super(entityClass, datasetRepositoryFactory, datasetDefinition);
+	}
+
+	@Override
+	protected DatasetReader<GenericRecord> createReader() {
+		Dataset<GenericRecord> dataset = DatasetUtils.getOrCreateDataset(getDatasetRepositoryFactory(),
+				getDatasetDefinition(), getEntityClass(), GenericRecord.class);
+		schema = dataset.getDescriptor().getSchema();
+		return dataset.newReader();
+	}
+	
+	@SuppressWarnings("unchecked")
+	@Override
+	protected T convertEntity(GenericRecord entity) {
+		BeanWrapper beanWrapper = new BeanWrapperImpl(getEntityClass());
+		for (Schema.Field f : schema.getFields()) {
+			if (beanWrapper.isWritableProperty(f.name())) {
+				beanWrapper.setPropertyValue(f.name(), entity.get(f.name()));
+			}
+		}
+		return (T) beanWrapper.getWrappedInstance();
+	}
+	
+}

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/AbstractDatasetStoreWriterTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/AbstractDatasetStoreWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.hadoop.store.dataset;
 
 import org.apache.hadoop.fs.FileSystem;
@@ -24,6 +23,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.BeanWrapper;
 import org.springframework.beans.BeanWrapperImpl;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.hadoop.store.DataStoreWriter;
 import org.springframework.data.hadoop.test.context.HadoopDelegatingSmartContextLoader;
 import org.springframework.data.hadoop.test.context.MiniHadoopCluster;
 import org.springframework.data.hadoop.test.junit.AbstractHadoopClusterTests;
@@ -47,7 +47,7 @@ import static org.junit.Assert.assertTrue;
 public abstract class AbstractDatasetStoreWriterTests<T extends Comparable<T>> extends AbstractHadoopClusterTests {
 
 	protected DatasetOperations datasetOperations;
-	protected AbstractDatasetStoreWriter<T> datasetStoreWriter;
+	protected DataStoreWriter<T> datasetStoreWriter;
 	protected List<T> records = new ArrayList<T>();
 	protected Class<T> recordClass;
 
@@ -88,6 +88,5 @@ public abstract class AbstractDatasetStoreWriterTests<T extends Comparable<T>> e
 		assertTrue(result.isReadableProperty("id"));
 		assertTrue(result.getPropertyValue("id").equals(48L));
 	}
-
 
 }

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/DatasetStoreTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/DatasetStoreTests.java
@@ -1,0 +1,411 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.hadoop.store.dataset;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.data.hadoop.store.DataStoreReader;
+import org.springframework.data.hadoop.store.DataStoreWriter;
+import org.springframework.data.hadoop.store.TestUtils;
+import org.springframework.data.hadoop.test.context.HadoopDelegatingSmartContextLoader;
+import org.springframework.data.hadoop.test.context.MiniHadoopCluster;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ConcurrentTaskExecutor;
+import org.springframework.scheduling.concurrent.ConcurrentTaskScheduler;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(loader=HadoopDelegatingSmartContextLoader.class, classes = DatasetStoreTests.EmptyConfig.class)
+@MiniHadoopCluster
+public class DatasetStoreTests {
+
+	@Autowired
+	private ApplicationContext context;
+
+	@Autowired
+	org.apache.hadoop.conf.Configuration configuration;
+
+	@SuppressWarnings({ "unchecked" })
+	@Test
+	public void testAvroDataset() throws IOException {
+		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
+		ctx.setParent(context);
+		ctx.register(Config1.class);
+		ctx.refresh();
+
+		DataStoreWriter<DatasetPojo> writer = ctx.getBean(DataStoreWriter.class);
+		DataStoreReader<DatasetPojo> reader = ctx.getBean(DataStoreReader.class);
+
+		writer.write(new DatasetPojo(10, "testname10"));
+		writer.close();
+
+		writer.write(new DatasetPojo(11, "testname11"));
+		writer.close();
+		
+		ArrayList<DatasetPojo> results = new ArrayList<DatasetPojo>();		
+		for (DatasetPojo pojo = reader.read(); pojo != null; pojo = reader.read()) {
+			results.add(pojo);
+		}		
+		Collections.sort(results);
+
+		assertThat(results.get(0).getAge(), is(10));
+		assertThat(results.get(0).getName(), is("testname10"));
+		
+		assertThat(results.get(1).getAge(), is(11));
+		assertThat(results.get(1).getName(), is("testname11"));
+				
+		assertThat(reader.read(), nullValue());
+
+		ctx.close();
+		TestUtils.printLsR(Config1.PATH, configuration);
+	}
+
+	@SuppressWarnings({ "unchecked" })
+	@Test
+	public void testParquetDataset() throws IOException {
+		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
+		ctx.setParent(context);
+		ctx.register(Config2.class);
+		ctx.refresh();
+
+		DataStoreWriter<DatasetPojo> writer = ctx.getBean(DataStoreWriter.class);
+		DataStoreReader<DatasetPojo> reader = ctx.getBean(DataStoreReader.class);
+
+		writer.write(new DatasetPojo(10, "testname10"));
+		writer.close();
+
+		writer.write(new DatasetPojo(11, "testname11"));
+		writer.close();
+		
+		ArrayList<DatasetPojo> results = new ArrayList<DatasetPojo>();		
+		for (DatasetPojo pojo = reader.read(); pojo != null; pojo = reader.read()) {
+			results.add(pojo);
+		}		
+		Collections.sort(results);
+
+		assertThat(results.get(0).getAge(), is(10));
+		assertThat(results.get(0).getName(), is("testname10"));
+		
+		assertThat(results.get(1).getAge(), is(11));
+		assertThat(results.get(1).getName(), is("testname11"));
+				
+		assertThat(reader.read(), nullValue());
+
+		ctx.close();
+		TestUtils.printLsR(Config2.PATH, configuration);
+	}
+
+	@SuppressWarnings({ "unchecked" })
+	@Test
+	public void testIdleTimeout() throws IOException, InterruptedException {
+		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
+		ctx.setParent(context);
+		ctx.register(Config3.class);
+		ctx.refresh();
+
+		DataStoreWriter<DatasetPojo> writer = ctx.getBean(DataStoreWriter.class);
+		DataStoreReader<DatasetPojo> reader = ctx.getBean(DataStoreReader.class);
+
+		writer.write(new DatasetPojo(10, "testname10"));
+		writer.write(new DatasetPojo(11, "testname11"));
+		
+		Thread.sleep(2000);
+		
+		ArrayList<DatasetPojo> results = new ArrayList<DatasetPojo>();		
+		for (DatasetPojo pojo = reader.read(); pojo != null; pojo = reader.read()) {
+			results.add(pojo);
+		}		
+		Collections.sort(results);
+
+		assertThat(results.get(0).getAge(), is(10));
+		assertThat(results.get(0).getName(), is("testname10"));
+		
+		assertThat(results.get(1).getAge(), is(11));
+		assertThat(results.get(1).getName(), is("testname11"));
+				
+		assertThat(reader.read(), nullValue());
+
+		ctx.close();
+		TestUtils.printLsR(Config3.PATH, configuration);
+	}
+
+	@SuppressWarnings({ "unchecked" })
+	@Test
+	public void testContextClose() throws IOException {
+		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
+		ctx.setParent(context);
+		ctx.register(Config4.class);
+		ctx.refresh();
+
+		DataStoreWriter<DatasetPojo> writer = ctx.getBean(DataStoreWriter.class);
+
+		writer.write(new DatasetPojo(10, "testname10"));
+		writer.close();
+
+		writer.write(new DatasetPojo(11, "testname11"));
+		writer.close();
+
+		writer.write(new DatasetPojo(12, "testname12"));
+		// close ctx used for writing without closing a writer
+		ctx.close();
+		
+		// open new ctx for reader
+		ctx = new AnnotationConfigApplicationContext();
+		ctx.setParent(context);
+		ctx.register(Config4.class);
+		ctx.refresh();
+		
+		DataStoreReader<DatasetPojo> reader = ctx.getBean(DataStoreReader.class);
+		ArrayList<DatasetPojo> results = new ArrayList<DatasetPojo>();		
+		for (DatasetPojo pojo = reader.read(); pojo != null; pojo = reader.read()) {
+			results.add(pojo);
+		}		
+		Collections.sort(results);
+
+		assertThat(results.get(0).getAge(), is(10));
+		assertThat(results.get(0).getName(), is("testname10"));
+		
+		assertThat(results.get(1).getAge(), is(11));
+		assertThat(results.get(1).getName(), is("testname11"));
+
+		assertThat(results.get(2).getAge(), is(12));
+		assertThat(results.get(2).getName(), is("testname12"));
+		
+		assertThat(reader.read(), nullValue());
+
+		ctx.close();
+		TestUtils.printLsR(Config4.PATH, configuration);
+	}
+	
+	@Configuration
+	static class Config1 {
+
+		final static String PATH = "/tmp/DatasetStoreTests/Config1";
+		final static String NAMESPACE = "test";
+
+		@Autowired
+		org.apache.hadoop.conf.Configuration configuration;
+
+		@Bean
+		public DatasetRepositoryFactory datasetRepositoryFactory() {
+			DatasetRepositoryFactory factory = new DatasetRepositoryFactory();
+			factory.setConf(configuration);
+			factory.setBasePath(PATH);
+			factory.setNamespace(NAMESPACE);
+			return factory;
+		}
+
+		@Bean
+		public DatasetDefinition datasetDefinition() {
+			DatasetDefinition definition = new DatasetDefinition();
+			return definition;
+		}
+
+		@Bean
+		public DataStoreWriter<DatasetPojo> dataStoreWriter() {
+			AvroPojoDatasetStoreWriter<DatasetPojo> writer = new AvroPojoDatasetStoreWriter<DatasetPojo>(
+					DatasetPojo.class, datasetRepositoryFactory(), datasetDefinition());
+			return writer;
+		}
+
+		@Bean
+		public DataStoreReader<DatasetPojo> dataStoreReader() {
+			AvroPojoDatasetStoreReader<DatasetPojo> reader = new AvroPojoDatasetStoreReader<DatasetPojo>(
+					DatasetPojo.class, datasetRepositoryFactory(), datasetDefinition());
+			return reader;
+		}
+
+	}
+
+	@Configuration
+	static class Config2 {
+
+		final static String PATH = "/tmp/DatasetStoreTests/Config2";
+		final static String NAMESPACE = "test";
+
+		@Autowired
+		org.apache.hadoop.conf.Configuration configuration;
+
+		@Bean
+		public DatasetRepositoryFactory datasetRepositoryFactory() {
+			DatasetRepositoryFactory factory = new DatasetRepositoryFactory();
+			factory.setConf(configuration);
+			factory.setBasePath(PATH);
+			factory.setNamespace(NAMESPACE);
+			return factory;
+		}
+
+		@Bean
+		public DatasetDefinition datasetDefinition() {
+			DatasetDefinition definition = new DatasetDefinition();
+			definition.setFormat("parquet");
+			return definition;
+		}
+
+		@Bean
+		public DataStoreWriter<DatasetPojo> dataStoreWriter() {
+			ParquetDatasetStoreWriter<DatasetPojo> writer = new ParquetDatasetStoreWriter<DatasetPojo>(
+					DatasetPojo.class, datasetRepositoryFactory(), datasetDefinition());
+			return writer;
+		}
+
+		@Bean
+		public DataStoreReader<DatasetPojo> dataStoreReader() {
+			ParquetDatasetStoreReader<DatasetPojo> reader = new ParquetDatasetStoreReader<DatasetPojo>(
+					DatasetPojo.class, datasetRepositoryFactory(), datasetDefinition());
+			return reader;
+		}
+
+	}
+
+	@Configuration
+	static class Config3 {
+
+		final static String PATH = "/tmp/DatasetStoreTests/Config3";
+		final static String NAMESPACE = "test";
+
+		@Autowired
+		org.apache.hadoop.conf.Configuration configuration;
+
+		@Bean
+		public DatasetRepositoryFactory datasetRepositoryFactory() {
+			DatasetRepositoryFactory factory = new DatasetRepositoryFactory();
+			factory.setConf(configuration);
+			factory.setBasePath(PATH);
+			factory.setNamespace(NAMESPACE);
+			return factory;
+		}
+
+		@Bean
+		public DatasetDefinition datasetDefinition() {
+			DatasetDefinition definition = new DatasetDefinition();
+			return definition;
+		}
+
+		@Bean
+		public DataStoreWriter<DatasetPojo> dataStoreWriter() {
+			AvroPojoDatasetStoreWriter<DatasetPojo> writer = new AvroPojoDatasetStoreWriter<DatasetPojo>(
+					DatasetPojo.class, datasetRepositoryFactory(), datasetDefinition());
+			writer.setIdleTimeout(500);
+			return writer;
+		}
+
+		@Bean
+		public DataStoreReader<DatasetPojo> dataStoreReader() {
+			AvroPojoDatasetStoreReader<DatasetPojo> reader = new AvroPojoDatasetStoreReader<DatasetPojo>(
+					DatasetPojo.class, datasetRepositoryFactory(), datasetDefinition());
+			return reader;
+		}
+		
+		@Bean
+		public TaskScheduler taskScheduler() {
+			return new ConcurrentTaskScheduler();
+		}
+
+		@Bean
+		public TaskExecutor taskExecutor() {
+			return new ConcurrentTaskExecutor();
+		}
+
+	}
+
+	@Configuration
+	static class Config4 {
+
+		final static String PATH = "/tmp/DatasetStoreTests/Config4";
+		final static String NAMESPACE = "test";
+
+		@Autowired
+		org.apache.hadoop.conf.Configuration configuration;
+
+		@Bean
+		public DatasetRepositoryFactory datasetRepositoryFactory() {
+			DatasetRepositoryFactory factory = new DatasetRepositoryFactory();
+			factory.setConf(configuration);
+			factory.setBasePath(PATH);
+			factory.setNamespace(NAMESPACE);
+			return factory;
+		}
+
+		@Bean
+		public DatasetDefinition datasetDefinition() {
+			DatasetDefinition definition = new DatasetDefinition();
+			return definition;
+		}
+
+		@Bean
+		public DataStoreWriter<DatasetPojo> dataStoreWriter() {
+			AvroPojoDatasetStoreWriter<DatasetPojo> writer = new AvroPojoDatasetStoreWriter<DatasetPojo>(
+					DatasetPojo.class, datasetRepositoryFactory(), datasetDefinition());
+			return writer;
+		}
+
+		@Bean
+		public DataStoreReader<DatasetPojo> dataStoreReader() {
+			AvroPojoDatasetStoreReader<DatasetPojo> reader = new AvroPojoDatasetStoreReader<DatasetPojo>(
+					DatasetPojo.class, datasetRepositoryFactory(), datasetDefinition());
+			return reader;
+		}
+
+	}
+	
+	@Configuration
+	static class EmptyConfig {
+	}
+
+	public static class DatasetPojo implements Comparable<DatasetPojo>{
+		Integer age;
+		String name;
+		public DatasetPojo() {
+		}
+		public DatasetPojo(Integer age, String name) {
+			this.age = age;
+			this.name = name;
+		}
+		public Integer getAge() {
+			return age;
+		}
+		public void setAge(Integer age) {
+			this.age = age;
+		}
+		public String getName() {
+			return name;
+		}
+		public void setName(String name) {
+			this.name = name;
+		}
+		@Override
+		public int compareTo(DatasetPojo o) {
+			return age.compareTo(o.getAge());
+		}		
+	}
+
+}


### PR DESCRIPTION
- Writer now keeps dataset open and can use
  idleTimeout flag to close it automatically.
- Combine avro and parquet writer common functionality
  in AbstractDatasetStoreWriter.
- Create reader classes using same model familiar
  from writers.
- Use two different generic types in readers and writers
- to differentiate between entities for externally shown
  to user and internally of what type will be written to
  a dataset. This was mostly needed for parquet.
- Introduce new internal conversion of these two
  different types.