### PR TITLE
SHDP-464 Support yarn app name in cli submit command

### DIFF
--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/CliSystemConstants.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/CliSystemConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,8 @@ public abstract class CliSystemConstants {
 
 	public final static List<String> OPTIONS_APPLICATION_VERSION  = asList("application-version", "v");
 
+	public final static List<String> OPTIONS_APPLICATION_NAME  = asList("application-name", "n");
+
 	public final static List<String> OPTIONS_CLUSTER_ID  = asList("cluster-id", "c");
 
 	public final static List<String> OPTIONS_CLUSTER_DEF  = asList("cluster-def", "i");
@@ -58,6 +60,8 @@ public abstract class CliSystemConstants {
 	public final static String DESC_APPLICATION_TYPE = "Application type";
 
 	public final static String DESC_APPLICATION_VERSION = "Application version";
+
+	public final static String DESC_APPLICATION_NAME = "Application name";
 
 	public final static String DESC_VERBOSE = "Verbose output";
 

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnSubmitCommand.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnSubmitCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import joptsimple.OptionSpec;
 
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 import org.springframework.yarn.boot.app.ClientApplicationRunner;
 import org.springframework.yarn.boot.app.YarnSubmitApplication;
 
@@ -68,17 +69,25 @@ public class YarnSubmitCommand extends AbstractApplicationCommand {
 
 		private OptionSpec<String> applicationVersionOption;
 
+		private OptionSpec<String> applicationNameOption;
+		
 		@Override
 		protected final void options() {
 			this.applicationVersionOption = option(CliSystemConstants.OPTIONS_APPLICATION_VERSION,
 					CliSystemConstants.DESC_APPLICATION_VERSION).withOptionalArg().defaultsTo("app");
+			this.applicationNameOption = option(CliSystemConstants.OPTIONS_APPLICATION_NAME,
+					CliSystemConstants.DESC_APPLICATION_NAME).withOptionalArg();
 		}
 
 		@Override
 		protected void runApplication(OptionSet options) throws Exception {
 			String appVersion = options.valueOf(applicationVersionOption);
+			String appName = options.valueOf(applicationNameOption);
 			Assert.hasText(appVersion, "Application version must be defined");
 			YarnSubmitApplication app = new YarnSubmitApplication();
+			if (StringUtils.hasText(appName)) {
+				app.applicationName(appName);
+			}
 			app.applicationVersion(appVersion);
 			handleApplicationRun(app);
 		}
@@ -89,9 +98,23 @@ public class YarnSubmitCommand extends AbstractApplicationCommand {
 			handleOutput("New instance submitted with id " + applicationId);
 		}
 
+		/**
+		 * Get the application version option.
+		 * 
+		 * @return the application version option
+		 */
 		public OptionSpec<String> getApplicationVersionOption() {
 			return applicationVersionOption;
 		}
+		
+		/**
+		 * Get the application name option.
+		 * 
+		 * @return the application name option
+		 */
+		public OptionSpec<String> getApplicationNameOption() {
+			return applicationNameOption;
+		}		
 
 	}
 

--- a/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnSubmitCommandTests.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnSubmitCommandTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package org.springframework.yarn.boot.cli;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 import joptsimple.OptionSet;
 
@@ -34,8 +35,9 @@ public class YarnSubmitCommandTests {
 
 	@Test
 	public void testDefaultOptionHelp() {
-		YarnPushCommand command = new YarnPushCommand();
+		YarnSubmitCommand command = new YarnSubmitCommand();
 		assertThat(command.getHelp(), containsString("-v, --application-version"));
+		assertThat(command.getHelp(), containsString("-n, --application-name"));
 	}
 
 	@Test
@@ -44,6 +46,7 @@ public class YarnSubmitCommandTests {
 		YarnSubmitCommand command = new YarnSubmitCommand(handler);
 		command.run();
 		assertThat(handler.appVersion, is("app"));
+		assertThat(handler.appName, nullValue());
 	}
 
 	@Test
@@ -62,7 +65,25 @@ public class YarnSubmitCommandTests {
 		command.run();
 		assertThat(handler.output, is("output"));
 	}
+	
+	@Test
+	public void testSetOptionsShort() throws Exception {
+		NoRunSubmitOptionHandler handler = new NoRunSubmitOptionHandler();
+		YarnSubmitCommand command = new YarnSubmitCommand(handler);
+		command.run("-v", "foo", "-n", "bar");
+		assertThat(handler.appVersion, is("foo"));
+		assertThat(handler.appName, is("bar"));
+	}
 
+	@Test
+	public void testSetOptionsLong() throws Exception {
+		NoRunSubmitOptionHandler handler = new NoRunSubmitOptionHandler();
+		YarnSubmitCommand command = new YarnSubmitCommand(handler);
+		command.run("--application-version", "foo", "--application-name", "bar");
+		assertThat(handler.appVersion, is("foo"));
+		assertThat(handler.appName, is("bar"));
+	}
+	
 	private static class CustomSubmitOptionHandler extends SubmitOptionHandler {
 
 		@Override
@@ -78,10 +99,12 @@ public class YarnSubmitCommandTests {
 	private static class NoRunSubmitOptionHandler extends SubmitOptionHandler {
 
 		String appVersion;
+		String appName;
 
 		@Override
 		protected void runApplication(OptionSet options) throws Exception {
 			appVersion = options.valueOf(getApplicationVersionOption());
+			appName = options.valueOf(getApplicationNameOption());
 		}
 
 	}

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/YarnSubmitApplication.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/YarnSubmitApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,6 +49,8 @@ import org.springframework.yarn.client.YarnClient;
 		EndpointMBeanExportAutoConfiguration.class, EndpointAutoConfiguration.class })
 public class YarnSubmitApplication extends AbstractClientApplication<ApplicationId, YarnSubmitApplication> {
 
+	private String applicationName;
+	
 	/**
 	 * Run a {@link SpringApplication} build by a
 	 * {@link SpringApplicationBuilder} using an empty args.
@@ -91,7 +93,7 @@ public class YarnSubmitApplication extends AbstractClientApplication<Application
 				SpringYarnProperties syp = context.getBean(SpringYarnProperties.class);
 				String applicationdir = SpringYarnBootUtils.resolveApplicationdir(syp);
 				if (client instanceof ApplicationYarnClient) {
-					return ((ApplicationYarnClient)client).submitApplication(new ApplicationDescriptor(applicationdir));
+					return ((ApplicationYarnClient)client).submitApplication(new ApplicationDescriptor(applicationdir, applicationName));
 				} else {
 					return client.submitApplication(false);
 				}
@@ -103,6 +105,18 @@ public class YarnSubmitApplication extends AbstractClientApplication<Application
 	@Override
 	protected YarnSubmitApplication getThis() {
 		return this;
+	}
+
+	/**
+	 * Sets the application name used for submit. Effectively this will override
+	 * setting from set for yarn client for configuration properties.
+	 * 
+	 * @param applicationName the application name 
+	 * @return the YarnSubmitApplication for chaining
+	 */
+	public YarnSubmitApplication applicationName(String applicationName) {
+		this.applicationName = applicationName;
+		return getThis();
 	}
 
 }

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/client/ApplicationDescriptor.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/client/ApplicationDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,8 @@ public class ApplicationDescriptor {
 	// are in place.
 
 	private String directory;
+	
+	private String name;
 
 	/**
 	 * Instantiates a new application descriptor.
@@ -45,7 +47,18 @@ public class ApplicationDescriptor {
 	 * @param directory the application directory
 	 */
 	public ApplicationDescriptor(String directory) {
+		this(directory, null);
+	}
+	
+	/**
+	 * Instantiates a new application descriptor.
+	 *
+	 * @param directory the application directory
+	 * @param name the application name
+	 */
+	public ApplicationDescriptor(String directory, String name) {
 		this.directory = directory;
+		this.name = name;
 	}
 
 	/**
@@ -64,6 +77,24 @@ public class ApplicationDescriptor {
 	 */
 	public void setDirectory(String directory) {
 		this.directory = directory;
+	}
+
+	/**
+	 * Gets the application name.
+	 * 
+	 * @return the application name
+	 */
+	public String getName() {
+		return name;
+	}
+	
+	/**
+	 * Sets the application name.
+	 * 
+	 * @param name the application name
+	 */
+	public void setName(String name) {
+		this.name = name;
 	}
 
 }

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/client/DefaultApplicationYarnClient.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/client/DefaultApplicationYarnClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.yarn.client;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.springframework.util.StringUtils;
 import org.springframework.yarn.YarnSystemException;
 
 /**
@@ -48,6 +49,10 @@ public class DefaultApplicationYarnClient extends CommandYarnClient implements A
 	@Override
 	public ApplicationId submitApplication(ApplicationDescriptor descriptor) {
 		preSubmitVerify(descriptor);
+		// override app name if it has been set is descriptor
+		if (StringUtils.hasText(descriptor.getName())) {
+			setAppName(descriptor.getName());
+		}
 		ApplicationId applicationId = submitApplication(false);
 		postSubmitVerify(applicationId, descriptor);
 		return applicationId;


### PR DESCRIPTION
- Default application name still comes from property
  `spring.yarn.appName` but can be now overridden in
  yarn boot cli submit command by using options `-n`
  or `--application-name`.