### PR TITLE
SHDP-469 DefaultYarnContainer should not exit without @YarnComponent

### DIFF
--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/DefaultYarnContainer.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/DefaultYarnContainer.java
@@ -68,7 +68,16 @@ public class DefaultYarnContainer extends AbstractYarnContainer implements Appli
 		});
 
 		try {
-			handleResults(getContainerHandlerResults(getContainerHandlers()));
+			// if we don't have any handlers thus meaning no results we
+			// explicitly disable handling which should disable possible
+			// end state notification and container is left running as is.
+			List<ContainerHandler> containerHandlers = getContainerHandlers();
+			if (containerHandlers.size() > 0) {
+				log.info("Processing " + containerHandlers.size() + " @YarnComponent handlers");
+				handleResults(getContainerHandlerResults(containerHandlers));
+			} else {
+				log.info("Found no @YarnComponent methods, not going to notify end state.");
+			}
 		} catch (Exception e) {
 			log.info("About to notifyEndState from catched exception", e);
 			notifyEndState(new ArrayList<Object>(), e);

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/container/DefaultYarnContainerTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/container/DefaultYarnContainerTests.java
@@ -496,6 +496,30 @@ public class DefaultYarnContainerTests {
 		assertThat(testBean14.future2.interrupted, is(true));
 	}
 
+	@Test
+	public void testNoMethods() {
+		@SuppressWarnings("resource")
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(BaseConfig.class);
+		DefaultYarnContainer container = context.getBean(DefaultYarnContainer.class);
+		final StateWrapper stateWrapper = new StateWrapper();
+
+		container.addContainerStateListener(new ContainerStateListener() {
+			@Override
+			public void state(ContainerState state, Object exit) {
+				stateWrapper.count.incrementAndGet();
+				stateWrapper.state = state;
+				stateWrapper.exit = exit;
+			}
+		});
+
+		container.run();
+		assertThat(stateWrapper.state, nullValue());
+		assertThat(stateWrapper.exit, nullValue());
+		assertThat(stateWrapper.count.get(), is(0));
+
+		context.stop();
+	}
+
 	@Configuration
 	static class BaseConfig {
 


### PR DESCRIPTION
- Modify DefaultYarnContainer not to instruct container exit
  if no @YarnComponent methods are present. This is more close
  to what user would expect when using boot configuration.
  For example it allows to keep the context alive without
  dummy Future or sleep.