### PR TITLE
SHDP-468 Backport DistCp fixes

### DIFF
--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/fs/DistCpTest.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/fs/DistCpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2013 the original author or authors.
+ * Copyright 2011-2015 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,9 +21,7 @@ import java.util.UUID;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.hamcrest.core.Is;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,10 +29,11 @@ import org.springframework.data.hadoop.TestUtils;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import static org.junit.Assume.assumeThat;
-
 /**
+ * Tests for DistCp.
+ *
  * @author Costin Leau
+ * @author Janne Valkealahti
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
@@ -49,11 +48,6 @@ public class DistCpTest {
 	Configuration cfg;
 
 	private static final String dir = "distcp/";
-
-	@Before
-	public void init() {
-		assumeThat(TestUtils.isHadoop1X(), Is.is(Boolean.TRUE));
-	}
 
 	@After
 	public void destroy() throws Exception {


### PR DESCRIPTION
- Backporting DistCp fixes from 2.1.x in a way that
  uses reflection order to work with hadoop v1 and v2.