### PR TITLE
Very small change to allow Parquet writer to act in the same way as Avro Writer

### DIFF
--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/ParquetDatasetStoreWriter.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/ParquetDatasetStoreWriter.java
@@ -88,6 +88,9 @@ public class ParquetDatasetStoreWriter<T> extends AbstractDatasetStoreWriter<T, 
 	
 	@Override
 	protected GenericRecord convertEntity(T entity) {
+        if (entity instanceof GenericRecord)
+            return (GenericRecord) entity;
+
 		GenericRecordBuilder builder = new GenericRecordBuilder(schema);
 		BeanWrapper beanWrapper = PropertyAccessorFactory.forBeanPropertyAccess(entity);
 		for (Schema.Field f : schema.getFields()) {


### PR DESCRIPTION
While testing the DatasetTemplate and passing in a generated schema and then externally building a GenericRecord it is able to write successfully to Avro,  however it failed on Parquet - this change brings them inline.