### PR TITLE
SHDP-481 Add close timeout for writing to HDFS

### DIFF
--- a/docs/src/reference/asciidoc/springandhadoop-store.adoc
+++ b/docs/src/reference/asciidoc/springandhadoop-store.adoc
@@ -36,8 +36,8 @@ public interface DataWriter<T> {
 
 The DataStoreWriter interface adds methods to close and flush a writer.
 Some of the writers have a property to close a stream after an idle time
-has been reached but generally this interface is meant for programmatic
-control of these operations.
+or a close time has been reached but generally this interface is meant
+for programmatic control of these operations.
 
 [source,java]
 ----
@@ -930,8 +930,8 @@ as its argument.
 * Bean of type {shdp-DataStoreWriter}[DataStoreWriter] is created automatically.
 
 We can also do configuration for other usual properties like,
-`idleTimeout`, `partitioning strategy`, `naming strategy` and
-`rollover strategy`.
+`idleTimeout`, `closeTimeout`, `partitioning strategy`,
+`naming strategy` and `rollover strategy`.
 
 [source,java]
 ----
@@ -946,6 +946,7 @@ static class Config
     config
       .basePath("/tmp/store")
       .idleTimeout(60000)
+      .closeTimeout(120000)
       .inWritingSuffix(".tmp")
       .withPartitionStrategy()
         .map("dateFormat('yyyy/MM/dd/HH/mm', timestamp)")
@@ -966,6 +967,8 @@ What happened in above example:
 
 * We set idle timeout meaning file will be closed automatically if
   no writes are done in 60 seconds.
+* We set close timeout meaning file will be closed automatically when
+  120 seconds has been elapsed.
 * We set the in-writing suffix to `.tmp` which will indicate that file
   is currently open for writing. Writer will automatically remove this
   suffix when file is closed.

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/config/annotation/SpringDataStoreWriterConfigs.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/config/annotation/SpringDataStoreWriterConfigs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +47,8 @@ public class SpringDataStoreWriterConfigs {
 	private Boolean appendable;
 
 	private Long idleTimeout;
+
+	private Long closeTimeout;
 
 	private Integer fileOpenAttempts;
 
@@ -124,6 +126,14 @@ public class SpringDataStoreWriterConfigs {
 
 	public void setIdleTimeout(Long idleTimeout) {
 		this.idleTimeout = idleTimeout;
+	}
+
+	public Long getCloseTimeout() {
+		return closeTimeout;
+	}
+
+	public void setCloseTimeout(Long closeTimeout) {
+		this.closeTimeout = closeTimeout;
 	}
 
 	public Integer getFileOpenAttempts() {

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/config/annotation/builders/DataStoreTextWriterBuilder.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/config/annotation/builders/DataStoreTextWriterBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,6 +65,8 @@ public final class DataStoreTextWriterBuilder
 
 	private Long idleTimeout;
 
+	private Long closeTimeout;
+
 	private Integer fileOpenAttempts;
 
 	private String inWritingPrefix;
@@ -98,6 +100,7 @@ public final class DataStoreTextWriterBuilder
 		configs.setOverwrite(overwrite);
 		configs.setAppendable(appendable);
 		configs.setIdleTimeout(idleTimeout);
+		configs.setCloseTimeout(closeTimeout);
 		configs.setFileOpenAttempts(fileOpenAttempts);
 		configs.setInWritingPrefix(inWritingPrefix);
 		configs.setInWritingSuffix(inWritingSuffix);
@@ -164,6 +167,12 @@ public final class DataStoreTextWriterBuilder
 	@Override
 	public DataStoreTextWriterConfigurer idleTimeout(long timeout) {
 		this.idleTimeout = timeout;
+		return this;
+	}
+
+	@Override
+	public DataStoreTextWriterConfigurer closeTimeout(long timeout) {
+		this.closeTimeout = timeout;
 		return this;
 	}
 

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/config/annotation/builders/DataStoreTextWriterConfigurer.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/config/annotation/builders/DataStoreTextWriterConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -393,6 +393,30 @@ public interface DataStoreTextWriterConfigurer {
 	 * @return {@link DataStoreTextWriterConfigurer} for chaining
 	 */
 	DataStoreTextWriterConfigurer idleTimeout(long timeout);
+
+	/**
+	 * Specify a writer's close timeout.
+	 *
+	 * <br>
+	 * <br>JavaConfig:
+	 * <br>
+	 * <pre>
+	 *
+	 * public void configure(DataStoreTextWriterConfigurer writer) throws Exception {
+	 *   writer
+	 *     .closeTimeout(60000);
+	 * }
+	 * </pre>
+	 *
+	 * <br>XML:
+	 * <br>
+	 * No equivalent
+	 *
+	 * @param timeout the close timeout
+	 *
+	 * @return {@link DataStoreTextWriterConfigurer} for chaining
+	 */
+	DataStoreTextWriterConfigurer closeTimeout(long timeout);
 
 	/**
 	 * Specify a writer's max file open attempts.

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/config/annotation/configuration/SpringDataStoreTextWriterConfiguration.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/config/annotation/configuration/SpringDataStoreTextWriterConfiguration.java
@@ -119,6 +119,9 @@ public class SpringDataStoreTextWriterConfiguration extends
 				if (configs.getIdleTimeout() != null) {
 					writer.setIdleTimeout(configs.getIdleTimeout());
 				}
+				if (configs.getCloseTimeout() != null) {
+					writer.setCloseTimeout(configs.getCloseTimeout());
+				}
 				if (configs.getFileOpenAttempts() != null) {
 					writer.setMaxOpenAttempts(configs.getFileOpenAttempts());
 				}
@@ -151,6 +154,9 @@ public class SpringDataStoreTextWriterConfiguration extends
 				}
 				if (configs.getIdleTimeout() != null) {
 					writer.setIdleTimeout(configs.getIdleTimeout());
+				}
+				if (configs.getCloseTimeout() != null) {
+					writer.setCloseTimeout(configs.getCloseTimeout());
 				}
 				if (configs.getFileOpenAttempts() != null) {
 					writer.setMaxOpenAttempts(configs.getFileOpenAttempts());

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/AbstractPartitionDataStoreWriter.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/AbstractPartitionDataStoreWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,6 +74,9 @@ public abstract class AbstractPartitionDataStoreWriter<T, K> extends LifecycleOb
 
 	/** Idle timeout for writers */
 	private long idleTimeout;
+
+	/** Close timeout for writers */
+	private long closeTimeout;
 
 	/** Append flag for writers */
 	private boolean append = false;
@@ -260,6 +263,15 @@ public abstract class AbstractPartitionDataStoreWriter<T, K> extends LifecycleOb
 		this.idleTimeout = idleTimeout;
 	}
 
+	/**
+	 * Sets the close timeout.
+	 *
+	 * @param closeTimeout the new idle timeout
+	 */
+	public void setCloseTimeout(long closeTimeout) {
+		this.closeTimeout = closeTimeout;
+	}
+
     /**
      * Sets the in writing suffix.
      *
@@ -343,6 +355,15 @@ public abstract class AbstractPartitionDataStoreWriter<T, K> extends LifecycleOb
 	 */
 	public long getIdleTimeout() {
 		return idleTimeout;
+	}
+
+	/**
+	 * Gets the close timeout.
+	 *
+	 * @return the close timeout
+	 */
+	public long getCloseTimeout() {
+		return closeTimeout;
 	}
 
 	/**

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/PartitionTextFileWriter.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/PartitionTextFileWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,6 +82,7 @@ public class PartitionTextFileWriter<K> extends AbstractPartitionDataStoreWriter
 			writer.setRolloverStrategy(getRolloverStrategyFactory().createInstance());
 		}
 		writer.setIdleTimeout(getIdleTimeout());
+		writer.setCloseTimeout(getCloseTimeout());
 		writer.setOverwrite(isOverwrite());
 		writer.setAppendable(isAppendable());
 		writer.setInWritingPrefix(getInWritingPrefix());

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/support/StoreObjectSupport.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/support/StoreObjectSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,6 +49,12 @@ public abstract class StoreObjectSupport extends LifecycleObjectSupport {
 	/** Trigger in poller */
 	private volatile IdleTimeoutTrigger idleTrigger;
 
+	/** Poller checking idle timeouts */
+	private CloseTimeoutPoller closePoller;
+
+	/** Trigger in poller */
+	private volatile IdleTimeoutTrigger closeTrigger;
+
 	/**
 	 * In millis last idle time reset. We explicitly use negative value to indicate reset state
 	 * because we can't use long max value which would flip if adding something. We reset this
@@ -58,6 +64,9 @@ public abstract class StoreObjectSupport extends LifecycleObjectSupport {
 
 	/** In millis an idle timeout for writer/reader. */
 	private volatile long idleTimeout;
+
+	/** In millis a close timeout for writer/reader. */
+	private volatile long closeTimeout;
 
 	/**
 	 * Instantiates a new abstract store support.
@@ -74,11 +83,18 @@ public abstract class StoreObjectSupport extends LifecycleObjectSupport {
 
 	@Override
 	protected void onInit() throws Exception {
-		// if we have timeout, enable polling by creating it
+		// if we have idle timeout, enable polling by creating it
 		if (idleTimeout > 0) {
 			idleTrigger = new IdleTimeoutTrigger(idleTimeout);
 			idlePoller = new IdleTimeoutPoller(getTaskScheduler(), getTaskExecutor(), idleTrigger);
 			idlePoller.init();
+		}
+		// if we have close timeout, setup trigger with delay
+		if (closeTimeout > 0) {
+			closeTrigger = new IdleTimeoutTrigger(closeTimeout);
+			closeTrigger.setInitialDelay(closeTimeout);
+			closePoller = new CloseTimeoutPoller(getTaskScheduler(), getTaskExecutor(), closeTrigger);
+			closePoller.init();
 		}
 	}
 
@@ -86,6 +102,9 @@ public abstract class StoreObjectSupport extends LifecycleObjectSupport {
 	protected void doStart() {
 		if (idlePoller != null) {
 			idlePoller.start();
+		}
+		if (closePoller != null) {
+			closePoller.start();
 		}
 	}
 
@@ -95,6 +114,10 @@ public abstract class StoreObjectSupport extends LifecycleObjectSupport {
 			idlePoller.stop();
 		}
 		idlePoller = null;
+		if (closePoller != null) {
+			closePoller.stop();
+		}
+		closePoller = null;
 	}
 
 	/**
@@ -140,6 +163,15 @@ public abstract class StoreObjectSupport extends LifecycleObjectSupport {
 	 */
 	public void setIdleTimeout(long idleTimeout) {
 		this.idleTimeout = idleTimeout;
+	}
+
+	/**
+	 * Sets the close timeout.
+	 *
+	 * @param closeTimeout the new close timeout
+	 */
+	public void setCloseTimeout(long closeTimeout) {
+		this.closeTimeout = closeTimeout;
 	}
 
 	/**
@@ -193,6 +225,30 @@ public abstract class StoreObjectSupport extends LifecycleObjectSupport {
 			}
 		}
 
+	}
+
+	/**
+	 * Poller which gets called by a close timeout and closes a writer.
+	 */
+	private class CloseTimeoutPoller extends PollingTaskSupport<Void> {
+
+		public CloseTimeoutPoller(TaskScheduler taskScheduler, TaskExecutor taskExecutor, Trigger trigger) {
+			super(taskScheduler, taskExecutor, trigger);
+		}
+
+		@Override
+		protected Void doPoll() {
+			try {
+				if (log.isDebugEnabled()) {
+					log.debug("Close timeout detected, calling handleIdleTimeout()");
+				}
+				handleIdleTimeout();
+			} catch (Exception e) {
+				// TODO: handle error
+				log.error("error closing", e);
+			}
+			return null;
+		}
 	}
 
 }

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TimeoutTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TimeoutTests.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.hadoop.store;
+
+import org.apache.hadoop.fs.Path;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.data.hadoop.store.config.annotation.EnableDataStorePartitionTextWriter;
+import org.springframework.data.hadoop.store.config.annotation.EnableDataStoreTextWriter;
+import org.springframework.data.hadoop.store.config.annotation.SpringDataStoreTextWriterConfigurerAdapter;
+import org.springframework.data.hadoop.store.config.annotation.builders.DataStoreTextWriterConfigurer;
+import org.springframework.data.hadoop.store.input.TextFileReader;
+import org.springframework.data.hadoop.test.context.HadoopDelegatingSmartContextLoader;
+import org.springframework.data.hadoop.test.context.MiniHadoopCluster;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ConcurrentTaskExecutor;
+import org.springframework.scheduling.concurrent.ConcurrentTaskScheduler;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(loader=HadoopDelegatingSmartContextLoader.class, classes = TimeoutTests.EmptyConfig.class)
+@MiniHadoopCluster
+public class TimeoutTests {
+
+	@Autowired
+	private ApplicationContext context;
+
+	@Autowired
+	org.apache.hadoop.conf.Configuration configuration;
+
+	@SuppressWarnings({ "unchecked" })
+	@Test
+	public void testIdleTimeout() throws Exception {
+		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
+		ctx.setParent(context);
+		ctx.register(Config.class, Config1.class);
+		ctx.refresh();
+
+		DataStoreWriter<String> writer = ctx.getBean(DataStoreWriter.class);
+		String[] dataArray = new String[] { "0123456789" };
+		TestUtils.writeData(writer, dataArray, false, false);
+
+		Thread.sleep(2000);
+
+		TextFileReader reader = new TextFileReader(configuration, new Path("/tmp/TimeoutTests/testIdleTimeout/data"), null);
+		TestUtils.readDataAndAssert(reader, dataArray);
+
+		ctx.close();
+	}
+
+	@SuppressWarnings({ "unchecked" })
+	@Test
+	public void testCloseTimeout() throws Exception {
+		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
+		ctx.setParent(context);
+		ctx.register(Config.class, Config2.class);
+		ctx.refresh();
+
+		DataStoreWriter<String> writer = ctx.getBean(DataStoreWriter.class);
+		String[] dataArray = new String[] { "0123456789" };
+		TestUtils.writeData(writer, dataArray, false, false);
+
+		Thread.sleep(2000);
+
+		TextFileReader reader = new TextFileReader(configuration, new Path("/tmp/TimeoutTests/testCloseTimeout/data"), null);
+		TestUtils.readDataAndAssert(reader, dataArray);
+
+		ctx.close();
+	}
+
+	@SuppressWarnings({ "unchecked" })
+	@Test
+	public void testCloseTimeoutWithPartitioning() throws Exception {
+		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
+		ctx.setParent(context);
+		ctx.register(Config.class, Config3.class);
+		ctx.refresh();
+
+		DataStoreWriter<String> writer = ctx.getBean(DataStoreWriter.class);
+		String[] dataArray1 = new String[] { "fin", "swe" };
+		String[] dataArray2 = new String[] { "eng", "sco" };
+		TestUtils.writeData(writer, dataArray1, false, false);
+		TestUtils.writeData(writer, dataArray2, false, false);
+
+		Thread.sleep(2000);
+
+		TextFileReader reader = new TextFileReader(configuration, new Path("/tmp/TimeoutTests/testCloseTimeoutWithPartitioning/data/nordic_list"), null);
+		TestUtils.readDataAndAssert(reader, dataArray1);
+		reader = new TextFileReader(configuration, new Path("/tmp/TimeoutTests/testCloseTimeoutWithPartitioning/data/britain_list"), null);
+		TestUtils.readDataAndAssert(reader, dataArray2);
+
+		ctx.close();
+	}
+
+	@Configuration
+	static class Config {
+
+		@Bean
+		public TaskScheduler taskScheduler() {
+			return new ConcurrentTaskScheduler();
+		}
+
+		@Bean
+		public TaskExecutor taskExecutor() {
+			return new ConcurrentTaskExecutor();
+		}
+
+	}
+
+	@Configuration
+	@EnableDataStoreTextWriter
+	static class Config1 extends SpringDataStoreTextWriterConfigurerAdapter {
+
+		@Override
+		public void configure(DataStoreTextWriterConfigurer config) throws Exception {
+			config
+				.basePath("/tmp/TimeoutTests/testIdleTimeout/data")
+				.idleTimeout(1000);
+		}
+
+	}
+
+	@Configuration
+	@EnableDataStoreTextWriter
+	static class Config2 extends SpringDataStoreTextWriterConfigurerAdapter {
+
+		@Override
+		public void configure(DataStoreTextWriterConfigurer config) throws Exception {
+			config
+				.basePath("/tmp/TimeoutTests/testCloseTimeout/data")
+				.closeTimeout(1000);
+		}
+
+	}
+
+	@Configuration
+	@EnableDataStorePartitionTextWriter
+	static class Config3 extends SpringDataStoreTextWriterConfigurerAdapter {
+
+		@Override
+		public void configure(DataStoreTextWriterConfigurer config) throws Exception {
+			config
+				.basePath("/tmp/TimeoutTests/testCloseTimeoutWithPartitioning/data")
+				.closeTimeout(1000)
+				.withPartitionStrategy()
+					.map("list(content,{{'nordic','fin','swe'},{'britain','eng','sco'}})");
+		}
+
+	}
+
+	@Configuration
+	static class EmptyConfig {
+	}
+
+}


### PR DESCRIPTION
- Duplicating a concept of idleTimeout into a new setting
  named closeTimeout which simply closes a stream/file
  after elapsed time has passed.
- This is done for normal writers, partition writers
  and a dataset.
- In case both idleTimeout and closeTimeout has been set,
  first one to timeout will close stream.