### PR TITLE
SHDP-482 TextFileWriter unable to continue after close errors

### DIFF
--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/TextFileWriter.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/TextFileWriter.java
@@ -100,16 +100,27 @@ public class TextFileWriter extends AbstractDataStreamWriter implements DataStor
 	@Override
 	public synchronized void close() throws IOException {
 		if (streamsHolder != null) {
-			streamsHolder.close();
 
-			renameFile(streamsHolder.getPath());
-
-			StoreEventPublisher storeEventPublisher = getStoreEventPublisher();
-			if (storeEventPublisher != null) {
-				storeEventPublisher.publishEvent(new FileWrittenEvent(this, streamsHolder.getPath()));
+			// we store the possible error and rethrow it
+			// later so that we can null holder for further
+			// operations not to fail
+			IOException rethrow = null;
+			try {
+				streamsHolder.close();
+				renameFile(streamsHolder.getPath());
+				StoreEventPublisher storeEventPublisher = getStoreEventPublisher();
+				if (storeEventPublisher != null) {
+					storeEventPublisher.publishEvent(new FileWrittenEvent(this, streamsHolder.getPath()));
+				}
+			} catch (IOException e) {
+				rethrow = e;
+				log.error("error in close", e);
+			} finally {
+				streamsHolder = null;
 			}
-
-			streamsHolder = null;
+			if (rethrow != null) {
+				throw rethrow;
+			}
 		}
 	}
 


### PR DESCRIPTION
- in close() we now simply wrap stuff with try/catch and
  rethrow before setting stream holder to null which
  should allow further writes not to fail into a new
  rolled files.