### PR TITLE
SHDP-490 Use Syncable methods

### DIFF
--- a/docs/src/reference/asciidoc/springandhadoop-store.adoc
+++ b/docs/src/reference/asciidoc/springandhadoop-store.adoc
@@ -400,6 +400,28 @@ Hadoop's SequenceFile.
 wraps multiple TextFileWriters providing automatic partitioning
 functionality.
 
+===== Append and Sync Data
+
+HDFS client library which is usually referred as a _DFS Client_ is
+using a rather complex set of buffers to make writes fast. Using a
+compression codec adds yet another internal buffer. One big problem
+with these buffers is that if a jvm suddenly dies bufferred data is
+naturally lost.
+
+With _TextFileWriter_ and _TextSequenceFileWriter_ it is possible to
+enable either append or syncable mode which effectively is causing our
+store libraries to call sync method which will flush buffers from a
+client side into a currently active datanodes.
+
+[NOTE]
+====
+Appending or synching data will be considerably slower than a normal
+write. It is always a trade-off between fast write and data integrity.
+Using append or sync with a compression is also problematic because
+it's up to a codec implementation when it can actually flush its own
+data to a datanode.
+====
+
 ==== Reading Data
 
 Main interface reading from a store is a DataReader.

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/AbstractPartitionDataStoreWriter.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/AbstractPartitionDataStoreWriter.java
@@ -96,6 +96,9 @@ public abstract class AbstractPartitionDataStoreWriter<T, K> extends LifecycleOb
 	/** In-house flag indicating if this partition writer is closed */
 	private volatile boolean closed = false;
 
+	/** Flag enabling Syncable hflush*/
+	private boolean syncable = false;
+
 	/**
 	 * Instantiates a new abstract data store partition writer.
 	 *
@@ -346,6 +349,26 @@ public abstract class AbstractPartitionDataStoreWriter<T, K> extends LifecycleOb
 	 */
 	public void setAppendable(boolean append) {
 		this.append = append;
+	}
+
+	/**
+	 * Checks if syncable is enabled.
+	 *
+	 * @return true, if syncable is enabled
+	 */
+	public boolean isSyncable() {
+		return syncable;
+	}
+
+	/**
+	 * Sets the syncable. Enabling will result automatic
+	 * call to hdfs Syncable hflush() if available. This
+	 * is disable by default.
+	 *
+	 * @param syncable the syncable flag
+	 */
+	public void setSyncable(boolean syncable) {
+		this.syncable = syncable;
 	}
 
 	/**

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/PartitionTextFileWriter.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/PartitionTextFileWriter.java
@@ -85,6 +85,7 @@ public class PartitionTextFileWriter<K> extends AbstractPartitionDataStoreWriter
 		writer.setCloseTimeout(getCloseTimeout());
 		writer.setOverwrite(isOverwrite());
 		writer.setAppendable(isAppendable());
+		writer.setSyncable(isSyncable());
 		writer.setInWritingPrefix(getInWritingPrefix());
 		writer.setInWritingSuffix(getInWritingSuffix());
 		writer.setMaxOpenAttempts(getMaxOpenAttempts());

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/TextFileWriter.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/TextFileWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,7 +91,7 @@ public class TextFileWriter extends AbstractDataStreamWriter implements DataStor
 		if (streamsHolder != null) {
 			OutputStream stream = streamsHolder.getStream();
 			stream.flush();
-			if(isAppendable() && stream instanceof Syncable) {
+			if ((isAppendable() || isSyncable()) && stream instanceof Syncable) {
 				((Syncable)stream).hflush();
 			}
 		}

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/support/OutputStoreObjectSupport.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/support/OutputStoreObjectSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,6 +59,9 @@ public abstract class OutputStoreObjectSupport extends StoreObjectSupport {
 
 	/** Flag guarding if file is appended or not */
 	private boolean append = false;
+
+	/** Flag enabling Syncable hflush*/
+	private boolean syncable = false;
 
 	/**
 	 * Instantiates a new abstract output store support.
@@ -212,6 +215,26 @@ public abstract class OutputStoreObjectSupport extends StoreObjectSupport {
 	 */
 	public void setAppendable(boolean append) {
 		this.append = append;
+	}
+
+	/**
+	 * Checks if syncable is enabled.
+	 *
+	 * @return true, if syncable is enabled
+	 */
+	public boolean isSyncable() {
+		return syncable;
+	}
+
+	/**
+	 * Sets the syncable. Enabling will result automatic
+	 * call to hdfs Syncable hflush() if available. This
+	 * is disable by default.
+	 *
+	 * @param syncable the syncable flag
+	 */
+	public void setSyncable(boolean syncable) {
+		this.syncable = syncable;
 	}
 
 	/**

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TextFileStoreSyncTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TextFileStoreSyncTests.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,11 +31,10 @@ import org.springframework.data.hadoop.store.strategy.naming.StaticFileNamingStr
 import org.springframework.data.hadoop.test.context.HadoopDelegatingSmartContextLoader;
 import org.springframework.data.hadoop.test.context.MiniHadoopCluster;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.util.StringUtils;
 
 @ContextConfiguration(loader=HadoopDelegatingSmartContextLoader.class)
 @MiniHadoopCluster
-public class TextFileStoreAppendTests extends AbstractStoreTests {
+public class TextFileStoreSyncTests extends AbstractStoreTests {
 
 	@org.springframework.context.annotation.Configuration
 	static class Config {
@@ -43,9 +42,9 @@ public class TextFileStoreAppendTests extends AbstractStoreTests {
 	}
 
 	@Test
-	public void testWriteAppendReadTextManyLines() throws IOException {
+	public void testWriteSyncReadBeforeClosing() throws IOException {
 		TextFileWriter writer = new TextFileWriter(getConfiguration(), testDefaultPath, null);
-		writer.setAppendable(true);
+		writer.setSyncable(true);
 		TestUtils.writeData(writer, DATA09ARRAY, false);
 
 		TextFileReader reader = new TextFileReader(getConfiguration(), testDefaultPath, null);
@@ -54,26 +53,7 @@ public class TextFileStoreAppendTests extends AbstractStoreTests {
 	}
 
 	@Test
-	public void testWriteAppendReopen() throws IOException {
-		TextFileWriter writer = new TextFileWriter(getConfiguration(), testDefaultPath, null);
-		writer.setAppendable(true);
-		TestUtils.writeData(writer, DATA09ARRAY, false);
-		TextFileReader reader = new TextFileReader(getConfiguration(), testDefaultPath, null);
-		TestUtils.readDataAndAssert(reader, DATA09ARRAY);
-		writer.close();
-		reader.close();
-
-		writer = new TextFileWriter(getConfiguration(), testDefaultPath, null);
-		writer.setAppendable(true);
-		TestUtils.writeData(writer, DATA09ARRAY, false);
-		reader = new TextFileReader(getConfiguration(), testDefaultPath, null);
-		TestUtils.readDataAndAssert(reader, StringUtils.concatenateStringArrays(DATA09ARRAY, DATA09ARRAY));
-		writer.close();
-		reader.close();
-	}
-
-	@Test
-	public void testMapWriteAppendReadTextOneLine() throws IOException {
+	public void testPartitionWriteSyncReadBeforeClosing() throws IOException {
 		String expression = "path(region,dateFormat('yyyy/MM',timestamp),hash(region,1),list(region,{{'jee','foo'}}),range(range,{10}))";
 		String[] dataArray = new String[] { DATA10 };
 		DefaultPartitionStrategy<String> strategy = new DefaultPartitionStrategy<String>(expression);
@@ -87,7 +67,7 @@ public class TextFileStoreAppendTests extends AbstractStoreTests {
 		PartitionTextFileWriter<Map<String, Object>> writer =
 				new PartitionTextFileWriter<Map<String, Object>>(getConfiguration(), testDefaultPath, null, strategy);
 		writer.setFileNamingStrategyFactory(new StaticFileNamingStrategy("bar"));
-		writer.setAppendable(true);
+		writer.setSyncable(true);
 
 		writer.write(dataArray[0], headers);
 		writer.flush();


### PR DESCRIPTION
- For both TextFileWriter and PartitionTextFileWriter add
  new flag which can be set via setSyncable(boolean) method
  causing call of Appendable#hflush() with every write.