### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ defaultTasks 'build'
 
 buildscript {
 	repositories {
-		maven { url "http://repo.spring.io/plugins-release" }
-		maven { url "http://repo.spring.io/plugins-snapshot" }
+		maven { url "https://repo.spring.io/plugins-release" }
+		maven { url "https://repo.spring.io/plugins-snapshot" }
 	}
 	dependencies {
 		classpath("org.springframework.boot:spring-boot-gradle-plugin:$springBootVersion")
@@ -21,8 +21,8 @@ allprojects {
 
 	repositories {
 		mavenCentral()
-		maven { url 'http://repo.spring.io/libs-release' }
-		maven { url 'http://repo.spring.io/libs-milestone' }
+		maven { url 'https://repo.spring.io/libs-release' }
+		maven { url 'https://repo.spring.io/libs-milestone' }
 	}
 }
 
@@ -358,16 +358,16 @@ configure(javaProjects()) {
 	//		]
 
 			links = [
-				"http://docs.spring.io/spring/docs/4.0.x/javadoc-api/",
-				"http://docs.oracle.com/javase/6/docs/api/",
-				"http://commons.apache.org/proper/commons-logging/apidocs/",
-				"http://logging.apache.org/log4j/1.2/apidocs/",
-				"http://hadoop.apache.org/common/docs/current/api/",
-				"http://hbase.apache.org/apidocs/",
-				"http://pig.apache.org/docs/r0.12.0/api/",
-				"http://hive.apache.org/javadocs/r0.12.0/api/",
-				"http://docs.spring.io/spring-batch/apidocs/",
-				"http://docs.spring.io/spring-integration/api/"
+				"https://docs.spring.io/spring/docs/4.0.x/javadoc-api/",
+				"https://docs.oracle.com/javase/6/docs/api/",
+				"https://commons.apache.org/proper/commons-logging/apidocs/",
+				"https://logging.apache.org/log4j/1.2/apidocs/",
+				"https://hadoop.apache.org/common/docs/current/api/",
+				"https://hbase.apache.org/apidocs/",
+				"https://pig.apache.org/docs/r0.12.0/api/",
+				"https://hive.apache.org/javadocs/r0.12.0/api/",
+				"https://docs.spring.io/spring-batch/apidocs/",
+				"https://docs.spring.io/spring-integration/api/"
 			]
 
 			exclude "org/springframework/data/hadoop/config/**"
@@ -380,7 +380,7 @@ configure(javaProjects()) {
 		manifest.attributes["Created-By"] = "${System.getProperty("java.version")} (${System.getProperty("java.specification.vendor")})"
 		manifest.attributes['Implementation-Title'] = 'spring-data-hadoop'
 		manifest.attributes['Implementation-Version'] = project.version
-		manifest.attributes['Implementation-URL'] = "http://projects.spring.io/spring-hadoop/"
+		manifest.attributes['Implementation-URL'] = "https://projects.spring.io/spring-hadoop/"
 		manifest.attributes['Implementation-Vendor'] = "Spring by Pivotal"
 		manifest.attributes['Implementation-Vendor-Id'] = "org.springframework"
 
@@ -610,7 +610,7 @@ configure(rootProject) {
 		baseName = "spring-data-hadoop"
 		classifier = "docs"
 		description = "Builds -${classifier} archive containing api and reference " +
-			"for deployment at http://static.springframework.org/spring-hadoop/docs."
+			"for deployment at https://docs.spring.io/spring-hadoop/docs."
 
 		from("docs/src/info") {
 			include "changelog.txt"
@@ -630,7 +630,7 @@ configure(rootProject) {
 		baseName = "spring-data-hadoop"
 		classifier = "schema"
 		description = "Builds -${classifier} archive containing all " +
-			"XSDs for deployment at http://springframework.org/schema."
+			"XSDs for deployment at https://springframework.org/schema."
 
 		subprojects.each { subproject ->
 			def Properties schemas = new Properties();
@@ -916,13 +916,13 @@ project('spring-data-hadoop-build-tests') {
 	}
 
     task downloadGutenbergBooks {
-        ant.get(src: 'http://mirrors.xmission.com/gutenberg/1/0/100/100-0.txt',
+        ant.get(src: 'https://mirrors.xmission.com/gutenberg/1/0/100/100-0.txt',
                 dest: 'src/test/resources/input/gutenberg',skipexisting:true)
-        ant.get(src: 'http://mirrors.xmission.com/gutenberg/1/3/135/135-0.txt',
+        ant.get(src: 'https://mirrors.xmission.com/gutenberg/1/3/135/135-0.txt',
                 dest: 'src/test/resources/input/gutenberg',skipexisting:true)
-        ant.get(src: 'http://mirrors.xmission.com/gutenberg/1/3/9/1399/1399-0.txt',
+        ant.get(src: 'https://mirrors.xmission.com/gutenberg/1/3/9/1399/1399-0.txt',
                 dest: 'src/test/resources/input/gutenberg',skipexisting:true)
-        ant.get(src: 'http://mirrors.xmission.com/gutenberg/2/6/0/2600/2600-0.txt',
+        ant.get(src: 'https://mirrors.xmission.com/gutenberg/2/6/0/2600/2600-0.txt',
                 dest: 'src/test/resources/input/gutenberg',skipexisting:true)
     }
 

--- a/maven.gradle
+++ b/maven.gradle
@@ -19,20 +19,20 @@ def customizePom(pom, gradleProject) {
         generatedPom.project {
             name = gradleProject.description
             description = gradleProject.description
-            url = 'http://github.com/spring-projects/spring-hadoop'
+            url = 'https://github.com/spring-projects/spring-hadoop'
             organization {
                 name = 'Spring by Pivotal'
-                url = 'http://projects.spring.io/spring-hadoop/'
+                url = 'https://projects.spring.io/spring-hadoop/'
             }
             licenses {
                 license {
                     name 'The Apache Software License, Version 2.0'
-                    url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
                     distribution 'repo'
                 }
             }
             scm {
-                url = 'http://github.com/spring-projects/spring-hadoop'
+                url = 'https://github.com/spring-projects/spring-hadoop'
                 connection = 'scm:git:git://github.com/spring-projects/spring-hadoop'
                 developerConnection = 'scm:git:git://github.com/spring-projects/spring-hadoop'
             }


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://hadoop.apache.org/common/docs/current/api/ (404) migrated to:  
  https://hadoop.apache.org/common/docs/current/api/ ([https](https://hadoop.apache.org/common/docs/current/api/) result 404).
* http://hive.apache.org/javadocs/r0.12.0/api/ (404) migrated to:  
  https://hive.apache.org/javadocs/r0.12.0/api/ ([https](https://hive.apache.org/javadocs/r0.12.0/api/) result 404).

## Fixed Success 
These URLs were fixed successfully.

* http://commons.apache.org/proper/commons-logging/apidocs/ migrated to:  
  https://commons.apache.org/proper/commons-logging/apidocs/ ([https](https://commons.apache.org/proper/commons-logging/apidocs/) result 200).
* http://docs.oracle.com/javase/6/docs/api/ migrated to:  
  https://docs.oracle.com/javase/6/docs/api/ ([https](https://docs.oracle.com/javase/6/docs/api/) result 200).
* http://docs.spring.io/spring-integration/api/ migrated to:  
  https://docs.spring.io/spring-integration/api/ ([https](https://docs.spring.io/spring-integration/api/) result 200).
* http://docs.spring.io/spring/docs/4.0.x/javadoc-api/ migrated to:  
  https://docs.spring.io/spring/docs/4.0.x/javadoc-api/ ([https](https://docs.spring.io/spring/docs/4.0.x/javadoc-api/) result 200).
* http://github.com/spring-projects/spring-hadoop migrated to:  
  https://github.com/spring-projects/spring-hadoop ([https](https://github.com/spring-projects/spring-hadoop) result 200).
* http://hbase.apache.org/apidocs/ migrated to:  
  https://hbase.apache.org/apidocs/ ([https](https://hbase.apache.org/apidocs/) result 200).
* http://logging.apache.org/log4j/1.2/apidocs/ migrated to:  
  https://logging.apache.org/log4j/1.2/apidocs/ ([https](https://logging.apache.org/log4j/1.2/apidocs/) result 200).
* http://mirrors.xmission.com/gutenberg/1/0/100/100-0.txt migrated to:  
  https://mirrors.xmission.com/gutenberg/1/0/100/100-0.txt ([https](https://mirrors.xmission.com/gutenberg/1/0/100/100-0.txt) result 200).
* http://mirrors.xmission.com/gutenberg/1/3/135/135-0.txt migrated to:  
  https://mirrors.xmission.com/gutenberg/1/3/135/135-0.txt ([https](https://mirrors.xmission.com/gutenberg/1/3/135/135-0.txt) result 200).
* http://mirrors.xmission.com/gutenberg/1/3/9/1399/1399-0.txt migrated to:  
  https://mirrors.xmission.com/gutenberg/1/3/9/1399/1399-0.txt ([https](https://mirrors.xmission.com/gutenberg/1/3/9/1399/1399-0.txt) result 200).
* http://mirrors.xmission.com/gutenberg/2/6/0/2600/2600-0.txt migrated to:  
  https://mirrors.xmission.com/gutenberg/2/6/0/2600/2600-0.txt ([https](https://mirrors.xmission.com/gutenberg/2/6/0/2600/2600-0.txt) result 200).
* http://projects.spring.io/spring-hadoop/ migrated to:  
  https://projects.spring.io/spring-hadoop/ ([https](https://projects.spring.io/spring-hadoop/) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://docs.spring.io/spring-batch/apidocs/ migrated to:  
  https://docs.spring.io/spring-batch/apidocs/ ([https](https://docs.spring.io/spring-batch/apidocs/) result 301).
* http://static.springframework.org/spring-hadoop/docs (301) migrated to:  
  https://docs.spring.io/spring-hadoop/docs ([https](https://static.springframework.org/spring-hadoop/docs) result 301).
* http://pig.apache.org/docs/r0.12.0/api/ migrated to:  
  https://pig.apache.org/docs/r0.12.0/api/ ([https](https://pig.apache.org/docs/r0.12.0/api/) result 301).
* http://springframework.org/schema migrated to:  
  https://springframework.org/schema ([https](https://springframework.org/schema) result 301).
* http://repo.spring.io/libs-milestone migrated to:  
  https://repo.spring.io/libs-milestone ([https](https://repo.spring.io/libs-milestone) result 302).
* http://repo.spring.io/libs-release migrated to:  
  https://repo.spring.io/libs-release ([https](https://repo.spring.io/libs-release) result 302).
* http://repo.spring.io/plugins-release migrated to:  
  https://repo.spring.io/plugins-release ([https](https://repo.spring.io/plugins-release) result 302).
* http://repo.spring.io/plugins-snapshot migrated to:  
  https://repo.spring.io/plugins-snapshot ([https](https://repo.spring.io/plugins-snapshot) result 302).