### PR TITLE
URL Cleanup

### DIFF
--- a/spring-hadoop-build-tests/src/test/resources/config/hadoop-ns-1.xml
+++ b/spring-hadoop-build-tests/src/test/resources/config/hadoop-ns-1.xml
@@ -2,9 +2,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:context="http://www.springframework.org/schema/context" xmlns:hadoop="http://www.springframework.org/schema/hadoop"
 	xsi:schemaLocation="
-http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd
-http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd
+http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.0.xsd">
 
 	<context:component-scan base-package="org.springframework.data.hadoop.config" />
 	

--- a/spring-hadoop-build-tests/src/test/resources/jobs/kv/job-context.xml
+++ b/spring-hadoop-build-tests/src/test/resources/jobs/kv/job-context.xml
@@ -2,9 +2,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:context="http://www.springframework.org/schema/context" xmlns:hadoop="http://www.springframework.org/schema/hadoop"
 	xsi:schemaLocation="
-http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop-1.0.xsd
-http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop-1.0.xsd
+http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.0.xsd">
 
 	<bean id="autowiredWordCount" class="org.springframework.data.hadoop.mapreduce.JobFactoryBean">
 		<property name="mapper" ref="mapper" />

--- a/spring-hadoop-build-tests/src/test/resources/jobs/word/autowired-job-context.xml
+++ b/spring-hadoop-build-tests/src/test/resources/jobs/word/autowired-job-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<bean id="autowiredWordCount" class="org.springframework.data.hadoop.mapreduce.JobFactoryBean">
 		<property name="mapper" ref="mapper" />

--- a/spring-hadoop-build-tests/src/test/resources/jobs/word/bootstrap-job-context.xml
+++ b/spring-hadoop-build-tests/src/test/resources/jobs/word/bootstrap-job-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.0.xsd">
 
 	<bean id="autowiredWordCount" class="org.springframework.data.hadoop.mapreduce.JobFactoryBean">
 		<property name="mapper" ref="mapper" />

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/batch-common.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/batch-common.xml
@@ -2,7 +2,7 @@
 	xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="jobRepository" class="org.springframework.batch.core.repository.support.MapJobRepositoryFactoryBean">
 		<constructor-arg ref="transactionManager"/>

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/batch/JobParamsTest-context.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/batch/JobParamsTest-context.xml
@@ -4,9 +4,9 @@
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
 	xmlns:c="http://www.springframework.org/schema/c"
 	xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-      	http://www.springframework.org/schema/batch	http://www.springframework.org/schema/batch/spring-batch.xsd
-      	http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+      	http://www.springframework.org/schema/batch	https://www.springframework.org/schema/batch/spring-batch.xsd
+      	http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 	<import resource="../batch-common.xml"/>
 	<import resource="../hadoop-ctx.xml"/>

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/batch/hive/HiveBatchTest-context.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/batch/hive/HiveBatchTest-context.xml
@@ -6,11 +6,11 @@
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:c="http://www.springframework.org/schema/c"
 	xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-      	http://www.springframework.org/schema/batch	http://www.springframework.org/schema/batch/spring-batch.xsd
-      	http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
-      	http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-      	http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+      	http://www.springframework.org/schema/batch	https://www.springframework.org/schema/batch/spring-batch.xsd
+      	http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
+      	http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+      	http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 	<import resource="../../batch-common.xml"/>
 	<import resource="../../hadoop-ctx.xml"/>

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/batch/in-do-out-ns.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/batch/in-do-out-ns.xml
@@ -4,9 +4,9 @@
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
 	xmlns:c="http://www.springframework.org/schema/c"
 	xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-      	http://www.springframework.org/schema/batch	http://www.springframework.org/schema/batch/spring-batch.xsd
-      	http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+      	http://www.springframework.org/schema/batch	https://www.springframework.org/schema/batch/spring-batch.xsd
+      	http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 	<import resource="../batch-common.xml"/>
 	<import resource="../hadoop-ctx.xml"/>

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/batch/in-do-out.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/batch/in-do-out.xml
@@ -3,9 +3,9 @@
 	xmlns:batch="http://www.springframework.org/schema/batch"
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
 	xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-      	http://www.springframework.org/schema/batch	http://www.springframework.org/schema/batch/spring-batch.xsd
-      	http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+      	http://www.springframework.org/schema/batch	https://www.springframework.org/schema/batch/spring-batch.xsd
+      	http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 	<import resource="../batch-common.xml"/>
 	<import resource="../hadoop-ctx.xml"/>

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/batch/item/HdfsItemReaderTest-context.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/batch/item/HdfsItemReaderTest-context.xml
@@ -2,8 +2,8 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
 	xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-      	http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+      	http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 
 	<import resource="../../hadoop-ctx.xml"/>

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/batch/multi-thread.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/batch/multi-thread.xml
@@ -4,9 +4,9 @@
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
 	xmlns:c="http://www.springframework.org/schema/c"
 	xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-      	http://www.springframework.org/schema/batch	http://www.springframework.org/schema/batch/spring-batch.xsd
-      	http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+      	http://www.springframework.org/schema/batch	https://www.springframework.org/schema/batch/spring-batch.xsd
+      	http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 	<import resource="../batch-common.xml"/>
 	

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/batch/scripting/ScriptingBatchTest-context.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/batch/scripting/ScriptingBatchTest-context.xml
@@ -3,9 +3,9 @@
     xmlns:batch="http://www.springframework.org/schema/batch"
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
 	xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-      	http://www.springframework.org/schema/batch	http://www.springframework.org/schema/batch/spring-batch.xsd
-      	http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+      	http://www.springframework.org/schema/batch	https://www.springframework.org/schema/batch/spring-batch.xsd
+      	http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 	<import resource="../../batch-common.xml"/>
 	<import resource="../../hadoop-ctx.xml"/>

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/batch/spark/spark-batch.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/batch/spark/spark-batch.xml
@@ -4,9 +4,9 @@
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
 	xmlns:c="http://www.springframework.org/schema/c"
 	xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-      	http://www.springframework.org/schema/batch	http://www.springframework.org/schema/batch/spring-batch.xsd
-      	http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+      	http://www.springframework.org/schema/batch	https://www.springframework.org/schema/batch/spring-batch.xsd
+      	http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 	<bean name="ppc" class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"
 	      p:valueSeparator="|" p:location="test.properties" p:systemPropertiesModeName="SYSTEM_PROPERTIES_MODE_OVERRIDE" p:order="100"/>

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/batch/sqoop2/sqoop2-batch.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/batch/sqoop2/sqoop2-batch.xml
@@ -4,9 +4,9 @@
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
 	xmlns:c="http://www.springframework.org/schema/c"
 	xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-      	http://www.springframework.org/schema/batch	http://www.springframework.org/schema/batch/spring-batch.xsd
-      	http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+      	http://www.springframework.org/schema/batch	https://www.springframework.org/schema/batch/spring-batch.xsd
+      	http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 	<bean name="ppc" class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"
 	      p:valueSeparator="|" p:location="test.properties" p:systemPropertiesModeName="SYSTEM_PROPERTIES_MODE_OVERRIDE" p:order="100"/>

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/cascading/CascadingBatchTest-context.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/cascading/CascadingBatchTest-context.xml
@@ -5,10 +5,10 @@
 	xmlns:casc="http://www.springframework.org/schema/cascading"
 	xmlns:c="http://www.springframework.org/schema/c"
 	xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-      	http://www.springframework.org/schema/batch	http://www.springframework.org/schema/batch/spring-batch.xsd
-      	http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd
-      	http://www.springframework.org/schema/cascading http://www.springframework.org/schema/cascading/spring-cascading.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+      	http://www.springframework.org/schema/batch	https://www.springframework.org/schema/batch/spring-batch.xsd
+      	http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd
+      	http://www.springframework.org/schema/cascading https://www.springframework.org/schema/cascading/spring-cascading.xsd">
 
 	<import resource="../batch-common.xml"/>
 	<import resource="../hadoop-ctx.xml"/>

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/cascading/CascadingTest-context.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/cascading/CascadingTest-context.xml
@@ -5,10 +5,10 @@
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
 	xmlns:casc="http://www.springframework.org/schema/cascading"
 	xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd
-		http://www.springframework.org/schema/cascading http://www.springframework.org/schema/cascading/spring-cascading.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd
+		http://www.springframework.org/schema/cascading https://www.springframework.org/schema/cascading/spring-cascading.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<import resource="../hadoop-ctx.xml"/>
 	

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/cascading/cascade-import-ctx.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/cascading/cascade-import-ctx.xml
@@ -1,8 +1,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:util="http://www.springframework.org/schema/util"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<bean id="scheme" class="cascading.scheme.hadoop.TextLine"/>
 	

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/config/ConfigurationNamespaceTests-context.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/config/ConfigurationNamespaceTests-context.xml
@@ -4,10 +4,10 @@
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:util="http://www.springframework.org/schema/util"
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd"
 		default-lazy-init="true">
 
 	<!-- default -->

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/config/ConfigurationSecureHdfsTest-context.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/config/ConfigurationSecureHdfsTest-context.xml
@@ -3,9 +3,9 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:beans="http://www.springframework.org/schema/beans"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-	http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+	http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 	<configuration id="secureHdfsConfig" file-system-uri="hdfs://localhost:8020" user-keytab="/usr/local/hadoops/janne.keytab"
 		user-principal="janne/neo" security-method="kerberos" rm-manager-principal="yarn/neo@LOCALDOMAIN"

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/config/ResourceLoaderNamespaceTests-context.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/config/ResourceLoaderNamespaceTests-context.xml
@@ -3,8 +3,8 @@
 	xmlns:c="http://www.springframework.org/schema/c"
 	xmlns:p="http://www.springframework.org/schema/p"
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 	<!--use the bean definition to go beyond the configuration options provided by the namespace -->
 	<bean name="ppc" class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/config/ResourceLoaderRegistrarNamespaceTests-context.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/config/ResourceLoaderRegistrarNamespaceTests-context.xml
@@ -3,8 +3,8 @@
 	xmlns:c="http://www.springframework.org/schema/c"
 	xmlns:p="http://www.springframework.org/schema/p"
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 	<!--use the bean definition to go beyond the configuration options provided by the namespace -->
 	<bean name="ppc" class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/config/common/annotation/XmlImportDependencies.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/config/common/annotation/XmlImportDependencies.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<bean id="dependencyBean" class="org.springframework.data.hadoop.config.common.annotation.DependencyBean">
 		<property name="beanB" ref="simpleConfigBeanB" />

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/context/job-context.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/context/job-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<bean id="job" class="org.apache.hadoop.mapreduce.Job"/>
 

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/fs/AbstractROFsShellTest-context.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/fs/AbstractROFsShellTest-context.xml
@@ -2,8 +2,8 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
 	xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd" default-lazy-init="true">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd" default-lazy-init="true">
 
 	<import resource="../hadoop-ctx.xml"/>
 

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/fs/CustomResourceLoaderRegistrarTests-context.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/fs/CustomResourceLoaderRegistrarTests-context.xml
@@ -3,8 +3,8 @@
 	xmlns:c="http://www.springframework.org/schema/c"
 	xmlns:p="http://www.springframework.org/schema/p"
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 	<!--use the bean definition to go beyond the configuration options provided by the namespace -->
 	<bean name="ppc" class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"
@@ -28,7 +28,7 @@
 		p:resource="classpath:test.properties" />
 
 	<bean id="testBeanHttp" class="org.springframework.data.hadoop.fs.CustomResourceLoaderRegistrarTests$TestBean"
-		p:resource="http://example.com/tmp/test.txt" />
+		p:resource="https://example.com/tmp/test.txt" />
 
 	<bean id="testBeanFile" class="org.springframework.data.hadoop.fs.CustomResourceLoaderRegistrarTests$TestBean"
 		p:resource="file:/tmp/test.txt" />

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/fs/DistCpTest-context.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/fs/DistCpTest-context.xml
@@ -3,8 +3,8 @@
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
 	xmlns:c="http://www.springframework.org/schema/c"
 	xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd" default-lazy-init="true">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd" default-lazy-init="true">
 
 	<import resource="../hadoop-ctx.xml"/>
 

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/fs/DistributedCacheTest-context.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/fs/DistributedCacheTest-context.xml
@@ -1,8 +1,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-      	http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd" default-lazy-init="true">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+      	http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd" default-lazy-init="true">
 
 
 	<import resource="../hadoop-ctx.xml"/>

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/fs/FsShellInitTest-context.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/fs/FsShellInitTest-context.xml
@@ -2,8 +2,8 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
 	xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd" default-lazy-init="true">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd" default-lazy-init="true">
 
 	<import resource="../hadoop-ctx.xml"/>
 

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/fs/FsShellTest-context.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/fs/FsShellTest-context.xml
@@ -2,8 +2,8 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
 	xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd" default-lazy-init="true">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd" default-lazy-init="true">
 
 	<bean id="hadoopFs" class="org.springframework.data.hadoop.fs.FileSystemFactoryBean" p:configuration-ref="hadoopConfiguration"/>
 	

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/fs/HdfsItemWriterTest-context.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/fs/HdfsItemWriterTest-context.xml
@@ -3,9 +3,9 @@
 	xmlns:batch="http://www.springframework.org/schema/batch"
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
 	xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	  	http://www.springframework.org/schema/batch	http://www.springframework.org/schema/batch/spring-batch.xsd
-	  	http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	  	http://www.springframework.org/schema/batch	https://www.springframework.org/schema/batch/spring-batch.xsd
+	  	http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 	<import resource="../batch-common.xml"/>
 	<import resource="../hadoop-ctx.xml"/>

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/fs/HdfsResourceLoaderTests-context.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/fs/HdfsResourceLoaderTests-context.xml
@@ -3,8 +3,8 @@
 	xmlns:c="http://www.springframework.org/schema/c"
 	xmlns:p="http://www.springframework.org/schema/p"
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
     <!--make sure we have a /user directory with the correct permissions -->
     <hdp:script language="javascript" run-at-startup="true">

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/fs/HftpFsShellTest-context.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/fs/HftpFsShellTest-context.xml
@@ -2,8 +2,8 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
 	xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd" default-lazy-init="true">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd" default-lazy-init="true">
 
 	<hdp:file-system uri="#{'hftp://' + T(java.net.URI).create('${hadoop.fs}').getHost() }"/>
 	

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/fs/WebHdfsFsShellTest-context.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/fs/WebHdfsFsShellTest-context.xml
@@ -2,8 +2,8 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
 	xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd" default-lazy-init="true">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd" default-lazy-init="true">
 
 	<bean id="hadoopFs" class="org.springframework.data.hadoop.fs.FileSystemFactoryBean" p:configuration-ref="hadoopConfiguration" p:uri="webhdfs://localhost/"/>
 	

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/hadoop-ctx.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/hadoop-ctx.xml
@@ -3,8 +3,8 @@
 	xmlns:c="http://www.springframework.org/schema/c"
 	xmlns:p="http://www.springframework.org/schema/p"
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 	<!--use the bean definition to go beyond the configuration options provided by the namespace -->
 	<bean name="ppc" class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer" 

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/hbase/BasicHBaseTest-context.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/hbase/BasicHBaseTest-context.xml
@@ -5,10 +5,10 @@
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:c="http://www.springframework.org/schema/c"
 	xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-      	http://www.springframework.org/schema/batch	http://www.springframework.org/schema/batch/spring-batch.xsd
-      	http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-      	http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+      	http://www.springframework.org/schema/batch	https://www.springframework.org/schema/batch/spring-batch.xsd
+      	http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+      	http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 	<import resource="../hadoop-ctx.xml"/>
 	 

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/hbase/HBaseCfgTest-context.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/hbase/HBaseCfgTest-context.xml
@@ -5,10 +5,10 @@
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:c="http://www.springframework.org/schema/c"
 	xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-      	http://www.springframework.org/schema/batch	http://www.springframework.org/schema/batch/spring-batch.xsd
-      	http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-      	http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+      	http://www.springframework.org/schema/batch	https://www.springframework.org/schema/batch/spring-batch.xsd
+      	http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+      	http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 	<import resource="../hadoop-ctx.xml"/>
 	

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/hbase/HbaseTemplateTest-context.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/hbase/HbaseTemplateTest-context.xml
@@ -3,9 +3,9 @@
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-      	http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-      	http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+      	http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+      	http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 	<import resource="../hadoop-ctx.xml"/>
 	 

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/hive/basic.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/hive/basic.xml
@@ -4,10 +4,10 @@
 	xmlns:util="http://www.springframework.org/schema/util"
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
 	xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-      	http://www.springframework.org/schema/batch	http://www.springframework.org/schema/batch/spring-batch.xsd
-      	http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
-      	http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+      	http://www.springframework.org/schema/batch	https://www.springframework.org/schema/batch/spring-batch.xsd
+      	http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
+      	http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 	<import resource="../hadoop-ctx.xml"/>
 	 

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/mapreduce/JarTests-context.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/mapreduce/JarTests-context.xml
@@ -4,10 +4,10 @@
 	xmlns:batch="http://www.springframework.org/schema/batch"
 	xmlns:util="http://www.springframework.org/schema/util"
 	xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
-		http://www.springframework.org/schema/batch	http://www.springframework.org/schema/batch/spring-batch.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/batch	https://www.springframework.org/schema/batch/spring-batch.xsd">
 
 	<import resource="../hadoop-ctx.xml"/>
 	<import resource="../batch-common.xml"/>

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/mapreduce/JobKillTests-context.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/mapreduce/JobKillTests-context.xml
@@ -2,9 +2,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
 	xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd
-		http://www.springframework.org/schema/batch	http://www.springframework.org/schema/batch/spring-batch.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd
+		http://www.springframework.org/schema/batch	https://www.springframework.org/schema/batch/spring-batch.xsd">
 
 	<import resource="../batch-common.xml"/>
 	<import resource="../hadoop-ctx.xml"/>

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/mapreduce/JobTests-context.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/mapreduce/JobTests-context.xml
@@ -4,10 +4,10 @@
 	xmlns:util="http://www.springframework.org/schema/util"
 	xmlns:p="http://www.springframework.org/schema/p"
 	xmlns:task="http://www.springframework.org/schema/task" 
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
-		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/task https://www.springframework.org/schema/task/spring-task.xsd">
 
 	<import resource="../hadoop-ctx.xml"/>
 	<hdp:script id="script" language="javascript" run-at-startup="true">

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/mapreduce/ToolTests-context.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/mapreduce/ToolTests-context.xml
@@ -4,10 +4,10 @@
 	xmlns:batch="http://www.springframework.org/schema/batch"
 	xmlns:util="http://www.springframework.org/schema/util"
 	xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
-		http://www.springframework.org/schema/batch	http://www.springframework.org/schema/batch/spring-batch.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/batch	https://www.springframework.org/schema/batch/spring-batch.xsd">
 
 	<import resource="../hadoop-ctx.xml"/>
 	<import resource="../batch-common.xml"/>

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/pig/basic.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/pig/basic.xml
@@ -3,10 +3,10 @@
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
 	xmlns:util="http://www.springframework.org/schema/util"
 	xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-      	http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-      	http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd
-      	http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+      	http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+      	http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd
+      	http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<import resource="../hadoop-ctx.xml"/>
 	

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/pig/batch.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/pig/batch.xml
@@ -4,9 +4,9 @@
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
 	xmlns:c="http://www.springframework.org/schema/c"
 	xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-      	http://www.springframework.org/schema/batch	http://www.springframework.org/schema/batch/spring-batch.xsd
-      	http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+      	http://www.springframework.org/schema/batch	https://www.springframework.org/schema/batch/spring-batch.xsd
+      	http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 	<import resource="../batch-common.xml"/>
 	<hdp:configuration register-url-handler="false">

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/poc/context.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/poc/context.xml
@@ -4,9 +4,9 @@
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
 	xmlns:c="http://www.springframework.org/schema/c"
 	xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-      	http://www.springframework.org/schema/batch	http://www.springframework.org/schema/batch/spring-batch.xsd
-      	http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+      	http://www.springframework.org/schema/batch	https://www.springframework.org/schema/batch/spring-batch.xsd
+      	http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 	<import resource="../batch-common.xml"/>
 	<import resource="../hadoop-ctx.xml"/>

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/poc/int-trigger.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/poc/int-trigger.xml
@@ -3,9 +3,9 @@
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:file="http://www.springframework.org/schema/integration/file"
 	xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-      	http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-      	http://www.springframework.org/schema/integration/file http://www.springframework.org/schema/integration/file/spring-integration-file.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+      	http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+      	http://www.springframework.org/schema/integration/file https://www.springframework.org/schema/integration/file/spring-integration-file.xsd">
 
 	<!--  watch for input files to act as a trigger -->
 	

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/scripting/ScriptingTest-context.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/scripting/ScriptingTest-context.xml
@@ -3,8 +3,8 @@
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
 	xmlns:c="http://www.springframework.org/schema/c"
 	xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd" default-lazy-init="true">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd" default-lazy-init="true">
 
 	<import resource="../hadoop-ctx.xml"/>
 

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/streaming/basic.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/streaming/basic.xml
@@ -5,11 +5,11 @@
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:util="http://www.springframework.org/schema/util"
 	xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-      	http://www.springframework.org/schema/batch	http://www.springframework.org/schema/batch/spring-batch.xsd
-      	http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-      	http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd
-      	http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+      	http://www.springframework.org/schema/batch	https://www.springframework.org/schema/batch/spring-batch.xsd
+      	http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+      	http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd
+      	http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<import resource="../hadoop-ctx.xml"/>
 	 

--- a/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/util/PathUtilsTestWithXml-context.xml
+++ b/spring-hadoop-build-tests/src/test/resources/org/springframework/data/hadoop/util/PathUtilsTestWithXml-context.xml
@@ -3,10 +3,10 @@
 	xmlns:beans="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:batch="http://www.springframework.org/schema/batch" xmlns:p="http://www.springframework.org/schema/p"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/batch https://www.springframework.org/schema/batch/spring-batch.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.0.xsd">
 
 	<beans:bean id="test-ref"
 		class="org.springframework.data.hadoop.util.PathUtilsTestWithXml.ReferenceClass"

--- a/spring-hadoop-cluster-tests/src/test/resources/org/springframework/data/hadoop/test/HadoopClusterTests-context.xml
+++ b/spring-hadoop-cluster-tests/src/test/resources/org/springframework/data/hadoop/test/HadoopClusterTests-context.xml
@@ -3,10 +3,10 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<bean id="hadoopCluster" class="org.springframework.data.hadoop.test.support.HadoopClusterFactoryBean">
 		<property name="clusterId" value="HadoopClusterTests"/>

--- a/spring-hadoop-cluster-tests/src/test/resources/org/springframework/data/hadoop/test/junit/HadoopClusterBaseTestClassTests-context.xml
+++ b/spring-hadoop-cluster-tests/src/test/resources/org/springframework/data/hadoop/test/junit/HadoopClusterBaseTestClassTests-context.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 </beans>

--- a/spring-hadoop-store/src/test/resources/org/springframework/data/hadoop/store/SequenceFileStoreCtxTests-context.xml
+++ b/spring-hadoop-store/src/test/resources/org/springframework/data/hadoop/store/SequenceFileStoreCtxTests-context.xml
@@ -5,11 +5,11 @@
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-hadoop="http://www.springframework.org/schema/integration/hadoop"
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/hadoop http://www.springframework.org/schema/integration/hadoop/spring-integration-hadoop.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd
-		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/hadoop https://www.springframework.org/schema/integration/hadoop/spring-integration-hadoop.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/task https://www.springframework.org/schema/task/spring-task.xsd
+		http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 	<task:executor id="taskExecutor" pool-size="2"/>
 	<task:scheduler id="taskScheduler" pool-size="2"/>

--- a/spring-hadoop-store/src/test/resources/org/springframework/data/hadoop/store/TextFileStoreAppendCtxTests-context.xml
+++ b/spring-hadoop-store/src/test/resources/org/springframework/data/hadoop/store/TextFileStoreAppendCtxTests-context.xml
@@ -5,11 +5,11 @@
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-hadoop="http://www.springframework.org/schema/integration/hadoop"
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/hadoop http://www.springframework.org/schema/integration/hadoop/spring-integration-hadoop.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd
-		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/hadoop https://www.springframework.org/schema/integration/hadoop/spring-integration-hadoop.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/task https://www.springframework.org/schema/task/spring-task.xsd
+		http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 	<task:executor id="taskExecutor" pool-size="2"/>
 	<task:scheduler id="taskScheduler" pool-size="2"/>

--- a/spring-hadoop-store/src/test/resources/org/springframework/data/hadoop/store/TextFileStoreCtxTests-context.xml
+++ b/spring-hadoop-store/src/test/resources/org/springframework/data/hadoop/store/TextFileStoreCtxTests-context.xml
@@ -5,11 +5,11 @@
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-hadoop="http://www.springframework.org/schema/integration/hadoop"
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/hadoop http://www.springframework.org/schema/integration/hadoop/spring-integration-hadoop.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd
-		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/hadoop https://www.springframework.org/schema/integration/hadoop/spring-integration-hadoop.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/task https://www.springframework.org/schema/task/spring-task.xsd
+		http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 	<task:executor id="taskExecutor" pool-size="2"/>
 	<task:scheduler id="taskScheduler" pool-size="2"/>

--- a/spring-hadoop-store/src/test/resources/org/springframework/data/hadoop/store/dataset/DatasetStoreWriterTests-context.xml
+++ b/spring-hadoop-store/src/test/resources/org/springframework/data/hadoop/store/dataset/DatasetStoreWriterTests-context.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
     <bean id="path" class="java.lang.String">
         <constructor-arg value="/tmp/dataset/test"/>

--- a/spring-hadoop-store/src/test/resources/org/springframework/data/hadoop/store/dataset/DatasetTemplateTests-context.xml
+++ b/spring-hadoop-store/src/test/resources/org/springframework/data/hadoop/store/dataset/DatasetTemplateTests-context.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
     <bean id="path" class="java.lang.String">
         <constructor-arg value="/tmp/dataset/test"/>

--- a/spring-hadoop-test/src/test/resources/org/springframework/data/hadoop/test/context/HadoopClusterInjectingXmlContextLoaderTests-context.xml
+++ b/spring-hadoop-test/src/test/resources/org/springframework/data/hadoop/test/context/HadoopClusterInjectingXmlContextLoaderTests-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 </beans>

--- a/spring-yarn/spring-yarn-batch/src/test/resources/org/springframework/yarn/batch/config/master-ns.xml
+++ b/spring-yarn/spring-yarn-batch/src/test/resources/org/springframework/yarn/batch/config/master-ns.xml
@@ -3,10 +3,10 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:yarn="http://www.springframework.org/schema/yarn"
 	xmlns:yarn-batch="http://www.springframework.org/schema/yarn/batch"
-	xsi:schemaLocation="http://www.springframework.org/schema/yarn http://www.springframework.org/schema/yarn/spring-yarn.xsd
-		http://www.springframework.org/schema/yarn/batch http://www.springframework.org/schema/yarn/batch/spring-yarn-batch.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/yarn https://www.springframework.org/schema/yarn/spring-yarn.xsd
+		http://www.springframework.org/schema/yarn/batch https://www.springframework.org/schema/yarn/batch/spring-yarn-batch.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<yarn:configuration/>
 

--- a/spring-yarn/spring-yarn-batch/src/test/resources/org/springframework/yarn/batch/item/HdfsFileSplitItemReaderIntegrationTests-context.xml
+++ b/spring-yarn/spring-yarn-batch/src/test/resources/org/springframework/yarn/batch/item/HdfsFileSplitItemReaderIntegrationTests-context.xml
@@ -3,10 +3,10 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:yarn="http://www.springframework.org/schema/yarn"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/yarn http://www.springframework.org/schema/yarn/spring-yarn.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/yarn https://www.springframework.org/schema/yarn/spring-yarn.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<context:property-placeholder location="hadoop.properties"/>
 

--- a/spring-yarn/spring-yarn-batch/src/test/resources/org/springframework/yarn/batch/repository/RemoteJobRepositoryTests-context.xml
+++ b/spring-yarn/spring-yarn-batch/src/test/resources/org/springframework/yarn/batch/repository/RemoteJobRepositoryTests-context.xml
@@ -5,12 +5,12 @@
 	xmlns:ip="http://www.springframework.org/schema/integration/ip"
 	xmlns:yarn-int="http://www.springframework.org/schema/yarn/integration"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/yarn/integration
-			http://www.springframework.org/schema/yarn/integration/spring-yarn-integration.xsd
+			https://www.springframework.org/schema/yarn/integration/spring-yarn-integration.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd
+			https://www.springframework.org/schema/integration/spring-integration.xsd
 			http://www.springframework.org/schema/integration/ip
-			http://www.springframework.org/schema/integration/ip/spring-integration-ip.xsd">
+			https://www.springframework.org/schema/integration/ip/spring-integration-ip.xsd">
 
 </beans>

--- a/spring-yarn/spring-yarn-build-tests/src/test/resources/YarnClusterTests-appmaster-context.xml
+++ b/spring-yarn/spring-yarn-build-tests/src/test/resources/YarnClusterTests-appmaster-context.xml
@@ -4,10 +4,10 @@
 	xmlns:yarn="http://www.springframework.org/schema/yarn"
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:util="http://www.springframework.org/schema/util"
-	xsi:schemaLocation="http://www.springframework.org/schema/yarn http://www.springframework.org/schema/yarn/spring-yarn.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/yarn https://www.springframework.org/schema/yarn/spring-yarn.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<context:property-placeholder/>
 

--- a/spring-yarn/spring-yarn-build-tests/src/test/resources/org/springframework/yarn/client/ClientRmTemplateTests-context.xml
+++ b/spring-yarn/spring-yarn-build-tests/src/test/resources/org/springframework/yarn/client/ClientRmTemplateTests-context.xml
@@ -3,10 +3,10 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:yarn="http://www.springframework.org/schema/yarn"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/yarn http://www.springframework.org/schema/yarn/spring-yarn.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/yarn https://www.springframework.org/schema/yarn/spring-yarn.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<bean id="yarnClientRmTemplate" class="org.springframework.yarn.client.ClientRmTemplate">
 		<constructor-arg index="0"><ref bean="yarnConfiguration"/></constructor-arg>

--- a/spring-yarn/spring-yarn-build-tests/src/test/resources/org/springframework/yarn/test/YarnClusterTests-context.xml
+++ b/spring-yarn/spring-yarn-build-tests/src/test/resources/org/springframework/yarn/test/YarnClusterTests-context.xml
@@ -4,10 +4,10 @@
 	xmlns:yarn="http://www.springframework.org/schema/yarn"
 	xmlns:util="http://www.springframework.org/schema/util"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/yarn http://www.springframework.org/schema/yarn/spring-yarn.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/yarn https://www.springframework.org/schema/yarn/spring-yarn.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<bean id="yarnCluster" class="org.springframework.yarn.test.support.YarnClusterFactoryBean">
 		<property name="clusterId" value="YarnClusterTests"/>

--- a/spring-yarn/spring-yarn-build-tests/src/test/resources/org/springframework/yarn/test/junit/ClusterBaseTestClassSubmitTests-context.xml
+++ b/spring-yarn/spring-yarn-build-tests/src/test/resources/org/springframework/yarn/test/junit/ClusterBaseTestClassSubmitTests-context.xml
@@ -4,10 +4,10 @@
 	xmlns:yarn="http://www.springframework.org/schema/yarn"
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:util="http://www.springframework.org/schema/util"
-	xsi:schemaLocation="http://www.springframework.org/schema/yarn http://www.springframework.org/schema/yarn/spring-yarn.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/yarn https://www.springframework.org/schema/yarn/spring-yarn.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<yarn:localresources>
 		<yarn:copy src="file:build/dependency-all-libs/*" staging="true"/>

--- a/spring-yarn/spring-yarn-build-tests/src/test/resources/org/springframework/yarn/test/junit/ClusterBaseTestClassTests-context.xml
+++ b/spring-yarn/spring-yarn-build-tests/src/test/resources/org/springframework/yarn/test/junit/ClusterBaseTestClassTests-context.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:yarn="http://www.springframework.org/schema/yarn"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/yarn http://www.springframework.org/schema/yarn/spring-yarn.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/yarn https://www.springframework.org/schema/yarn/spring-yarn.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 </beans>

--- a/spring-yarn/spring-yarn-core/src/test/resources/org/springframework/yarn/am/AppmasterTests-context.xml
+++ b/spring-yarn/spring-yarn-core/src/test/resources/org/springframework/yarn/am/AppmasterTests-context.xml
@@ -2,9 +2,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:yarn="http://www.springframework.org/schema/yarn"
-	xsi:schemaLocation="http://www.springframework.org/schema/yarn http://www.springframework.org/schema/yarn/spring-yarn.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/yarn https://www.springframework.org/schema/yarn/spring-yarn.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<bean id="taskScheduler" class="org.springframework.scheduling.concurrent.ConcurrentTaskScheduler"/>
 	<bean id="taskExecutor" class="org.springframework.core.task.SyncTaskExecutor"/>

--- a/spring-yarn/spring-yarn-core/src/test/resources/org/springframework/yarn/client/ClientLocalizerIntegrationTests-context.xml
+++ b/spring-yarn/spring-yarn-core/src/test/resources/org/springframework/yarn/client/ClientLocalizerIntegrationTests-context.xml
@@ -3,10 +3,10 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:yarn="http://www.springframework.org/schema/yarn"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/yarn http://www.springframework.org/schema/yarn/spring-yarn.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/yarn https://www.springframework.org/schema/yarn/spring-yarn.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<context:property-placeholder location="hadoop.properties"/>
 

--- a/spring-yarn/spring-yarn-core/src/test/resources/org/springframework/yarn/config/annotation/XmlImportDependencies.xml
+++ b/spring-yarn/spring-yarn-core/src/test/resources/org/springframework/yarn/config/annotation/XmlImportDependencies.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<bean id="dependencyBean" class="org.springframework.yarn.config.annotation.DependencyBean">
 		<property name="configuration" ref="yarnConfiguration" />

--- a/spring-yarn/spring-yarn-core/src/test/resources/org/springframework/yarn/config/client-ns.xml
+++ b/spring-yarn/spring-yarn-core/src/test/resources/org/springframework/yarn/config/client-ns.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:yarn="http://www.springframework.org/schema/yarn"
 	xmlns:util="http://www.springframework.org/schema/util"
-	xsi:schemaLocation="http://www.springframework.org/schema/yarn http://www.springframework.org/schema/yarn/spring-yarn.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/yarn https://www.springframework.org/schema/yarn/spring-yarn.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<yarn:configuration/>
 	<yarn:localresources/>

--- a/spring-yarn/spring-yarn-core/src/test/resources/org/springframework/yarn/config/configuration-ns.xml
+++ b/spring-yarn/spring-yarn-core/src/test/resources/org/springframework/yarn/config/configuration-ns.xml
@@ -4,10 +4,10 @@
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:util="http://www.springframework.org/schema/util"
 	xmlns:yarn="http://www.springframework.org/schema/yarn"
-	xsi:schemaLocation="http://www.springframework.org/schema/yarn http://www.springframework.org/schema/yarn/spring-yarn.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/yarn https://www.springframework.org/schema/yarn/spring-yarn.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<context:property-placeholder location="hadoop-fake.properties"/>
 

--- a/spring-yarn/spring-yarn-core/src/test/resources/org/springframework/yarn/config/container-ns.xml
+++ b/spring-yarn/spring-yarn-core/src/test/resources/org/springframework/yarn/config/container-ns.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:yarn="http://www.springframework.org/schema/yarn"
 	xmlns:util="http://www.springframework.org/schema/util"
-	xsi:schemaLocation="http://www.springframework.org/schema/yarn http://www.springframework.org/schema/yarn/spring-yarn.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/yarn https://www.springframework.org/schema/yarn/spring-yarn.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<bean id="testContainer" class="org.springframework.yarn.container.TestContainer"/>
 

--- a/spring-yarn/spring-yarn-core/src/test/resources/org/springframework/yarn/config/environment-ns.xml
+++ b/spring-yarn/spring-yarn-core/src/test/resources/org/springframework/yarn/config/environment-ns.xml
@@ -4,10 +4,10 @@
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:util="http://www.springframework.org/schema/util"
 	xmlns:yarn="http://www.springframework.org/schema/yarn"
-	xsi:schemaLocation="http://www.springframework.org/schema/yarn http://www.springframework.org/schema/yarn/spring-yarn.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/yarn https://www.springframework.org/schema/yarn/spring-yarn.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<context:property-placeholder location="env.properties"/>
 

--- a/spring-yarn/spring-yarn-core/src/test/resources/org/springframework/yarn/config/localresources-ns.xml
+++ b/spring-yarn/spring-yarn-core/src/test/resources/org/springframework/yarn/config/localresources-ns.xml
@@ -4,10 +4,10 @@
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:util="http://www.springframework.org/schema/util"
 	xmlns:yarn="http://www.springframework.org/schema/yarn"
-	xsi:schemaLocation="http://www.springframework.org/schema/yarn http://www.springframework.org/schema/yarn/spring-yarn.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/yarn https://www.springframework.org/schema/yarn/spring-yarn.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<context:property-placeholder location="hadoop.properties"/>
 

--- a/spring-yarn/spring-yarn-core/src/test/resources/org/springframework/yarn/config/master-ns.xml
+++ b/spring-yarn/spring-yarn-core/src/test/resources/org/springframework/yarn/config/master-ns.xml
@@ -3,10 +3,10 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:yarn="http://www.springframework.org/schema/yarn"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/yarn http://www.springframework.org/schema/yarn/spring-yarn.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/yarn https://www.springframework.org/schema/yarn/spring-yarn.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<bean id="taskScheduler" class="org.springframework.scheduling.concurrent.ConcurrentTaskScheduler"/>
 

--- a/spring-yarn/spring-yarn-core/src/test/resources/org/springframework/yarn/launch/AbstractCommandLineRunnerTests-child.xml
+++ b/spring-yarn/spring-yarn-core/src/test/resources/org/springframework/yarn/launch/AbstractCommandLineRunnerTests-child.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="stubTestChildBean" class="org.springframework.yarn.launch.AbstractCommandLineRunnerTests$StubBean">
 		<property name="data" value="childdata" />

--- a/spring-yarn/spring-yarn-core/src/test/resources/org/springframework/yarn/launch/AbstractCommandLineRunnerTests-run.xml
+++ b/spring-yarn/spring-yarn-core/src/test/resources/org/springframework/yarn/launch/AbstractCommandLineRunnerTests-run.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="stubTestBean" class="org.springframework.yarn.launch.AbstractCommandLineRunnerTests$StubBean">
 		<property name="data" value="data" />

--- a/spring-yarn/spring-yarn-core/src/test/resources/static-appmaster-context.xml
+++ b/spring-yarn/spring-yarn-core/src/test/resources/static-appmaster-context.xml
@@ -3,10 +3,10 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:yarn="http://www.springframework.org/schema/yarn"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/yarn http://www.springframework.org/schema/yarn/spring-yarn.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/yarn https://www.springframework.org/schema/yarn/spring-yarn.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<context:property-placeholder location="hadoop-local.properties"/>
 

--- a/spring-yarn/spring-yarn-integration/src/test/resources/org/springframework/yarn/integration/ServerBindTests-context.xml
+++ b/spring-yarn/spring-yarn-integration/src/test/resources/org/springframework/yarn/integration/ServerBindTests-context.xml
@@ -4,11 +4,11 @@
 	xmlns="http://www.springframework.org/schema/beans"
 	xmlns:ip="http://www.springframework.org/schema/integration/ip"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd
+			https://www.springframework.org/schema/integration/spring-integration.xsd
 			http://www.springframework.org/schema/integration/ip
-			http://www.springframework.org/schema/integration/ip/spring-integration-ip.xsd">
+			https://www.springframework.org/schema/integration/ip/spring-integration-ip.xsd">
 
 	<bean id="javaSerializer" class="org.springframework.core.serializer.DefaultSerializer" />
 	<bean id="javaDeserializer" class="org.springframework.core.serializer.DefaultDeserializer" />

--- a/spring-yarn/spring-yarn-integration/src/test/resources/org/springframework/yarn/integration/config/amservice-ns.xml
+++ b/spring-yarn/spring-yarn-integration/src/test/resources/org/springframework/yarn/integration/config/amservice-ns.xml
@@ -6,15 +6,15 @@
 	xmlns:int-ip="http://www.springframework.org/schema/integration/ip"
 	xsi:schemaLocation="
 		http://www.springframework.org/schema/yarn/integration
-		http://www.springframework.org/schema/yarn/integration/spring-yarn-integration.xsd
+		https://www.springframework.org/schema/yarn/integration/spring-yarn-integration.xsd
 		http://www.springframework.org/schema/integration
-		http://www.springframework.org/schema/integration/spring-integration.xsd
+		https://www.springframework.org/schema/integration/spring-integration.xsd
 		http://www.springframework.org/schema/integration/ip
-		http://www.springframework.org/schema/integration/ip/spring-integration-ip.xsd
+		https://www.springframework.org/schema/integration/ip/spring-integration-ip.xsd
 		http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans.xsd
+		https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/util
-		http://www.springframework.org/schema/util/spring-util.xsd">
+		https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<yarn-int:amservice service-impl="org.springframework.yarn.integration.ip.mind.TestService"/>
 

--- a/spring-yarn/spring-yarn-integration/src/test/resources/org/springframework/yarn/integration/config/amserviceclient-ns.xml
+++ b/spring-yarn/spring-yarn-integration/src/test/resources/org/springframework/yarn/integration/config/amserviceclient-ns.xml
@@ -7,15 +7,15 @@
 	xmlns:int-ip="http://www.springframework.org/schema/integration/ip"
 	xsi:schemaLocation="
 		http://www.springframework.org/schema/yarn/integration
-		http://www.springframework.org/schema/yarn/integration/spring-yarn-integration.xsd
+		https://www.springframework.org/schema/yarn/integration/spring-yarn-integration.xsd
 		http://www.springframework.org/schema/integration
-		http://www.springframework.org/schema/integration/spring-integration.xsd
+		https://www.springframework.org/schema/integration/spring-integration.xsd
 		http://www.springframework.org/schema/integration/ip
-		http://www.springframework.org/schema/integration/ip/spring-integration-ip.xsd
+		https://www.springframework.org/schema/integration/ip/spring-integration-ip.xsd
 		http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans.xsd
+		https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/util
-		http://www.springframework.org/schema/util/spring-util.xsd">
+		https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<yarn-int:amservice-client service-impl="org.springframework.yarn.integration.ip.mind.TestServiceClient"/>
 

--- a/spring-yarn/spring-yarn-integration/src/test/resources/org/springframework/yarn/integration/ip/mind/MindIntegrationDefaultTests-context.xml
+++ b/spring-yarn/spring-yarn-integration/src/test/resources/org/springframework/yarn/integration/ip/mind/MindIntegrationDefaultTests-context.xml
@@ -5,13 +5,13 @@
 	xmlns:ip="http://www.springframework.org/schema/integration/ip"
 	xmlns:yarn-int="http://www.springframework.org/schema/yarn/integration"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/yarn/integration
-			http://www.springframework.org/schema/yarn/integration/spring-yarn-integration.xsd
+			https://www.springframework.org/schema/yarn/integration/spring-yarn-integration.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd
+			https://www.springframework.org/schema/integration/spring-integration.xsd
 			http://www.springframework.org/schema/integration/ip
-			http://www.springframework.org/schema/integration/ip/spring-integration-ip.xsd">
+			https://www.springframework.org/schema/integration/ip/spring-integration-ip.xsd">
 
 	<!-- We can't use random ports in tests, so use below trick to get one available -->
 	<bean id="tcpIpUtils" class="org.springframework.util.SocketUtils" />

--- a/spring-yarn/spring-yarn-integration/src/test/resources/org/springframework/yarn/integration/ip/mind/MindIntegrationNsTests-context.xml
+++ b/spring-yarn/spring-yarn-integration/src/test/resources/org/springframework/yarn/integration/ip/mind/MindIntegrationNsTests-context.xml
@@ -5,13 +5,13 @@
 	xmlns:ip="http://www.springframework.org/schema/integration/ip"
 	xmlns:yarn-int="http://www.springframework.org/schema/yarn/integration"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/yarn/integration
-			http://www.springframework.org/schema/yarn/integration/spring-yarn-integration.xsd
+			https://www.springframework.org/schema/yarn/integration/spring-yarn-integration.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd
+			https://www.springframework.org/schema/integration/spring-integration.xsd
 			http://www.springframework.org/schema/integration/ip
-			http://www.springframework.org/schema/integration/ip/spring-integration-ip.xsd">
+			https://www.springframework.org/schema/integration/ip/spring-integration-ip.xsd">
 
 	<!-- We can't use random ports in tests, so use below trick to get one available -->
 	<bean id="tcpIpUtils" class="org.springframework.util.SocketUtils" />

--- a/spring-yarn/spring-yarn-integration/src/test/resources/org/springframework/yarn/integration/ip/mind/MindIntegrationRawTests-context.xml
+++ b/spring-yarn/spring-yarn-integration/src/test/resources/org/springframework/yarn/integration/ip/mind/MindIntegrationRawTests-context.xml
@@ -5,13 +5,13 @@
 	xmlns:ip="http://www.springframework.org/schema/integration/ip"
 	xmlns:yarn-int="http://www.springframework.org/schema/yarn/integration"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/yarn/integration
-			http://www.springframework.org/schema/yarn/integration/spring-yarn-integration.xsd
+			https://www.springframework.org/schema/yarn/integration/spring-yarn-integration.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd
+			https://www.springframework.org/schema/integration/spring-integration.xsd
 			http://www.springframework.org/schema/integration/ip
-			http://www.springframework.org/schema/integration/ip/spring-integration-ip.xsd">
+			https://www.springframework.org/schema/integration/ip/spring-integration-ip.xsd">
 
 	<bean id="tcpIpUtils" class="org.springframework.util.SocketUtils" />
 	<bean id="randomTestPort" class="java.lang.Integer" >

--- a/spring-yarn/spring-yarn-integration/src/test/resources/org/springframework/yarn/integration/support/PortExposingTcpSocketSupportNetTests-context.xml
+++ b/spring-yarn/spring-yarn-integration/src/test/resources/org/springframework/yarn/integration/support/PortExposingTcpSocketSupportNetTests-context.xml
@@ -5,13 +5,13 @@
 	xmlns:ip="http://www.springframework.org/schema/integration/ip"
 	xmlns:yarn-int="http://www.springframework.org/schema/yarn/integration"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/yarn/integration
-			http://www.springframework.org/schema/yarn/integration/spring-yarn-integration.xsd
+			https://www.springframework.org/schema/yarn/integration/spring-yarn-integration.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd
+			https://www.springframework.org/schema/integration/spring-integration.xsd
 			http://www.springframework.org/schema/integration/ip
-			http://www.springframework.org/schema/integration/ip/spring-integration-ip.xsd">
+			https://www.springframework.org/schema/integration/ip/spring-integration-ip.xsd">
 
 	<bean id="tcpIpUtils" class="org.springframework.util.SocketUtils" />
 

--- a/spring-yarn/spring-yarn-integration/src/test/resources/org/springframework/yarn/integration/support/PortExposingTcpSocketSupportNioTests-context.xml
+++ b/spring-yarn/spring-yarn-integration/src/test/resources/org/springframework/yarn/integration/support/PortExposingTcpSocketSupportNioTests-context.xml
@@ -5,13 +5,13 @@
 	xmlns:ip="http://www.springframework.org/schema/integration/ip"
 	xmlns:yarn-int="http://www.springframework.org/schema/yarn/integration"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/yarn/integration
-			http://www.springframework.org/schema/yarn/integration/spring-yarn-integration.xsd
+			https://www.springframework.org/schema/yarn/integration/spring-yarn-integration.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd
+			https://www.springframework.org/schema/integration/spring-integration.xsd
 			http://www.springframework.org/schema/integration/ip
-			http://www.springframework.org/schema/integration/ip/spring-integration-ip.xsd">
+			https://www.springframework.org/schema/integration/ip/spring-integration-ip.xsd">
 
 	<bean id="tcpIpUtils" class="org.springframework.util.SocketUtils" />
 

--- a/spring-yarn/spring-yarn-test/src/test/resources/org/springframework/yarn/test/context/YarnClusterInjectingXmlContextLoaderTests-context.xml
+++ b/spring-yarn/spring-yarn-test/src/test/resources/org/springframework/yarn/test/context/YarnClusterInjectingXmlContextLoaderTests-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 </beans>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://example.com/tmp/test.txt (404) with 1 occurrences migrated to:  
  https://example.com/tmp/test.txt ([https](https://example.com/tmp/test.txt) result 404).
* http://www.springframework.org/schema/cascading/spring-cascading.xsd (404) with 2 occurrences migrated to:  
  https://www.springframework.org/schema/cascading/spring-cascading.xsd ([https](https://www.springframework.org/schema/cascading/spring-cascading.xsd) result 404).
* http://www.springframework.org/schema/integration/hadoop/spring-integration-hadoop.xsd (404) with 3 occurrences migrated to:  
  https://www.springframework.org/schema/integration/hadoop/spring-integration-hadoop.xsd ([https](https://www.springframework.org/schema/integration/hadoop/spring-integration-hadoop.xsd) result 404).
* http://www.springframework.org/schema/yarn/batch/spring-yarn-batch.xsd (404) with 1 occurrences migrated to:  
  https://www.springframework.org/schema/yarn/batch/spring-yarn-batch.xsd ([https](https://www.springframework.org/schema/yarn/batch/spring-yarn-batch.xsd) result 404).
* http://www.springframework.org/schema/yarn/integration/spring-yarn-integration.xsd (404) with 8 occurrences migrated to:  
  https://www.springframework.org/schema/yarn/integration/spring-yarn-integration.xsd ([https](https://www.springframework.org/schema/yarn/integration/spring-yarn-integration.xsd) result 404).
* http://www.springframework.org/schema/yarn/spring-yarn.xsd (404) with 16 occurrences migrated to:  
  https://www.springframework.org/schema/yarn/spring-yarn.xsd ([https](https://www.springframework.org/schema/yarn/spring-yarn.xsd) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.springframework.org/schema/batch/spring-batch.xsd with 20 occurrences migrated to:  
  https://www.springframework.org/schema/batch/spring-batch.xsd ([https](https://www.springframework.org/schema/batch/spring-batch.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans-3.0.xsd with 6 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-3.0.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-3.0.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans.xsd with 80 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* http://www.springframework.org/schema/context/spring-context-3.0.xsd with 4 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context-3.0.xsd ([https](https://www.springframework.org/schema/context/spring-context-3.0.xsd) result 200).
* http://www.springframework.org/schema/context/spring-context.xsd with 27 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context.xsd ([https](https://www.springframework.org/schema/context/spring-context.xsd) result 200).
* http://www.springframework.org/schema/hadoop/spring-hadoop-1.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/hadoop/spring-hadoop-1.0.xsd ([https](https://www.springframework.org/schema/hadoop/spring-hadoop-1.0.xsd) result 200).
* http://www.springframework.org/schema/hadoop/spring-hadoop.xsd with 48 occurrences migrated to:  
  https://www.springframework.org/schema/hadoop/spring-hadoop.xsd ([https](https://www.springframework.org/schema/hadoop/spring-hadoop.xsd) result 200).
* http://www.springframework.org/schema/integration/file/spring-integration-file.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/integration/file/spring-integration-file.xsd ([https](https://www.springframework.org/schema/integration/file/spring-integration-file.xsd) result 200).
* http://www.springframework.org/schema/integration/ip/spring-integration-ip.xsd with 9 occurrences migrated to:  
  https://www.springframework.org/schema/integration/ip/spring-integration-ip.xsd ([https](https://www.springframework.org/schema/integration/ip/spring-integration-ip.xsd) result 200).
* http://www.springframework.org/schema/integration/spring-integration.xsd with 13 occurrences migrated to:  
  https://www.springframework.org/schema/integration/spring-integration.xsd ([https](https://www.springframework.org/schema/integration/spring-integration.xsd) result 200).
* http://www.springframework.org/schema/task/spring-task.xsd with 4 occurrences migrated to:  
  https://www.springframework.org/schema/task/spring-task.xsd ([https](https://www.springframework.org/schema/task/spring-task.xsd) result 200).
* http://www.springframework.org/schema/util/spring-util.xsd with 31 occurrences migrated to:  
  https://www.springframework.org/schema/util/spring-util.xsd ([https](https://www.springframework.org/schema/util/spring-util.xsd) result 200).

# Ignored
These URLs were intentionally ignored.

* http://localhost:12000/sqoop/ with 1 occurrences
* http://www.springframework.org/schema/batch with 54 occurrences
* http://www.springframework.org/schema/beans with 172 occurrences
* http://www.springframework.org/schema/c with 18 occurrences
* http://www.springframework.org/schema/cascading with 4 occurrences
* http://www.springframework.org/schema/context with 61 occurrences
* http://www.springframework.org/schema/hadoop with 100 occurrences
* http://www.springframework.org/schema/integration with 26 occurrences
* http://www.springframework.org/schema/integration/file with 2 occurrences
* http://www.springframework.org/schema/integration/hadoop with 6 occurrences
* http://www.springframework.org/schema/integration/ip with 19 occurrences
* http://www.springframework.org/schema/p with 39 occurrences
* http://www.springframework.org/schema/task with 8 occurrences
* http://www.springframework.org/schema/util with 48 occurrences
* http://www.springframework.org/schema/yarn with 32 occurrences
* http://www.springframework.org/schema/yarn/batch with 2 occurrences
* http://www.springframework.org/schema/yarn/integration with 16 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 86 occurrences