### PR TITLE
URL Cleanup

### DIFF
--- a/docs/src/info/license.txt
+++ b/docs/src/info/license.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-batch/src/main/java/org/springframework/data/hadoop/batch/item/HdfsItemWriter.java
+++ b/spring-hadoop-batch/src/main/java/org/springframework/data/hadoop/batch/item/HdfsItemWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-batch/src/main/java/org/springframework/data/hadoop/batch/mapreduce/JarTasklet.java
+++ b/spring-hadoop-batch/src/main/java/org/springframework/data/hadoop/batch/mapreduce/JarTasklet.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-batch/src/main/java/org/springframework/data/hadoop/batch/mapreduce/JobTasklet.java
+++ b/spring-hadoop-batch/src/main/java/org/springframework/data/hadoop/batch/mapreduce/JobTasklet.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-batch/src/main/java/org/springframework/data/hadoop/batch/mapreduce/ToolTasklet.java
+++ b/spring-hadoop-batch/src/main/java/org/springframework/data/hadoop/batch/mapreduce/ToolTasklet.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-batch/src/main/java/org/springframework/data/hadoop/batch/scripting/ScriptTasklet.java
+++ b/spring-hadoop-batch/src/main/java/org/springframework/data/hadoop/batch/scripting/ScriptTasklet.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-boot/src/main/java/org/springframework/data/hadoop/boot/HadoopAutoConfiguration.java
+++ b/spring-hadoop-boot/src/main/java/org/springframework/data/hadoop/boot/HadoopAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-boot/src/main/java/org/springframework/data/hadoop/boot/HadoopFsShellAutoConfiguration.java
+++ b/spring-hadoop-boot/src/main/java/org/springframework/data/hadoop/boot/HadoopFsShellAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-boot/src/main/java/org/springframework/data/hadoop/boot/properties/SpringHadoopProperties.java
+++ b/spring-hadoop-boot/src/main/java/org/springframework/data/hadoop/boot/properties/SpringHadoopProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-boot/src/test/java/org/springframework/data/hadoop/boot/HadoopAutoConfigurationTests.java
+++ b/spring-hadoop-boot/src/test/java/org/springframework/data/hadoop/boot/HadoopAutoConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-boot/src/test/java/org/springframework/data/hadoop/boot/HadoopFsShellAutoConfigurationTests.java
+++ b/spring-hadoop-boot/src/test/java/org/springframework/data/hadoop/boot/HadoopFsShellAutoConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-boot/src/test/java/org/springframework/data/hadoop/boot/properties/SpringHadoopPropertiesTests.java
+++ b/spring-hadoop-boot/src/test/java/org/springframework/data/hadoop/boot/properties/SpringHadoopPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/InitBeforeHadoop.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/InitBeforeHadoop.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/TestUtils.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/TestUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/batch/BatchTest.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/batch/BatchTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/batch/JobParamsTest.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/batch/JobParamsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/batch/JobsTrigger.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/batch/JobsTrigger.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/batch/ReadWriteHdfsTest.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/batch/ReadWriteHdfsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/batch/hive/HiveBatchTest.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/batch/hive/HiveBatchTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/batch/item/HdfsItemReaderTest.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/batch/item/HdfsItemReaderTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/batch/pig/PigBatchTest.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/batch/pig/PigBatchTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/batch/scripting/ScriptingBatchTest.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/batch/scripting/ScriptingBatchTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/batch/spark/SparkYarnTaskletTests.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/batch/spark/SparkYarnTaskletTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/batch/sqoop2/Sqoop2TaskletTests.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/batch/sqoop2/Sqoop2TaskletTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/ConfigurationNamespaceTests.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/ConfigurationNamespaceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/ResourceLoaderNamespaceTests.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/ResourceLoaderNamespaceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/ResourceLoaderRegistrarNamespaceTests.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/ResourceLoaderRegistrarNamespaceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/annotation/SpringHadoopConfigurationTests.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/annotation/SpringHadoopConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/ComplexAnnotationConfigurationTests.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/ComplexAnnotationConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/DependencyBean.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/DependencyBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/ImportingBeanDefinitionTests.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/ImportingBeanDefinitionTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/SimpleAnnotationConfigurationTests.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/SimpleAnnotationConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/XmlImportDependenciesTests.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/XmlImportDependenciesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/complex/ComplexTestConfig.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/complex/ComplexTestConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/complex/ComplexTestConfigBeanA.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/complex/ComplexTestConfigBeanA.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/complex/ComplexTestConfigBeanABuilder.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/complex/ComplexTestConfigBeanABuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/complex/ComplexTestConfigBeanB.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/complex/ComplexTestConfigBeanB.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/complex/ComplexTestConfigBeanBBuilder.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/complex/ComplexTestConfigBeanBBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/complex/ComplexTestConfigBeanBConfigurer.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/complex/ComplexTestConfigBeanBConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/complex/ComplexTestConfigBuilder.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/complex/ComplexTestConfigBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/complex/ComplexTestConfiguration.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/complex/ComplexTestConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/complex/ComplexTestConfigurer.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/complex/ComplexTestConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/complex/ComplexTestConfigurerAdapter.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/complex/ComplexTestConfigurerAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/complex/EnableComplexTest.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/complex/EnableComplexTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/importing/EnableImportingTest.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/importing/EnableImportingTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/importing/ImportingTestConfig.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/importing/ImportingTestConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/importing/ImportingTestConfigBuilder.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/importing/ImportingTestConfigBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/importing/ImportingTestConfigurer.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/importing/ImportingTestConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/importing/ImportingTestConfigurerAdapter.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/importing/ImportingTestConfigurerAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/importing/SimpleImportingConfiguration.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/importing/SimpleImportingConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/simple/EnableSimpleTest.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/simple/EnableSimpleTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/simple/SimpleTestConfig.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/simple/SimpleTestConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/simple/SimpleTestConfigBeanA.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/simple/SimpleTestConfigBeanA.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/simple/SimpleTestConfigBeanABuilder.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/simple/SimpleTestConfigBeanABuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/simple/SimpleTestConfigBeanB.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/simple/SimpleTestConfigBeanB.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/simple/SimpleTestConfigBeanBBuilder.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/simple/SimpleTestConfigBeanBBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/simple/SimpleTestConfigBeanBConfigurer.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/simple/SimpleTestConfigBeanBConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/simple/SimpleTestConfigBuilder.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/simple/SimpleTestConfigBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/simple/SimpleTestConfiguration.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/simple/SimpleTestConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/simple/SimpleTestConfigurer.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/simple/SimpleTestConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/simple/SimpleTestConfigurerAdapter.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/config/common/annotation/simple/SimpleTestConfigurerAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/configuration/ConfigurationUtilsTest.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/configuration/ConfigurationUtilsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/configuration/UrlInfiniteLoopTest.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/configuration/UrlInfiniteLoopTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/fs/AbstractFsShellTest.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/fs/AbstractFsShellTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/fs/AbstractROFsShellTest.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/fs/AbstractROFsShellTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/fs/CustomResourceLoaderRegistrarTests.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/fs/CustomResourceLoaderRegistrarTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/fs/DistCpTest.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/fs/DistCpTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/fs/DistributedCacheTest.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/fs/DistributedCacheTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/fs/FsShellInitTest.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/fs/FsShellInitTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/fs/FsShellTest.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/fs/FsShellTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/fs/HdfsItemWriterTest.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/fs/HdfsItemWriterTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/fs/HdfsResourceLoaderLegacyTest.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/fs/HdfsResourceLoaderLegacyTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/fs/HdfsResourceLoaderTests.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/fs/HdfsResourceLoaderTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/fs/HftpFsShellTest.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/fs/HftpFsShellTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/fs/WebHdfsFsShellTest.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/fs/WebHdfsFsShellTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/hbase/BasicHBaseTest.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/hbase/BasicHBaseTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/hbase/HBaseCfgTest.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/hbase/HBaseCfgTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/hbase/HbaseTemplateTest.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/hbase/HbaseTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/hbase/Mapper.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/hbase/Mapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/hbase/Reducer.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/hbase/Reducer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/hive/BasicHiveTest.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/hive/BasicHiveTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/mapreduce/ClassUtilsTest.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/mapreduce/ClassUtilsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/mapreduce/JarTests.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/mapreduce/JarTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/mapreduce/JobKillTests.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/mapreduce/JobKillTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/mapreduce/JobTests.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/mapreduce/JobTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/mapreduce/StreamingTest.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/mapreduce/StreamingTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/mapreduce/ToolTests.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/mapreduce/ToolTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/pig/PigTest.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/pig/PigTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/pig/poc/LogAnalyzerTest.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/pig/poc/LogAnalyzerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/scripting/ScriptingTest.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/scripting/ScriptingTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/util/PathUtilsTestWithXml.java
+++ b/spring-hadoop-build-tests/src/test/java/org/springframework/data/hadoop/util/PathUtilsTestWithXml.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/test/SomeClass.java
+++ b/spring-hadoop-build-tests/src/test/java/test/SomeClass.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/test/SomeMainClass.java
+++ b/spring-hadoop-build-tests/src/test/java/test/SomeMainClass.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/test/SomeOtherMainClass.java
+++ b/spring-hadoop-build-tests/src/test/java/test/SomeOtherMainClass.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-build-tests/src/test/java/test/SomeToolCopy.java
+++ b/spring-hadoop-build-tests/src/test/java/test/SomeToolCopy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-cluster-tests/src/test/java/org/springframework/data/hadoop/test/HadoopClusterTests.java
+++ b/spring-hadoop-cluster-tests/src/test/java/org/springframework/data/hadoop/test/HadoopClusterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-cluster-tests/src/test/java/org/springframework/data/hadoop/test/MyMapper.java
+++ b/spring-hadoop-cluster-tests/src/test/java/org/springframework/data/hadoop/test/MyMapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-cluster-tests/src/test/java/org/springframework/data/hadoop/test/MyReduce.java
+++ b/spring-hadoop-cluster-tests/src/test/java/org/springframework/data/hadoop/test/MyReduce.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-cluster-tests/src/test/java/org/springframework/data/hadoop/test/junit/HadoopClusterBaseTestClassTests.java
+++ b/spring-hadoop-cluster-tests/src/test/java/org/springframework/data/hadoop/test/junit/HadoopClusterBaseTestClassTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/annotation/EnableHadoop.java
+++ b/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/annotation/EnableHadoop.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/annotation/SpringHadoopConfigs.java
+++ b/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/annotation/SpringHadoopConfigs.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/annotation/SpringHadoopConfigurer.java
+++ b/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/annotation/SpringHadoopConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/annotation/SpringHadoopConfigurerAdapter.java
+++ b/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/annotation/SpringHadoopConfigurerAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/annotation/builders/HadoopConfigBuilder.java
+++ b/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/annotation/builders/HadoopConfigBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/annotation/builders/HadoopConfigConfigurer.java
+++ b/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/annotation/builders/HadoopConfigConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/annotation/builders/SpringHadoopConfigBuilder.java
+++ b/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/annotation/builders/SpringHadoopConfigBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/annotation/configuration/SpringHadoopConfiguration.java
+++ b/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/annotation/configuration/SpringHadoopConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/AbstractAnnotationBuilder.java
+++ b/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/AbstractAnnotationBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/AbstractAnnotationConfiguration.java
+++ b/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/AbstractAnnotationConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/AbstractConfiguredAnnotationBuilder.java
+++ b/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/AbstractConfiguredAnnotationBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/AbstractImportingAnnotationConfiguration.java
+++ b/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/AbstractImportingAnnotationConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/AnnotationBuilder.java
+++ b/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/AnnotationBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/AnnotationConfigurer.java
+++ b/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/AnnotationConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/AnnotationConfigurerAdapter.java
+++ b/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/AnnotationConfigurerAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/AnnotationConfigurerBuilder.java
+++ b/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/AnnotationConfigurerBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/EnableAnnotationConfiguration.java
+++ b/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/EnableAnnotationConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/configuration/AutowireBeanFactoryObjectPostProcessor.java
+++ b/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/configuration/AutowireBeanFactoryObjectPostProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/configuration/ObjectPostProcessorConfiguration.java
+++ b/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/configuration/ObjectPostProcessorConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/configurers/DefaultPropertiesConfigurer.java
+++ b/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/configurers/DefaultPropertiesConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/configurers/DefaultResourceConfigurer.java
+++ b/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/configurers/DefaultResourceConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/configurers/DefaultSecurityConfigurer.java
+++ b/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/configurers/DefaultSecurityConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/configurers/PropertiesConfigurer.java
+++ b/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/configurers/PropertiesConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/configurers/PropertiesConfigurerAware.java
+++ b/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/configurers/PropertiesConfigurerAware.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/configurers/ResourceConfigurer.java
+++ b/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/configurers/ResourceConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/configurers/ResourceConfigurerAware.java
+++ b/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/configurers/ResourceConfigurerAware.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/configurers/SecurityConfigurer.java
+++ b/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/configurers/SecurityConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/configurers/SecurityConfigurerAware.java
+++ b/spring-hadoop-config/src/main/java/org/springframework/data/hadoop/config/common/annotation/configurers/SecurityConfigurerAware.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/HadoopException.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/HadoopException.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  * 
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/HadoopSecurityException.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/HadoopSecurityException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/HadoopSystemConstants.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/HadoopSystemConstants.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/configuration/ConfigurationFactoryBean.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/configuration/ConfigurationFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/configuration/ConfigurationUtils.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/configuration/ConfigurationUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/configuration/JobConfUtils.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/configuration/JobConfUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/fs/CustomResourceLoaderRegistrar.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/fs/CustomResourceLoaderRegistrar.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/fs/DistCp.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/fs/DistCp.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/fs/DistributedCacheFactoryBean.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/fs/DistributedCacheFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/fs/FileSystemFactoryBean.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/fs/FileSystemFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/fs/FsShell.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/fs/FsShell.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/fs/FsShellPermissions.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/fs/FsShellPermissions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/fs/HdfsResource.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/fs/HdfsResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/fs/HdfsResourceLoader.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/fs/HdfsResourceLoader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/fs/PrettyPrintList.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/fs/PrettyPrintList.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/fs/PrettyPrintMap.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/fs/PrettyPrintMap.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/fs/SimplerFileSystem.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/fs/SimplerFileSystem.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/fs/TextRecordInputStream.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/fs/TextRecordInputStream.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/mapreduce/ExecutionUtils.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/mapreduce/ExecutionUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/mapreduce/HadoopCodeExecutor.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/mapreduce/HadoopCodeExecutor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/mapreduce/JarExecutor.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/mapreduce/JarExecutor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/mapreduce/JarRunner.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/mapreduce/JarRunner.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/mapreduce/JobExecutor.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/mapreduce/JobExecutor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/mapreduce/JobFactoryBean.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/mapreduce/JobFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/mapreduce/JobGenericOptions.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/mapreduce/JobGenericOptions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/mapreduce/JobRunner.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/mapreduce/JobRunner.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/mapreduce/JobUtils.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/mapreduce/JobUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/mapreduce/MapReducePropertyEditorRegistrar.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/mapreduce/MapReducePropertyEditorRegistrar.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/mapreduce/ParentLastURLClassLoader.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/mapreduce/ParentLastURLClassLoader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/mapreduce/StreamJobFactoryBean.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/mapreduce/StreamJobFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/mapreduce/ToolExecutor.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/mapreduce/ToolExecutor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/mapreduce/ToolRunner.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/mapreduce/ToolRunner.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/scripting/EvaluationPolicy.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/scripting/EvaluationPolicy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/scripting/HdfsScriptRunner.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/scripting/HdfsScriptRunner.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/scripting/Jsr223ScriptEvaluator.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/scripting/Jsr223ScriptEvaluator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/scripting/Jsr223ScriptRunner.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/scripting/Jsr223ScriptRunner.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/scripting/ScriptEvaluator.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/scripting/ScriptEvaluator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/security/HadoopSecurity.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/security/HadoopSecurity.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/security/SecurityAuthMethod.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/security/SecurityAuthMethod.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/util/PathUtils.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/util/PathUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/util/ResourceUtils.java
+++ b/spring-hadoop-core/src/main/java/org/springframework/data/hadoop/util/ResourceUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-hbase/src/main/java/org/springframework/data/hadoop/hbase/HbaseAccessor.java
+++ b/spring-hadoop-hbase/src/main/java/org/springframework/data/hadoop/hbase/HbaseAccessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-hbase/src/main/java/org/springframework/data/hadoop/hbase/HbaseConfigurationFactoryBean.java
+++ b/spring-hadoop-hbase/src/main/java/org/springframework/data/hadoop/hbase/HbaseConfigurationFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-hbase/src/main/java/org/springframework/data/hadoop/hbase/HbaseInterceptor.java
+++ b/spring-hadoop-hbase/src/main/java/org/springframework/data/hadoop/hbase/HbaseInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-hbase/src/main/java/org/springframework/data/hadoop/hbase/HbaseOperations.java
+++ b/spring-hadoop-hbase/src/main/java/org/springframework/data/hadoop/hbase/HbaseOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-hbase/src/main/java/org/springframework/data/hadoop/hbase/HbaseSynchronizationManager.java
+++ b/spring-hadoop-hbase/src/main/java/org/springframework/data/hadoop/hbase/HbaseSynchronizationManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-hbase/src/main/java/org/springframework/data/hadoop/hbase/HbaseSystemException.java
+++ b/spring-hadoop-hbase/src/main/java/org/springframework/data/hadoop/hbase/HbaseSystemException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-hbase/src/main/java/org/springframework/data/hadoop/hbase/HbaseTemplate.java
+++ b/spring-hadoop-hbase/src/main/java/org/springframework/data/hadoop/hbase/HbaseTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-hbase/src/main/java/org/springframework/data/hadoop/hbase/HbaseUtils.java
+++ b/spring-hadoop-hbase/src/main/java/org/springframework/data/hadoop/hbase/HbaseUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-hbase/src/main/java/org/springframework/data/hadoop/hbase/ResultsExtractor.java
+++ b/spring-hadoop-hbase/src/main/java/org/springframework/data/hadoop/hbase/ResultsExtractor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-hbase/src/main/java/org/springframework/data/hadoop/hbase/RowMapper.java
+++ b/spring-hadoop-hbase/src/main/java/org/springframework/data/hadoop/hbase/RowMapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-hbase/src/main/java/org/springframework/data/hadoop/hbase/RowMapperResultsExtractor.java
+++ b/spring-hadoop-hbase/src/main/java/org/springframework/data/hadoop/hbase/RowMapperResultsExtractor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-hbase/src/main/java/org/springframework/data/hadoop/hbase/TableCallback.java
+++ b/spring-hadoop-hbase/src/main/java/org/springframework/data/hadoop/hbase/TableCallback.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-hive/src/main/java/org/springframework/data/hadoop/batch/hive/HiveTasklet.java
+++ b/spring-hadoop-hive/src/main/java/org/springframework/data/hadoop/batch/hive/HiveTasklet.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-hive/src/main/java/org/springframework/data/hadoop/hive/HiveClient.java
+++ b/spring-hadoop-hive/src/main/java/org/springframework/data/hadoop/hive/HiveClient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-hive/src/main/java/org/springframework/data/hadoop/hive/HiveClientCallback.java
+++ b/spring-hadoop-hive/src/main/java/org/springframework/data/hadoop/hive/HiveClientCallback.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-hive/src/main/java/org/springframework/data/hadoop/hive/HiveClientFactory.java
+++ b/spring-hadoop-hive/src/main/java/org/springframework/data/hadoop/hive/HiveClientFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-hive/src/main/java/org/springframework/data/hadoop/hive/HiveClientFactoryBean.java
+++ b/spring-hadoop-hive/src/main/java/org/springframework/data/hadoop/hive/HiveClientFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-hive/src/main/java/org/springframework/data/hadoop/hive/HiveExecutor.java
+++ b/spring-hadoop-hive/src/main/java/org/springframework/data/hadoop/hive/HiveExecutor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-hive/src/main/java/org/springframework/data/hadoop/hive/HiveOperations.java
+++ b/spring-hadoop-hive/src/main/java/org/springframework/data/hadoop/hive/HiveOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-hive/src/main/java/org/springframework/data/hadoop/hive/HiveRunner.java
+++ b/spring-hadoop-hive/src/main/java/org/springframework/data/hadoop/hive/HiveRunner.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-hive/src/main/java/org/springframework/data/hadoop/hive/HiveScript.java
+++ b/spring-hadoop-hive/src/main/java/org/springframework/data/hadoop/hive/HiveScript.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-hive/src/main/java/org/springframework/data/hadoop/hive/HiveServerFactoryBean.java
+++ b/spring-hadoop-hive/src/main/java/org/springframework/data/hadoop/hive/HiveServerFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-hive/src/main/java/org/springframework/data/hadoop/hive/HiveTemplate.java
+++ b/spring-hadoop-hive/src/main/java/org/springframework/data/hadoop/hive/HiveTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-hive/src/main/java/org/springframework/data/hadoop/hive/HiveUtils.java
+++ b/spring-hadoop-hive/src/main/java/org/springframework/data/hadoop/hive/HiveUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/AbstractGenericOptionsParser.java
+++ b/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/AbstractGenericOptionsParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/AbstractImprovedSimpleBeanDefinitionParser.java
+++ b/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/AbstractImprovedSimpleBeanDefinitionParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/AbstractPropertiesConfiguredBeanDefinitionParser.java
+++ b/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/AbstractPropertiesConfiguredBeanDefinitionParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/DistributedCacheParser.java
+++ b/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/DistributedCacheParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/HadoopConfigParser.java
+++ b/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/HadoopConfigParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/HadoopFileSystemParser.java
+++ b/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/HadoopFileSystemParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/HadoopJobParser.java
+++ b/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/HadoopJobParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/HadoopJobRunnerParser.java
+++ b/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/HadoopJobRunnerParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/HadoopJobTaskletParser.java
+++ b/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/HadoopJobTaskletParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/HadoopNamespaceHandler.java
+++ b/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/HadoopNamespaceHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/HadoopResourceLoaderParser.java
+++ b/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/HadoopResourceLoaderParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/HadoopResourceLoaderRegistrarParser.java
+++ b/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/HadoopResourceLoaderRegistrarParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/HadoopStreamJobParser.java
+++ b/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/HadoopStreamJobParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/HbaseConfigurationParser.java
+++ b/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/HbaseConfigurationParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/HiveClientParser.java
+++ b/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/HiveClientParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/HiveRunnerParser.java
+++ b/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/HiveRunnerParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/HiveServerParser.java
+++ b/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/HiveServerParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/HiveTaskletParser.java
+++ b/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/HiveTaskletParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/HiveTemplateParser.java
+++ b/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/HiveTemplateParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/JarRunnerParser.java
+++ b/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/JarRunnerParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/JarTaskletParser.java
+++ b/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/JarTaskletParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/LinkedProperties.java
+++ b/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/LinkedProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/NamespaceUtils.java
+++ b/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/NamespaceUtils.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  * 
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/PigRunnerParser.java
+++ b/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/PigRunnerParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/PigServerParser.java
+++ b/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/PigServerParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/PigTaskletParser.java
+++ b/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/PigTaskletParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/PigTemplateParser.java
+++ b/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/PigTemplateParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/ScriptParser.java
+++ b/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/ScriptParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/ScriptTaskletParser.java
+++ b/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/ScriptTaskletParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/ToolRunnerParser.java
+++ b/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/ToolRunnerParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/ToolTaskletParser.java
+++ b/spring-hadoop-namespace/src/main/java/org/springframework/data/hadoop/config/namespace/ToolTaskletParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-pig/src/main/java/org/springframework/data/hadoop/batch/pig/PigTasklet.java
+++ b/spring-hadoop-pig/src/main/java/org/springframework/data/hadoop/batch/pig/PigTasklet.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-pig/src/main/java/org/springframework/data/hadoop/pig/PigCallback.java
+++ b/spring-hadoop-pig/src/main/java/org/springframework/data/hadoop/pig/PigCallback.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-pig/src/main/java/org/springframework/data/hadoop/pig/PigContextFactoryBean.java
+++ b/spring-hadoop-pig/src/main/java/org/springframework/data/hadoop/pig/PigContextFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-pig/src/main/java/org/springframework/data/hadoop/pig/PigExecutor.java
+++ b/spring-hadoop-pig/src/main/java/org/springframework/data/hadoop/pig/PigExecutor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-pig/src/main/java/org/springframework/data/hadoop/pig/PigOperations.java
+++ b/spring-hadoop-pig/src/main/java/org/springframework/data/hadoop/pig/PigOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-pig/src/main/java/org/springframework/data/hadoop/pig/PigRunner.java
+++ b/spring-hadoop-pig/src/main/java/org/springframework/data/hadoop/pig/PigRunner.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-pig/src/main/java/org/springframework/data/hadoop/pig/PigScript.java
+++ b/spring-hadoop-pig/src/main/java/org/springframework/data/hadoop/pig/PigScript.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-pig/src/main/java/org/springframework/data/hadoop/pig/PigServerFactory.java
+++ b/spring-hadoop-pig/src/main/java/org/springframework/data/hadoop/pig/PigServerFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-pig/src/main/java/org/springframework/data/hadoop/pig/PigServerFactoryBean.java
+++ b/spring-hadoop-pig/src/main/java/org/springframework/data/hadoop/pig/PigServerFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-pig/src/main/java/org/springframework/data/hadoop/pig/PigTemplate.java
+++ b/spring-hadoop-pig/src/main/java/org/springframework/data/hadoop/pig/PigTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-pig/src/main/java/org/springframework/data/hadoop/pig/PigUtils.java
+++ b/spring-hadoop-pig/src/main/java/org/springframework/data/hadoop/pig/PigUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-spark/src/main/java/org/springframework/data/hadoop/batch/spark/SparkYarnTasklet.java
+++ b/spring-hadoop-spark/src/main/java/org/springframework/data/hadoop/batch/spark/SparkYarnTasklet.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-spark/src/test/java/org/springframework/data/hadoop/batch/spark/test/SparkHashtags.java
+++ b/spring-hadoop-spark/src/test/java/org/springframework/data/hadoop/batch/spark/test/SparkHashtags.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-sqoop2/src/main/java/org/springframework/data/hadoop/batch/sqoop2/Sqoop2Tasklet.java
+++ b/spring-hadoop-sqoop2/src/main/java/org/springframework/data/hadoop/batch/sqoop2/Sqoop2Tasklet.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/DataReader.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/DataReader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/DataStoreReader.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/DataStoreReader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/DataStoreWriter.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/DataStoreWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/DataWriter.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/DataWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/PartitionDataStoreWriter.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/PartitionDataStoreWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/StoreException.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/StoreException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/StoreSystemConstants.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/StoreSystemConstants.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/codec/CodecInfo.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/codec/CodecInfo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/codec/Codecs.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/codec/Codecs.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/codec/DefaultCodecInfo.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/codec/DefaultCodecInfo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/config/annotation/EnableDataStorePartitionTextWriter.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/config/annotation/EnableDataStorePartitionTextWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/config/annotation/EnableDataStoreTextWriter.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/config/annotation/EnableDataStoreTextWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/config/annotation/SpringDataStoreTextWriterConfigurer.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/config/annotation/SpringDataStoreTextWriterConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/config/annotation/SpringDataStoreTextWriterConfigurerAdapter.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/config/annotation/SpringDataStoreTextWriterConfigurerAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/config/annotation/SpringDataStoreWriterConfigs.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/config/annotation/SpringDataStoreWriterConfigs.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/config/annotation/builders/DataStoreTextWriterBuilder.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/config/annotation/builders/DataStoreTextWriterBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/config/annotation/builders/DataStoreTextWriterConfigurer.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/config/annotation/builders/DataStoreTextWriterConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/config/annotation/builders/SpringDataStoreTextWriterBuilder.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/config/annotation/builders/SpringDataStoreTextWriterBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/config/annotation/configuration/SpringDataStoreTextWriterConfiguration.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/config/annotation/configuration/SpringDataStoreTextWriterConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/config/annotation/configurers/DefaultNamingStrategyConfigurer.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/config/annotation/configurers/DefaultNamingStrategyConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/config/annotation/configurers/DefaultPartitionStrategyConfigurer.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/config/annotation/configurers/DefaultPartitionStrategyConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/config/annotation/configurers/DefaultRolloverStrategyConfigurer.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/config/annotation/configurers/DefaultRolloverStrategyConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/config/annotation/configurers/NamingStrategyConfigurer.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/config/annotation/configurers/NamingStrategyConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/config/annotation/configurers/PartitionStrategyConfigurer.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/config/annotation/configurers/PartitionStrategyConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/config/annotation/configurers/RolloverStrategyConfigurer.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/config/annotation/configurers/RolloverStrategyConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/AbstractDatasetStoreReader.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/AbstractDatasetStoreReader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/AbstractDatasetStoreWriter.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/AbstractDatasetStoreWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/AvroPojoDatasetStoreReader.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/AvroPojoDatasetStoreReader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/AvroPojoDatasetStoreWriter.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/AvroPojoDatasetStoreWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/DatasetDefinition.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/DatasetDefinition.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/DatasetOperations.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/DatasetOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/DatasetRepositoryCallback.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/DatasetRepositoryCallback.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/DatasetRepositoryFactory.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/DatasetRepositoryFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/DatasetStoreObjectSupport.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/DatasetStoreObjectSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/DatasetTemplate.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/DatasetTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/DatasetUtils.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/DatasetUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/ParquetDatasetStoreReader.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/ParquetDatasetStoreReader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/ParquetDatasetStoreWriter.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/ParquetDatasetStoreWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/RecordCallback.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/RecordCallback.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/ViewCallback.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/dataset/ViewCallback.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/event/AbstractStoreEvent.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/event/AbstractStoreEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/event/DefaultStoreEventPublisher.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/event/DefaultStoreEventPublisher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/event/FileWrittenEvent.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/event/FileWrittenEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/event/LoggingListener.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/event/LoggingListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/event/StoreEventPublisher.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/event/StoreEventPublisher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/expression/DateFormatMethodExecutor.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/expression/DateFormatMethodExecutor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/expression/HashListMethodExecutor.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/expression/HashListMethodExecutor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/expression/HashMethodExecutor.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/expression/HashMethodExecutor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/expression/HashRangeMethodExecutor.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/expression/HashRangeMethodExecutor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/expression/MapExpressionMethods.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/expression/MapExpressionMethods.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/expression/MapPartitionKeyPropertyAccessor.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/expression/MapPartitionKeyPropertyAccessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/expression/MessageDateFormatMethodExecutor.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/expression/MessageDateFormatMethodExecutor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/expression/MessageExpressionMethods.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/expression/MessageExpressionMethods.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/expression/MessagePartitionKeyMethodResolver.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/expression/MessagePartitionKeyMethodResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/expression/MessagePartitionKeyPropertyAccessor.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/expression/MessagePartitionKeyPropertyAccessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/expression/PartitionKeyMethodResolver.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/expression/PartitionKeyMethodResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/expression/PathCombiningMethodExecutor.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/expression/PathCombiningMethodExecutor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/input/AbstractDataStreamReader.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/input/AbstractDataStreamReader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/input/AbstractSequenceFileReader.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/input/AbstractSequenceFileReader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/input/DelimitedTextFileReader.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/input/DelimitedTextFileReader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/input/TextFileReader.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/input/TextFileReader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/input/TextSequenceFileReader.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/input/TextSequenceFileReader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/AbstractDataStreamWriter.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/AbstractDataStreamWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/AbstractPartitionDataStoreWriter.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/AbstractPartitionDataStoreWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/AbstractSequenceFileWriter.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/AbstractSequenceFileWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/DelimitedTextFileWriter.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/DelimitedTextFileWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/OutputStreamWriter.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/OutputStreamWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/PartitionTextFileWriter.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/PartitionTextFileWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/TextFileWriter.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/TextFileWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/TextSequenceFileWriter.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/output/TextSequenceFileWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/partition/AbstractPartitionStrategy.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/partition/AbstractPartitionStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/partition/DefaultPartitionKey.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/partition/DefaultPartitionKey.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/partition/DefaultPartitionStrategy.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/partition/DefaultPartitionStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/partition/MessagePartitionStrategy.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/partition/MessagePartitionStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/partition/PartitionKeyResolver.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/partition/PartitionKeyResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/partition/PartitionResolver.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/partition/PartitionResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/partition/PartitionStrategy.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/partition/PartitionStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/split/AbstractSplitter.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/split/AbstractSplitter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/split/GenericSplit.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/split/GenericSplit.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/split/SlopBlockSplitter.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/split/SlopBlockSplitter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/split/Split.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/split/Split.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/split/SplitLocation.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/split/SplitLocation.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/split/Splitter.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/split/Splitter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/split/StaticBlockSplitter.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/split/StaticBlockSplitter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/split/StaticLengthSplitter.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/split/StaticLengthSplitter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/strategy/naming/AbstractFileNamingStrategy.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/strategy/naming/AbstractFileNamingStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/strategy/naming/ChainedFileNamingStrategy.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/strategy/naming/ChainedFileNamingStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/strategy/naming/CodecFileNamingStrategy.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/strategy/naming/CodecFileNamingStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/strategy/naming/FileNamingStrategy.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/strategy/naming/FileNamingStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/strategy/naming/FileNamingStrategyFactory.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/strategy/naming/FileNamingStrategyFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/strategy/naming/RollingFileNamingStrategy.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/strategy/naming/RollingFileNamingStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/strategy/naming/StaticFileNamingStrategy.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/strategy/naming/StaticFileNamingStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/strategy/naming/UuidFileNamingStrategy.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/strategy/naming/UuidFileNamingStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/strategy/rollover/AbstractRolloverStrategy.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/strategy/rollover/AbstractRolloverStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/strategy/rollover/ChainedRolloverStrategy.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/strategy/rollover/ChainedRolloverStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/strategy/rollover/NoRolloverStrategy.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/strategy/rollover/NoRolloverStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/strategy/rollover/RolloverStrategy.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/strategy/rollover/RolloverStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/strategy/rollover/RolloverStrategyFactory.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/strategy/rollover/RolloverStrategyFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/strategy/rollover/SizeRolloverStrategy.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/strategy/rollover/SizeRolloverStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/support/IdleTimeoutTrigger.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/support/IdleTimeoutTrigger.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/support/InputContext.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/support/InputContext.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/support/InputStoreObjectSupport.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/support/InputStoreObjectSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/support/LifecycleObjectSupport.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/support/LifecycleObjectSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/support/OrderedComposite.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/support/OrderedComposite.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/support/OutputContext.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/support/OutputContext.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/support/OutputStoreObjectSupport.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/support/OutputStoreObjectSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/support/PollingTaskSupport.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/support/PollingTaskSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/support/SequenceFileWriterHolder.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/support/SequenceFileWriterHolder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/support/StoreContextUtils.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/support/StoreContextUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/support/StoreObjectSupport.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/support/StoreObjectSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/support/StoreUtils.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/support/StoreUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/support/StreamsHolder.java
+++ b/spring-hadoop-store/src/main/java/org/springframework/data/hadoop/store/support/StreamsHolder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/AbstractStoreTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/AbstractStoreTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/ContextCloseWriterTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/ContextCloseWriterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/DelimitedTextFileStoreTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/DelimitedTextFileStoreTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/PartitionTextFileWriterTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/PartitionTextFileWriterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/RawStreamStoreTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/RawStreamStoreTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/SequenceFileStoreCtxTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/SequenceFileStoreCtxTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/SequenceFileStoreTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/SequenceFileStoreTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TestUtils.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TestUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TextFileStoreAppendCtxTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TextFileStoreAppendCtxTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TextFileStoreAppendTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TextFileStoreAppendTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TextFileStoreCtxTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TextFileStoreCtxTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TextFileStoreFlushTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TextFileStoreFlushTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TextFileStoreSplitTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TextFileStoreSplitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TextFileStoreSyncTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TextFileStoreSyncTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TextFileStoreTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TextFileStoreTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TimeoutTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/TimeoutTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/config/annotation/SpringTextWriterConfigurationTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/config/annotation/SpringTextWriterConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/AbstractDatasetStoreWriterTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/AbstractDatasetStoreWriterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/AbstractDatasetTemplatePartitioningTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/AbstractDatasetTemplatePartitioningTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/AbstractDatasetTemplateTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/AbstractDatasetTemplateTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/AnotherPojo.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/AnotherPojo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/AvroNullablePojoDatasetStoreWriterTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/AvroNullablePojoDatasetStoreWriterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/AvroPojoDatasetStoreWriterTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/AvroPojoDatasetStoreWriterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/DatasetCompressionTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/DatasetCompressionTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/DatasetExtAvroSchemaTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/DatasetExtAvroSchemaTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/DatasetStoreTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/DatasetStoreTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/DatasetTemplateNoNullsTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/DatasetTemplateNoNullsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/DatasetTemplateParquetTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/DatasetTemplateParquetTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/DatasetTemplatePartitioningAvroTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/DatasetTemplatePartitioningAvroTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/DatasetTemplatePartitioningParquetTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/DatasetTemplatePartitioningParquetTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/DatasetTemplateTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/DatasetTemplateTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/DatasetWriterCacheSizeTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/DatasetWriterCacheSizeTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/NullableTestPojo.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/NullableTestPojo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/ParquetDatasetStoreWriterTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/ParquetDatasetStoreWriterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/RandomPojo.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/RandomPojo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/SimplePojo.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/SimplePojo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/TestPojo.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/dataset/TestPojo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/expression/AbstractExpressionTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/expression/AbstractExpressionTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/expression/DateFormatMethodExecutorTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/expression/DateFormatMethodExecutorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/expression/HashListMethodExecutorTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/expression/HashListMethodExecutorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/expression/HashMethodExecutorTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/expression/HashMethodExecutorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/expression/HashRangeMethodExecutorTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/expression/HashRangeMethodExecutorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/expression/MapExpressionMethodsTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/expression/MapExpressionMethodsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/expression/MapPartitionKeyPropertyAccessorTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/expression/MapPartitionKeyPropertyAccessorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/expression/MessageExpressionMethodsTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/expression/MessageExpressionMethodsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/expression/MessagePartitionKeyPropertyAccessorTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/expression/MessagePartitionKeyPropertyAccessorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/expression/PartitionKeyMethodResolverTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/expression/PartitionKeyMethodResolverTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/expression/PathCombiningMethodExecutorTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/expression/PathCombiningMethodExecutorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/expression/SpelCompileCoverageTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/expression/SpelCompileCoverageTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/output/FileWriteOpenTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/output/FileWriteOpenTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/output/PartitionTextFileWriterSmokeTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/output/PartitionTextFileWriterSmokeTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/output/TextFileWriterSmokeTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/output/TextFileWriterSmokeTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/partition/DefaultPartitionStrategyPerfTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/partition/DefaultPartitionStrategyPerfTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/partition/DefaultPartitionStrategyTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/partition/DefaultPartitionStrategyTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/partition/MessagePartitionStrategyPerfTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/partition/MessagePartitionStrategyPerfTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/partition/MessagePartitionStrategyTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/partition/MessagePartitionStrategyTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/partition/SpelPerfTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/partition/SpelPerfTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/split/AbstractSplitterTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/split/AbstractSplitterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/split/SlopBlockSplitterTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/split/SlopBlockSplitterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/split/StaticBlockSplitterTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/split/StaticBlockSplitterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/split/StaticLengthSplitterTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/split/StaticLengthSplitterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/strategy/naming/ChainedFileNamingStrategyTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/strategy/naming/ChainedFileNamingStrategyTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/strategy/naming/CodecFileNamingStrategyTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/strategy/naming/CodecFileNamingStrategyTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/strategy/naming/RollingFileNamingStrategyTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/strategy/naming/RollingFileNamingStrategyTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/strategy/naming/StaticFileNamingStrategyTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/strategy/naming/StaticFileNamingStrategyTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/strategy/naming/UuidFileNamingStrategyTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/strategy/naming/UuidFileNamingStrategyTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/support/OutputStoreObjectSupportTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/support/OutputStoreObjectSupportTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/support/PollingTaskSupportTests.java
+++ b/spring-hadoop-store/src/test/java/org/springframework/data/hadoop/store/support/PollingTaskSupportTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-test/src/main/java/org/springframework/data/hadoop/test/HadoopTestSystemConstants.java
+++ b/spring-hadoop-test/src/main/java/org/springframework/data/hadoop/test/HadoopTestSystemConstants.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-test/src/main/java/org/springframework/data/hadoop/test/context/HadoopCluster.java
+++ b/spring-hadoop-test/src/main/java/org/springframework/data/hadoop/test/context/HadoopCluster.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-test/src/main/java/org/springframework/data/hadoop/test/context/HadoopClusterInjectUtils.java
+++ b/spring-hadoop-test/src/main/java/org/springframework/data/hadoop/test/context/HadoopClusterInjectUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-test/src/main/java/org/springframework/data/hadoop/test/context/HadoopClusterInjectingAnnotationConfigContextLoader.java
+++ b/spring-hadoop-test/src/main/java/org/springframework/data/hadoop/test/context/HadoopClusterInjectingAnnotationConfigContextLoader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-test/src/main/java/org/springframework/data/hadoop/test/context/HadoopClusterInjectingXmlContextLoader.java
+++ b/spring-hadoop-test/src/main/java/org/springframework/data/hadoop/test/context/HadoopClusterInjectingXmlContextLoader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-test/src/main/java/org/springframework/data/hadoop/test/context/HadoopDelegatingSmartContextLoader.java
+++ b/spring-hadoop-test/src/main/java/org/springframework/data/hadoop/test/context/HadoopDelegatingSmartContextLoader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-test/src/main/java/org/springframework/data/hadoop/test/context/MiniHadoopCluster.java
+++ b/spring-hadoop-test/src/main/java/org/springframework/data/hadoop/test/context/MiniHadoopCluster.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-test/src/main/java/org/springframework/data/hadoop/test/junit/AbstractHadoopClusterTests.java
+++ b/spring-hadoop-test/src/main/java/org/springframework/data/hadoop/test/junit/AbstractHadoopClusterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-test/src/main/java/org/springframework/data/hadoop/test/junit/AbstractMapReduceTests.java
+++ b/spring-hadoop-test/src/main/java/org/springframework/data/hadoop/test/junit/AbstractMapReduceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-test/src/main/java/org/springframework/data/hadoop/test/support/ClusterInfo.java
+++ b/spring-hadoop-test/src/main/java/org/springframework/data/hadoop/test/support/ClusterInfo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-test/src/main/java/org/springframework/data/hadoop/test/support/ConfigurationDelegatingFactoryBean.java
+++ b/spring-hadoop-test/src/main/java/org/springframework/data/hadoop/test/support/ConfigurationDelegatingFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-test/src/main/java/org/springframework/data/hadoop/test/support/HadoopClusterDelegatingFactoryBean.java
+++ b/spring-hadoop-test/src/main/java/org/springframework/data/hadoop/test/support/HadoopClusterDelegatingFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-test/src/main/java/org/springframework/data/hadoop/test/support/HadoopClusterFactoryBean.java
+++ b/spring-hadoop-test/src/main/java/org/springframework/data/hadoop/test/support/HadoopClusterFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-test/src/main/java/org/springframework/data/hadoop/test/support/HadoopClusterManager.java
+++ b/spring-hadoop-test/src/main/java/org/springframework/data/hadoop/test/support/HadoopClusterManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-test/src/main/java/org/springframework/data/hadoop/test/support/StandaloneHadoopCluster.java
+++ b/spring-hadoop-test/src/main/java/org/springframework/data/hadoop/test/support/StandaloneHadoopCluster.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-test/src/main/java/org/springframework/data/hadoop/test/support/compat/MiniMRClusterCompat.java
+++ b/spring-hadoop-test/src/main/java/org/springframework/data/hadoop/test/support/compat/MiniMRClusterCompat.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-test/src/test/java/org/springframework/data/hadoop/test/context/HadoopClusterInjectingAnnotationConfigContextLoaderTests.java
+++ b/spring-hadoop-test/src/test/java/org/springframework/data/hadoop/test/context/HadoopClusterInjectingAnnotationConfigContextLoaderTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-test/src/test/java/org/springframework/data/hadoop/test/context/HadoopClusterInjectingXmlContextLoaderTests.java
+++ b/spring-hadoop-test/src/test/java/org/springframework/data/hadoop/test/context/HadoopClusterInjectingXmlContextLoaderTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-test/src/test/java/org/springframework/data/hadoop/test/support/HadoopClusterManagerTests.java
+++ b/spring-hadoop-test/src/test/java/org/springframework/data/hadoop/test/support/HadoopClusterManagerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-test/src/test/java/org/springframework/data/hadoop/test/tests/Assume.java
+++ b/spring-hadoop-test/src/test/java/org/springframework/data/hadoop/test/tests/Assume.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-test/src/test/java/org/springframework/data/hadoop/test/tests/AssumeTests.java
+++ b/spring-hadoop-test/src/test/java/org/springframework/data/hadoop/test/tests/AssumeTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-test/src/test/java/org/springframework/data/hadoop/test/tests/TestGroup.java
+++ b/spring-hadoop-test/src/test/java/org/springframework/data/hadoop/test/tests/TestGroup.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-test/src/test/java/org/springframework/data/hadoop/test/tests/TestGroupTests.java
+++ b/spring-hadoop-test/src/test/java/org/springframework/data/hadoop/test/tests/TestGroupTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-test/src/test/java/org/springframework/data/hadoop/test/tests/Version.java
+++ b/spring-hadoop-test/src/test/java/org/springframework/data/hadoop/test/tests/Version.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-util/src/main/java/org/springframework/data/hadoop/util/net/DefaultHostInfoDiscovery.java
+++ b/spring-hadoop-util/src/main/java/org/springframework/data/hadoop/util/net/DefaultHostInfoDiscovery.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-util/src/main/java/org/springframework/data/hadoop/util/net/HostInfoDiscovery.java
+++ b/spring-hadoop-util/src/main/java/org/springframework/data/hadoop/util/net/HostInfoDiscovery.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-hadoop-util/src/test/org/springframework/data/hadoop/utils/net/DefaultHostInfoDiscoveryTests.java
+++ b/spring-hadoop-util/src/test/org/springframework/data/hadoop/utils/net/DefaultHostInfoDiscoveryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/BatchSystemConstants.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/BatchSystemConstants.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/am/AbstractBatchAppmaster.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/am/AbstractBatchAppmaster.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/am/BatchAppmaster.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/am/BatchAppmaster.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/am/BatchYarnAppmaster.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/am/BatchYarnAppmaster.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/config/BatchMasterParser.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/config/BatchMasterParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/config/BatchNamespaceHandler.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/config/BatchNamespaceHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/config/EnableYarnBatchProcessing.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/config/EnableYarnBatchProcessing.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/config/EnableYarnRemoteBatchProcessing.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/config/EnableYarnRemoteBatchProcessing.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/config/SimpleYarnBatchConfiguration.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/config/SimpleYarnBatchConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/config/SimpleYarnRemoteBatchConfiguration.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/config/SimpleYarnRemoteBatchConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/container/AbstractBatchYarnContainer.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/container/AbstractBatchYarnContainer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/container/DefaultBatchYarnContainer.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/container/DefaultBatchYarnContainer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/event/JobExecutionEvent.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/event/JobExecutionEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/event/PartitionedStepExecutionEvent.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/event/PartitionedStepExecutionEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/item/DataStoreItemReader.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/item/DataStoreItemReader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/item/LineDataMapper.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/item/LineDataMapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/item/PassThroughLineDataMapper.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/item/PassThroughLineDataMapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/listener/CompositePartitionedStepExecutionStateListener.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/listener/CompositePartitionedStepExecutionStateListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/listener/PartitionedStepExecutionStateListener.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/listener/PartitionedStepExecutionStateListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/partition/AbstractPartitionHandler.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/partition/AbstractPartitionHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/partition/AbstractPartitioner.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/partition/AbstractPartitioner.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/partition/SplitterPartitionHandler.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/partition/SplitterPartitionHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/partition/SplitterPartitioner.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/partition/SplitterPartitioner.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/partition/StaticPartitionHandler.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/partition/StaticPartitionHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/AbstractRemoteDao.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/AbstractRemoteDao.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/BatchAppmasterService.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/BatchAppmasterService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/JobRepositoryRemoteServiceInterceptor.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/JobRepositoryRemoteServiceInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/JobRepositoryRpcFactory.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/JobRepositoryRpcFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/JobRepositoryService.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/JobRepositoryService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/RemoteJobExplorer.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/RemoteJobExplorer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/RemoteJobRepository.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/RemoteJobRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/ExecutionContextType.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/ExecutionContextType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/JobExecutionType.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/JobExecutionType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/JobInstanceType.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/JobInstanceType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/JobParameterType.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/JobParameterType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/JobParametersType.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/JobParametersType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/PartitionedStepExecutionStatusReq.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/PartitionedStepExecutionStatusReq.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/PartitionedStepExecutionStatusRes.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/PartitionedStepExecutionStatusRes.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/StepExecutionType.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/StepExecutionType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/exp/FindJobInstancesByJobNameReq.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/exp/FindJobInstancesByJobNameReq.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/exp/FindJobInstancesByJobNameRes.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/exp/FindJobInstancesByJobNameRes.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/exp/FindRunningJobExecutionsReq.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/exp/FindRunningJobExecutionsReq.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/exp/FindRunningJobExecutionsRes.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/exp/FindRunningJobExecutionsRes.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/exp/GetJobExecutionReq.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/exp/GetJobExecutionReq.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/exp/GetJobExecutionRes.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/exp/GetJobExecutionRes.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/exp/GetJobExecutionsReq.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/exp/GetJobExecutionsReq.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/exp/GetJobExecutionsRes.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/exp/GetJobExecutionsRes.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/exp/GetJobInstanceCountReq.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/exp/GetJobInstanceCountReq.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/exp/GetJobInstanceCountRes.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/exp/GetJobInstanceCountRes.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/exp/GetJobInstanceReq.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/exp/GetJobInstanceReq.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/exp/GetJobInstanceRes.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/exp/GetJobInstanceRes.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/exp/GetJobInstancesReq.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/exp/GetJobInstancesReq.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/exp/GetJobInstancesRes.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/exp/GetJobInstancesRes.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/exp/GetJobNamesReq.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/exp/GetJobNamesReq.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/exp/GetJobNamesRes.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/exp/GetJobNamesRes.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/exp/GetStepExecutionReq.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/exp/GetStepExecutionReq.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/exp/GetStepExecutionRes.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/exp/GetStepExecutionRes.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/AddWithStepExecutionReq.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/AddWithStepExecutionReq.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/AddWithStepExecutionRes.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/AddWithStepExecutionRes.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/CreateJobExecutionReq.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/CreateJobExecutionReq.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/CreateJobExecutionRes.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/CreateJobExecutionRes.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/CreateJobExecutionWithJobInstanceReq.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/CreateJobExecutionWithJobInstanceReq.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/CreateJobExecutionWithJobInstanceRes.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/CreateJobExecutionWithJobInstanceRes.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/CreateJobInstanceReq.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/CreateJobInstanceReq.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/CreateJobInstanceRes.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/CreateJobInstanceRes.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/GetLastJobExecutionReq.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/GetLastJobExecutionReq.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/GetLastJobExecutionRes.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/GetLastJobExecutionRes.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/GetLastStepExecutionReq.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/GetLastStepExecutionReq.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/GetLastStepExecutionRes.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/GetLastStepExecutionRes.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/GetStepExecutionCountReq.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/GetStepExecutionCountReq.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/GetStepExecutionCountRes.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/GetStepExecutionCountRes.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/IsJobInstanceExistsReq.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/IsJobInstanceExistsReq.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/IsJobInstanceExistsRes.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/IsJobInstanceExistsRes.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/UpdateExecutionContextReq.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/UpdateExecutionContextReq.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/UpdateExecutionContextRes.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/UpdateExecutionContextRes.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/UpdateWithJobExecutionReq.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/UpdateWithJobExecutionReq.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/UpdateWithJobExecutionRes.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/UpdateWithJobExecutionRes.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/UpdateWithStepExecutionReq.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/UpdateWithStepExecutionReq.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/UpdateWithStepExecutionRes.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/repository/bindings/repo/UpdateWithStepExecutionRes.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/support/BeanFactoryStepLocator.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/support/BeanFactoryStepLocator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/support/YarnBatchProperties.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/support/YarnBatchProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/support/YarnJobLauncher.java
+++ b/spring-yarn/spring-yarn-batch/src/main/java/org/springframework/yarn/batch/support/YarnJobLauncher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/test/java/org/springframework/yarn/batch/config/MasterNamespaceTest.java
+++ b/spring-yarn/spring-yarn-batch/src/test/java/org/springframework/yarn/batch/config/MasterNamespaceTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/test/java/org/springframework/yarn/batch/config/SimpleYarnBatchConfigurationTests.java
+++ b/spring-yarn/spring-yarn-batch/src/test/java/org/springframework/yarn/batch/config/SimpleYarnBatchConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/test/java/org/springframework/yarn/batch/config/SimpleYarnRemoteBatchConfigurationTests.java
+++ b/spring-yarn/spring-yarn-batch/src/test/java/org/springframework/yarn/batch/config/SimpleYarnRemoteBatchConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/test/java/org/springframework/yarn/batch/item/DataStoreItemReaderTests.java
+++ b/spring-yarn/spring-yarn-batch/src/test/java/org/springframework/yarn/batch/item/DataStoreItemReaderTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/test/java/org/springframework/yarn/batch/partition/ExampleItemReader.java
+++ b/spring-yarn/spring-yarn-batch/src/test/java/org/springframework/yarn/batch/partition/ExampleItemReader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/test/java/org/springframework/yarn/batch/partition/ExampleItemWriter.java
+++ b/spring-yarn/spring-yarn-batch/src/test/java/org/springframework/yarn/batch/partition/ExampleItemWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/test/java/org/springframework/yarn/batch/partition/PrintTasklet.java
+++ b/spring-yarn/spring-yarn-batch/src/test/java/org/springframework/yarn/batch/partition/PrintTasklet.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/test/java/org/springframework/yarn/batch/repository/AbstractJobRepositoryTests.java
+++ b/spring-yarn/spring-yarn-batch/src/test/java/org/springframework/yarn/batch/repository/AbstractJobRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/test/java/org/springframework/yarn/batch/repository/JobSupport.java
+++ b/spring-yarn/spring-yarn-batch/src/test/java/org/springframework/yarn/batch/repository/JobSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/test/java/org/springframework/yarn/batch/repository/RemoteJobRepositoryTests.java
+++ b/spring-yarn/spring-yarn-batch/src/test/java/org/springframework/yarn/batch/repository/RemoteJobRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/test/java/org/springframework/yarn/batch/repository/StepSupport.java
+++ b/spring-yarn/spring-yarn-batch/src/test/java/org/springframework/yarn/batch/repository/StepSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/test/java/org/springframework/yarn/batch/repository/StubAppmasterScOperations.java
+++ b/spring-yarn/spring-yarn-batch/src/test/java/org/springframework/yarn/batch/repository/StubAppmasterScOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-batch/src/test/java/org/springframework/yarn/batch/support/YarnJobLauncherTests.java
+++ b/spring-yarn/spring-yarn-batch/src/test/java/org/springframework/yarn/batch/support/YarnJobLauncherTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-build-tests/src/test/java/org/springframework/yarn/boot/app/AbstractApplicationTests.java
+++ b/spring-yarn/spring-yarn-boot-build-tests/src/test/java/org/springframework/yarn/boot/app/AbstractApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-build-tests/src/test/java/org/springframework/yarn/boot/app/StartExitAppmaster.java
+++ b/spring-yarn/spring-yarn-boot-build-tests/src/test/java/org/springframework/yarn/boot/app/StartExitAppmaster.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-build-tests/src/test/java/org/springframework/yarn/boot/app/StartSleepAppmaster.java
+++ b/spring-yarn/spring-yarn-boot-build-tests/src/test/java/org/springframework/yarn/boot/app/StartSleepAppmaster.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-build-tests/src/test/java/org/springframework/yarn/boot/app/YarnInfoApplicationTests.java
+++ b/spring-yarn/spring-yarn-boot-build-tests/src/test/java/org/springframework/yarn/boot/app/YarnInfoApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-build-tests/src/test/java/org/springframework/yarn/boot/app/YarnKillApplicationTests.java
+++ b/spring-yarn/spring-yarn-boot-build-tests/src/test/java/org/springframework/yarn/boot/app/YarnKillApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-build-tests/src/test/java/org/springframework/yarn/boot/app/YarnPushApplicationTests.java
+++ b/spring-yarn/spring-yarn-boot-build-tests/src/test/java/org/springframework/yarn/boot/app/YarnPushApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-build-tests/src/test/java/org/springframework/yarn/boot/app/YarnSubmitApplicationTests.java
+++ b/spring-yarn/spring-yarn-boot-build-tests/src/test/java/org/springframework/yarn/boot/app/YarnSubmitApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/AbstractApplicationCommand.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/AbstractApplicationCommand.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/AbstractCli.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/AbstractCli.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/CliSystemConstants.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/CliSystemConstants.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnClusterCreateCommand.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnClusterCreateCommand.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnClusterDestroyCommand.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnClusterDestroyCommand.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnClusterInfoCommand.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnClusterInfoCommand.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnClusterModifyCommand.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnClusterModifyCommand.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnClusterStartCommand.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnClusterStartCommand.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnClusterStopCommand.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnClusterStopCommand.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnClustersInfoCommand.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnClustersInfoCommand.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnKillCommand.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnKillCommand.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnPushCommand.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnPushCommand.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnPushedCommand.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnPushedCommand.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnShutdownCommand.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnShutdownCommand.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnSubmitCommand.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnSubmitCommand.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnSubmittedCommand.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/YarnSubmittedCommand.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/shell/AnsiString.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/shell/AnsiString.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/shell/ClearCommand.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/shell/ClearCommand.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/shell/CommandCompleter.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/shell/CommandCompleter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/shell/EscapeAwareWhiteSpaceArgumentDelimiter.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/shell/EscapeAwareWhiteSpaceArgumentDelimiter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/shell/ExitCommand.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/shell/ExitCommand.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/shell/ForkProcessCommand.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/shell/ForkProcessCommand.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/shell/PromptCommand.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/shell/PromptCommand.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/shell/RunProcessCommand.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/shell/RunProcessCommand.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/shell/Shell.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/shell/Shell.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/shell/ShellCommand.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/shell/ShellCommand.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/shell/ShellExitException.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/shell/ShellExitException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/shell/ShellPrompts.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/main/java/org/springframework/yarn/boot/cli/shell/ShellPrompts.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/CliTester.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/CliTester.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/CliTests.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/CliTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/OutputCapture.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/OutputCapture.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnClusterCreateCommandTests.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnClusterCreateCommandTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnClusterDestroyCommandTests.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnClusterDestroyCommandTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnClusterInfoCommandTests.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnClusterInfoCommandTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnClusterModifyCommandTests.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnClusterModifyCommandTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnClusterStartCommandTests.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnClusterStartCommandTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnClusterStopCommandTests.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnClusterStopCommandTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnClustersInfoCommandTests.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnClustersInfoCommandTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnKillCommandTests.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnKillCommandTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnPushCommandTests.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnPushCommandTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnPushedCommandTests.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnPushedCommandTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnShutdownCommandTests.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnShutdownCommandTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnSubmitCommandTests.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnSubmitCommandTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnSubmittedCommandTests.java
+++ b/spring-yarn/spring-yarn-boot-cli/src/test/java/org/springframework/yarn/boot/cli/YarnSubmittedCommandTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot-test/src/main/java/org/springframework/yarn/boot/test/junit/AbstractBootYarnClusterTests.java
+++ b/spring-yarn/spring-yarn-boot-test/src/main/java/org/springframework/yarn/boot/test/junit/AbstractBootYarnClusterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/ContainerClusterAppmasterAutoConfiguration.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/ContainerClusterAppmasterAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/FallbackYarnRestTemplateAutoConfiguration.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/FallbackYarnRestTemplateAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/SpringApplicationCallback.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/SpringApplicationCallback.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/SpringApplicationException.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/SpringApplicationException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/SpringApplicationTemplate.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/SpringApplicationTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/YarnAppmasterAutoConfiguration.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/YarnAppmasterAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/YarnClientAutoConfiguration.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/YarnClientAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/YarnContainerAutoConfiguration.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/YarnContainerAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/YarnRestTemplateAutoConfiguration.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/YarnRestTemplateAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/actuate/endpoint/YarnContainerClusterEndpoint.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/actuate/endpoint/YarnContainerClusterEndpoint.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/actuate/endpoint/YarnContainerRegisterEndpoint.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/actuate/endpoint/YarnContainerRegisterEndpoint.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/actuate/endpoint/mvc/AbstractContainerClusterRequest.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/actuate/endpoint/mvc/AbstractContainerClusterRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/actuate/endpoint/mvc/ContainerClusterCreateRequest.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/actuate/endpoint/mvc/ContainerClusterCreateRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/actuate/endpoint/mvc/ContainerClusterModifyRequest.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/actuate/endpoint/mvc/ContainerClusterModifyRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/actuate/endpoint/mvc/YarnContainerClusterMvcEndpoint.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/actuate/endpoint/mvc/YarnContainerClusterMvcEndpoint.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/actuate/endpoint/mvc/YarnContainerRegisterMvcEndpoint.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/actuate/endpoint/mvc/YarnContainerRegisterMvcEndpoint.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/actuate/endpoint/mvc/domain/ContainerAllocateDataResource.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/actuate/endpoint/mvc/domain/ContainerAllocateDataResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/actuate/endpoint/mvc/domain/ContainerClusterResource.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/actuate/endpoint/mvc/domain/ContainerClusterResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/actuate/endpoint/mvc/domain/ContainerClusterStateResource.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/actuate/endpoint/mvc/domain/ContainerClusterStateResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/actuate/endpoint/mvc/domain/ContainerRegisterResource.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/actuate/endpoint/mvc/domain/ContainerRegisterResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/actuate/endpoint/mvc/domain/GridMemberResource.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/actuate/endpoint/mvc/domain/GridMemberResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/actuate/endpoint/mvc/domain/GridProjectionResource.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/actuate/endpoint/mvc/domain/GridProjectionResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/actuate/endpoint/mvc/domain/YarnContainerClusterEndpointResource.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/actuate/endpoint/mvc/domain/YarnContainerClusterEndpointResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/AbstractClientApplication.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/AbstractClientApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/ClientApplicationRunner.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/ClientApplicationRunner.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/SpringYarnBootApplication.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/SpringYarnBootApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/YarnContainerClusterApplication.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/YarnContainerClusterApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/YarnContainerClusterClientException.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/YarnContainerClusterClientException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/YarnContainerClusterOperations.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/YarnContainerClusterOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/YarnContainerClusterTemplate.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/YarnContainerClusterTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/YarnInfoApplication.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/YarnInfoApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/YarnKillApplication.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/YarnKillApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/YarnPushApplication.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/YarnPushApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/YarnShutdownApplication.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/YarnShutdownApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/YarnSubmitApplication.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/app/YarnSubmitApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/condition/ConditionalOnMissingYarn.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/condition/ConditionalOnMissingYarn.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/condition/ConditionalOnYarn.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/condition/ConditionalOnYarn.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/condition/ConditionalOnYarnAppmaster.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/condition/ConditionalOnYarnAppmaster.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/condition/ConditionalOnYarnClient.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/condition/ConditionalOnYarnClient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/condition/ConditionalOnYarnContainer.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/condition/ConditionalOnYarnContainer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/condition/OnYarnAppmasterCondition.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/condition/OnYarnAppmasterCondition.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/condition/OnYarnClientCondition.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/condition/OnYarnClientCondition.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/condition/OnYarnClusterCondition.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/condition/OnYarnClusterCondition.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/condition/OnYarnContainerCondition.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/condition/OnYarnContainerCondition.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/AbstractLaunchContextProperties.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/AbstractLaunchContextProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/AbstractLocalizerProperties.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/AbstractLocalizerProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/AbstractResourceProperties.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/AbstractResourceProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/SpringHadoopProperties.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/SpringHadoopProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/SpringYarnAppmasterLaunchContextProperties.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/SpringYarnAppmasterLaunchContextProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/SpringYarnAppmasterLocalizerProperties.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/SpringYarnAppmasterLocalizerProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/SpringYarnAppmasterProperties.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/SpringYarnAppmasterProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/SpringYarnAppmasterResourceProperties.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/SpringYarnAppmasterResourceProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/SpringYarnBatchProperties.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/SpringYarnBatchProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/SpringYarnClientLaunchContextProperties.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/SpringYarnClientLaunchContextProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/SpringYarnClientLocalizerProperties.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/SpringYarnClientLocalizerProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/SpringYarnClientProperties.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/SpringYarnClientProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/SpringYarnClientResourceProperties.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/SpringYarnClientResourceProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/SpringYarnContainerProperties.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/SpringYarnContainerProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/SpringYarnEnvProperties.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/SpringYarnEnvProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/SpringYarnHostInfoDiscoveryProperties.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/SpringYarnHostInfoDiscoveryProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/SpringYarnProperties.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/SpringYarnProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/SpringYarnRestTemplateProperties.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/properties/SpringYarnRestTemplateProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/support/AppmasterLauncherRunner.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/support/AppmasterLauncherRunner.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/support/BootApplicationEventTransformer.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/support/BootApplicationEventTransformer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/support/BootLocalResourcesSelector.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/support/BootLocalResourcesSelector.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/support/BootMultiLocalResourcesSelector.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/support/BootMultiLocalResourcesSelector.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/support/ClientLauncherRunner.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/support/ClientLauncherRunner.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/support/CommandLineRunnerSupport.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/support/CommandLineRunnerSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/support/ContainerLauncherRunner.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/support/ContainerLauncherRunner.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/support/ContainerRegistrar.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/support/ContainerRegistrar.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/support/EmbeddedAppmasterTrackService.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/support/EmbeddedAppmasterTrackService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/support/EndpointContainerShutdown.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/support/EndpointContainerShutdown.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/support/SpringYarnBootUtils.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/support/SpringYarnBootUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/support/YarnBootClientApplicationListener.java
+++ b/spring-yarn/spring-yarn-boot/src/main/java/org/springframework/yarn/boot/support/YarnBootClientApplicationListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/MockUtils.java
+++ b/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/MockUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/TestUtils.java
+++ b/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/TestUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/YarnAppmasterAutoConfigurationTests.java
+++ b/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/YarnAppmasterAutoConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/YarnClientAutoConfigurationTests.java
+++ b/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/YarnClientAutoConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/YarnContainerAutoConfigurationTests.java
+++ b/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/YarnContainerAutoConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/YarnRestTemplateAutoConfigurationTests.java
+++ b/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/YarnRestTemplateAutoConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/actuate/endpoint/mvc/YarnContainerClusterMvcEndpointTests.java
+++ b/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/actuate/endpoint/mvc/YarnContainerClusterMvcEndpointTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/actuate/endpoint/mvc/YarnContainerClusterWithCustomProjectionsMvcEndpointTests.java
+++ b/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/actuate/endpoint/mvc/YarnContainerClusterWithCustomProjectionsMvcEndpointTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/actuate/endpoint/mvc/YarnContainerRegisterMvcEndpointTests.java
+++ b/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/actuate/endpoint/mvc/YarnContainerRegisterMvcEndpointTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/app/YarnContainerClusterApplicationOperationPropertiesTests.java
+++ b/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/app/YarnContainerClusterApplicationOperationPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/app/YarnContainerClusterTemplateTests.java
+++ b/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/app/YarnContainerClusterTemplateTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringHadoopPropertiesTests.java
+++ b/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringHadoopPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringHadoopSecurityPropertiesTests.java
+++ b/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringHadoopSecurityPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringYarnAppmasterContainerClusterPropertiesTests.java
+++ b/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringYarnAppmasterContainerClusterPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringYarnAppmasterLaunchContextPropertiesTests.java
+++ b/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringYarnAppmasterLaunchContextPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringYarnAppmasterLocalizerPropertiesTests.java
+++ b/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringYarnAppmasterLocalizerPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringYarnAppmasterPropertiesTests.java
+++ b/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringYarnAppmasterPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringYarnAppmasterResourcePropertiesTests.java
+++ b/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringYarnAppmasterResourcePropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringYarnBatchPropertiesTests.java
+++ b/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringYarnBatchPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringYarnClientLaunchContextPropertiesTests.java
+++ b/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringYarnClientLaunchContextPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringYarnClientLocalizerPropertiesTests.java
+++ b/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringYarnClientLocalizerPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringYarnClientPropertiesTests.java
+++ b/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringYarnClientPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringYarnClientResourcePropertiesTests.java
+++ b/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringYarnClientResourcePropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringYarnContainerPropertiesTests.java
+++ b/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringYarnContainerPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringYarnPropertiesTests.java
+++ b/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/properties/SpringYarnPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/support/BootLocalResourcesSelectorTests.java
+++ b/spring-yarn/spring-yarn-boot/src/test/java/org/springframework/yarn/boot/support/BootLocalResourcesSelectorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-build-tests/src/test/java/org/springframework/yarn/client/ClientRmTemplateTests.java
+++ b/spring-yarn/spring-yarn-build-tests/src/test/java/org/springframework/yarn/client/ClientRmTemplateTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-build-tests/src/test/java/org/springframework/yarn/config/annotation/SpringYarnConfigurationWithClusterTests.java
+++ b/spring-yarn/spring-yarn-build-tests/src/test/java/org/springframework/yarn/config/annotation/SpringYarnConfigurationWithClusterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-build-tests/src/test/java/org/springframework/yarn/config/annotation/YarnClusterInjectingConfigBuilderTests.java
+++ b/spring-yarn/spring-yarn-build-tests/src/test/java/org/springframework/yarn/config/annotation/YarnClusterInjectingConfigBuilderTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-build-tests/src/test/java/org/springframework/yarn/fs/DefaultResourceLocalizerTests.java
+++ b/spring-yarn/spring-yarn-build-tests/src/test/java/org/springframework/yarn/fs/DefaultResourceLocalizerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-build-tests/src/test/java/org/springframework/yarn/test/YarnClusterTests.java
+++ b/spring-yarn/spring-yarn-build-tests/src/test/java/org/springframework/yarn/test/YarnClusterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-build-tests/src/test/java/org/springframework/yarn/test/junit/ClusterBaseTestClassSubmitTests.java
+++ b/spring-yarn/spring-yarn-build-tests/src/test/java/org/springframework/yarn/test/junit/ClusterBaseTestClassSubmitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-build-tests/src/test/java/org/springframework/yarn/test/junit/ClusterBaseTestClassTests.java
+++ b/spring-yarn/spring-yarn-build-tests/src/test/java/org/springframework/yarn/test/junit/ClusterBaseTestClassTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/YarnSystemConstants.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/YarnSystemConstants.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/YarnSystemException.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/YarnSystemException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/AbstractAppmaster.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/AbstractAppmaster.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/AbstractEventingAppmaster.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/AbstractEventingAppmaster.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/AbstractProcessingAppmaster.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/AbstractProcessingAppmaster.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/AbstractServicesAppmaster.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/AbstractServicesAppmaster.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/AppmasterCmOperations.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/AppmasterCmOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/AppmasterCmTemplate.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/AppmasterCmTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/AppmasterConstants.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/AppmasterConstants.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/AppmasterRmOperations.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/AppmasterRmOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/AppmasterRmTemplate.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/AppmasterRmTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/AppmasterService.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/AppmasterService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/AppmasterServiceClient.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/AppmasterServiceClient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/AppmasterTrackService.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/AppmasterTrackService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/CommandLineAppmasterRunner.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/CommandLineAppmasterRunner.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/ContainerLauncherInterceptor.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/ContainerLauncherInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/GenericRpcMessage.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/GenericRpcMessage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/RpcMessage.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/RpcMessage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/StaticAppmaster.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/StaticAppmaster.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/StaticEventingAppmaster.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/StaticEventingAppmaster.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/YarnAppmaster.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/YarnAppmaster.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/allocate/AbstractAllocator.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/allocate/AbstractAllocator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/allocate/AbstractPollingAllocator.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/allocate/AbstractPollingAllocator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/allocate/AllocationGroup.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/allocate/AllocationGroup.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/allocate/AllocationGroups.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/allocate/AllocationGroups.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/allocate/ContainerAllocateData.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/allocate/ContainerAllocateData.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/allocate/ContainerAllocator.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/allocate/ContainerAllocator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/allocate/DefaultAllocateCountTracker.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/allocate/DefaultAllocateCountTracker.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/allocate/DefaultContainerAllocator.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/allocate/DefaultContainerAllocator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/assign/ContainerAssign.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/assign/ContainerAssign.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/assign/DefaultContainerAssign.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/assign/DefaultContainerAssign.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/cluster/AbstractContainerClusterAppmaster.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/cluster/AbstractContainerClusterAppmaster.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/cluster/ClusterAllocatingAction.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/cluster/ClusterAllocatingAction.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/cluster/ClusterDestroyingAction.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/cluster/ClusterDestroyingAction.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/cluster/ClusterEvent.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/cluster/ClusterEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/cluster/ClusterStartAction.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/cluster/ClusterStartAction.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/cluster/ClusterState.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/cluster/ClusterState.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/cluster/ClusterStoppingAction.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/cluster/ClusterStoppingAction.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/cluster/ContainerCluster.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/cluster/ContainerCluster.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/cluster/ContainerClusterAppmaster.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/cluster/ContainerClusterAppmaster.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/cluster/ContainerClusterInfo.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/cluster/ContainerClusterInfo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/cluster/ContainerClusterStateMachineConfiguration.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/cluster/ContainerClusterStateMachineConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/cluster/DefaultContainerCluster.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/cluster/DefaultContainerCluster.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/cluster/ManagedContainerClusterAppmaster.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/cluster/ManagedContainerClusterAppmaster.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/container/AbstractLauncher.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/container/AbstractLauncher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/container/ContainerLauncher.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/container/ContainerLauncher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/container/ContainerRegisterInfo.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/container/ContainerRegisterInfo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/container/ContainerRequestHint.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/container/ContainerRequestHint.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/container/ContainerResolver.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/container/ContainerResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/container/ContainerShutdown.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/container/ContainerShutdown.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/container/DefaultContainerLauncher.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/container/DefaultContainerLauncher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/Grid.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/Grid.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/GridMember.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/GridMember.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/GridProjection.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/GridProjection.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/GridProjectionFactory.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/GridProjectionFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/GridProjectionFactoryLocator.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/GridProjectionFactoryLocator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/listener/DefaultGridListener.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/listener/DefaultGridListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/listener/DefaultProjectedGridListener.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/listener/DefaultProjectedGridListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/listener/GridListener.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/listener/GridListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/listener/ProjectedGridListener.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/listener/ProjectedGridListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/listener/ProjectedGridListenerAdapter.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/listener/ProjectedGridListenerAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/support/AbstractGrid.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/support/AbstractGrid.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/support/AbstractGridMember.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/support/AbstractGridMember.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/support/AbstractGridProjection.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/support/AbstractGridProjection.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/support/AbstractProjectedGrid.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/support/AbstractProjectedGrid.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/support/DefaultGrid.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/support/DefaultGrid.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/support/DefaultGridMember.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/support/DefaultGridMember.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/support/DefaultGridProjection.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/support/DefaultGridProjection.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/support/DefaultGridProjectionFactory.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/support/DefaultGridProjectionFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/support/DefaultProjectedGrid.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/support/DefaultProjectedGrid.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/support/GridMemberInterceptor.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/support/GridMemberInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/support/GridMemberInterceptorChain.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/support/GridMemberInterceptorChain.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/support/GridProjectionFactoryRegistry.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/support/GridProjectionFactoryRegistry.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/support/ProjectionData.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/support/ProjectionData.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/support/ProjectionDataRegistry.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/support/ProjectionDataRegistry.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/support/SatisfyStateData.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/grid/support/SatisfyStateData.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/monitor/AbstractMonitor.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/monitor/AbstractMonitor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/monitor/ContainerAware.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/monitor/ContainerAware.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/monitor/ContainerMonitor.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/monitor/ContainerMonitor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/monitor/DefaultContainerMonitor.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/monitor/DefaultContainerMonitor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/track/UrlAppmasterTrackService.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/am/track/UrlAppmasterTrackService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/annotation/OnContainerStart.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/annotation/OnContainerStart.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/annotation/YarnComponent.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/annotation/YarnComponent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/annotation/YarnEnvironment.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/annotation/YarnEnvironment.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/annotation/YarnEnvironments.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/annotation/YarnEnvironments.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/annotation/YarnParameter.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/annotation/YarnParameter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/annotation/YarnParameters.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/annotation/YarnParameters.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/client/AbstractYarnClient.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/client/AbstractYarnClient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/client/ApplicationDescriptor.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/client/ApplicationDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/client/ApplicationYarnClient.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/client/ApplicationYarnClient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/client/AppmasterScOperations.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/client/AppmasterScOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/client/ClientRmOperations.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/client/ClientRmOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/client/ClientRmTemplate.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/client/ClientRmTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/client/CommandLineClientRunner.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/client/CommandLineClientRunner.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/client/CommandYarnClient.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/client/CommandYarnClient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/client/DefaultApplicationYarnClient.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/client/DefaultApplicationYarnClient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/client/YarnClient.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/client/YarnClient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/client/YarnClientFactoryBean.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/client/YarnClientFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/AbstractImprovedSimpleBeanDefinitionParser.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/AbstractImprovedSimpleBeanDefinitionParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/AbstractPropertiesConfiguredBeanDefinitionParser.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/AbstractPropertiesConfiguredBeanDefinitionParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/AbstractYarnNamespaceHandler.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/AbstractYarnNamespaceHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/ClientParser.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/ClientParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/ConfiguringBeanFactoryPostProcessor.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/ConfiguringBeanFactoryPostProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/ContainerParser.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/ContainerParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/EnvironmentParser.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/EnvironmentParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/LocalresourcesParser.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/LocalresourcesParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/MasterParser.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/MasterParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/NamespaceUtils.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/NamespaceUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/YarnConfigParser.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/YarnConfigParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/YarnNamespaceHandler.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/YarnNamespaceHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/YarnNamespaceUtils.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/YarnNamespaceUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/ConfiguringBeanFactoryPostProcessorConfiguration.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/ConfiguringBeanFactoryPostProcessorConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/ContainerActivatorAnnotationPostProcessor.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/ContainerActivatorAnnotationPostProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/EnableYarn.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/EnableYarn.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/MethodAnnotationPostProcessor.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/MethodAnnotationPostProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/SpringYarnAnnotationPostProcessor.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/SpringYarnAnnotationPostProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/SpringYarnConfigs.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/SpringYarnConfigs.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/SpringYarnConfigurationImportSelector.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/SpringYarnConfigurationImportSelector.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/SpringYarnConfigurer.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/SpringYarnConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/SpringYarnConfigurerAdapter.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/SpringYarnConfigurerAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/builders/SpringYarnConfigBuilder.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/builders/SpringYarnConfigBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/builders/YarnAppmasterBuilder.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/builders/YarnAppmasterBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/builders/YarnAppmasterConfigurer.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/builders/YarnAppmasterConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/builders/YarnClientBuilder.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/builders/YarnClientBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/builders/YarnClientConfigurer.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/builders/YarnClientConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/builders/YarnConfigBuilder.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/builders/YarnConfigBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/builders/YarnConfigConfigurer.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/builders/YarnConfigConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/builders/YarnContainerBuilder.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/builders/YarnContainerBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/builders/YarnContainerConfigurer.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/builders/YarnContainerConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/builders/YarnEnvironmentBuilder.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/builders/YarnEnvironmentBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/builders/YarnEnvironmentConfigurer.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/builders/YarnEnvironmentConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/builders/YarnResourceLocalizerBuilder.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/builders/YarnResourceLocalizerBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/builders/YarnResourceLocalizerConfigurer.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/builders/YarnResourceLocalizerConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/configuration/SpringYarnAppmasterConfiguration.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/configuration/SpringYarnAppmasterConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/configuration/SpringYarnClientConfiguration.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/configuration/SpringYarnClientConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/configuration/SpringYarnConfiguration.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/configuration/SpringYarnConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/configuration/SpringYarnContainerConfiguration.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/configuration/SpringYarnContainerConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/configurers/ClientMasterRunnerConfigurer.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/configurers/ClientMasterRunnerConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/configurers/DefaultClientMasterRunnerConfigurer.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/configurers/DefaultClientMasterRunnerConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/configurers/DefaultEnvironmentClasspathConfigurer.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/configurers/DefaultEnvironmentClasspathConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/configurers/DefaultLocalResourcesCopyConfigurer.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/configurers/DefaultLocalResourcesCopyConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/configurers/DefaultLocalResourcesHdfsConfigurer.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/configurers/DefaultLocalResourcesHdfsConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/configurers/DefaultMasterContainerAllocatorConfigurer.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/configurers/DefaultMasterContainerAllocatorConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/configurers/DefaultMasterContainerRunnerConfigurer.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/configurers/DefaultMasterContainerRunnerConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/configurers/EnvironmentClasspathConfigurer.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/configurers/EnvironmentClasspathConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/configurers/LocalResourcesCopyConfigurer.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/configurers/LocalResourcesCopyConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/configurers/LocalResourcesHdfsConfigurer.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/configurers/LocalResourcesHdfsConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/configurers/MasterContainerAllocatorConfigurer.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/configurers/MasterContainerAllocatorConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/configurers/MasterContainerRunnerConfigurer.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/config/annotation/configurers/MasterContainerRunnerConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/configuration/ConfigurationFactoryBean.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/configuration/ConfigurationFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/configuration/ConfigurationUtils.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/configuration/ConfigurationUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/configuration/EnvironmentFactoryBean.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/configuration/EnvironmentFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/AbstractYarnContainer.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/AbstractYarnContainer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/CommandLineContainerRunner.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/CommandLineContainerRunner.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/ContainerHandler.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/ContainerHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/ContainerHandlersResultsProcessor.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/ContainerHandlersResultsProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/ContainerMethodInvokerHelper.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/ContainerMethodInvokerHelper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/ContainerRunner.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/ContainerRunner.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/DefaultContainerHandlersResultsProcessor.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/DefaultContainerHandlersResultsProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/DefaultYarnContainer.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/DefaultYarnContainer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/LongRunningYarnContainer.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/LongRunningYarnContainer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/MethodInvokingYarnContainerRuntimeProcessor.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/MethodInvokingYarnContainerRuntimeProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/SimpleContainerRunner.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/SimpleContainerRunner.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/YarnContainer.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/YarnContainer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/YarnContainerFactoryBean.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/YarnContainerFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/YarnContainerRuntime.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/YarnContainerRuntime.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/YarnContainerRuntimeProcessor.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/YarnContainerRuntimeProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/YarnContainerSupport.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/container/YarnContainerSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/event/AbstractYarnEvent.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/event/AbstractYarnEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/event/ContainerAllocationEvent.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/event/ContainerAllocationEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/event/ContainerCompletedEvent.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/event/ContainerCompletedEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/event/ContainerLaunchRequestFailedEvent.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/event/ContainerLaunchRequestFailedEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/event/ContainerLaunchedEvent.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/event/ContainerLaunchedEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/event/ContainerRegisterEvent.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/event/ContainerRegisterEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/event/DefaultYarnEventPublisher.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/event/DefaultYarnEventPublisher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/event/LoggingListener.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/event/LoggingListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/event/YarnEventPublisher.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/event/YarnEventPublisher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/fs/AbstractLocalResourcesSelector.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/fs/AbstractLocalResourcesSelector.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/fs/AbstractResourceLocalizer.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/fs/AbstractResourceLocalizer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/fs/DefaultMultiResourceLocalizer.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/fs/DefaultMultiResourceLocalizer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/fs/DefaultResourceLocalizer.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/fs/DefaultResourceLocalizer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/fs/LocalResourcesFactoryBean.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/fs/LocalResourcesFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/fs/LocalResourcesSelector.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/fs/LocalResourcesSelector.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/fs/MultiLocalResourcesSelector.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/fs/MultiLocalResourcesSelector.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/fs/MultiResourceLocalizer.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/fs/MultiResourceLocalizer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/fs/ResourceLocalizer.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/fs/ResourceLocalizer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/fs/SmartResourceLocalizer.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/fs/SmartResourceLocalizer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/launch/AbstractCommandLineRunner.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/launch/AbstractCommandLineRunner.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/launch/ExitCodeMapper.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/launch/ExitCodeMapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/launch/ExitStatus.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/launch/ExitStatus.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/launch/JvmSystemExiter.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/launch/JvmSystemExiter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/launch/LaunchCommandsFactoryBean.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/launch/LaunchCommandsFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/launch/SimpleJvmExitCodeMapper.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/launch/SimpleJvmExitCodeMapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/launch/SystemExiter.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/launch/SystemExiter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/listener/AbstractCompositeListener.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/listener/AbstractCompositeListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/listener/AppmasterStateListener.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/listener/AppmasterStateListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/listener/CompositeAppmasterStateListener.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/listener/CompositeAppmasterStateListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/listener/CompositeContainerAllocatorListener.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/listener/CompositeContainerAllocatorListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/listener/CompositeContainerMonitorStateListener.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/listener/CompositeContainerMonitorStateListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/listener/CompositeContainerStateListener.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/listener/CompositeContainerStateListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/listener/ContainerAllocatorListener.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/listener/ContainerAllocatorListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/listener/ContainerMonitorListener.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/listener/ContainerMonitorListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/listener/ContainerStateListener.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/listener/ContainerStateListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/listener/OrderedComposite.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/listener/OrderedComposite.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/rpc/YarnRpcAccessor.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/rpc/YarnRpcAccessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/rpc/YarnRpcCallback.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/rpc/YarnRpcCallback.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/AbstractExpressionEvaluator.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/AbstractExpressionEvaluator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/AnnotatedMethodFilter.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/AnnotatedMethodFilter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/BeanFactoryTypeConverter.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/BeanFactoryTypeConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/ExpressionUtils.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/ExpressionUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/FixedMethodFilter.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/FixedMethodFilter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/LifecycleObjectSupport.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/LifecycleObjectSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/NetworkUtils.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/NetworkUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/ParsingUtils.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/ParsingUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/PollingTaskSupport.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/PollingTaskSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/UniqueMethodFilter.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/UniqueMethodFilter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/YarnContextUtils.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/YarnContextUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/YarnUtils.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/YarnUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/compat/NMTokenCacheCompat.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/compat/NMTokenCacheCompat.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/compat/ResourceCompat.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/compat/ResourceCompat.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/console/ApplicationsReport.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/console/ApplicationsReport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/console/CommonUtils.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/console/CommonUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/console/ContainerClusterReport.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/console/ContainerClusterReport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/console/Table.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/console/Table.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/console/TableHeader.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/console/TableHeader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/console/TableRow.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/console/TableRow.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/console/UiUtils.java
+++ b/spring-yarn/spring-yarn-core/src/main/java/org/springframework/yarn/support/console/UiUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/MockUtils.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/MockUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/TestUtils.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/TestUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/AppmasterTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/AppmasterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/NMTokenCacheTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/NMTokenCacheTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/allocate/AllocationGroupsTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/allocate/AllocationGroupsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/allocate/DefaultAllocateCountTrackerTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/allocate/DefaultAllocateCountTrackerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/allocate/DefaultContainerAllocatorTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/allocate/DefaultContainerAllocatorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/cluster/AbstractManagedContainerClusterAppmasterTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/cluster/AbstractManagedContainerClusterAppmasterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/cluster/ManagedContainerClusterAppmasterMultiTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/cluster/ManagedContainerClusterAppmasterMultiTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/cluster/ManagedContainerClusterAppmasterSingleTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/cluster/ManagedContainerClusterAppmasterSingleTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/grid/GridTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/grid/GridTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/grid/support/DefaultGridProjectionTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/grid/support/DefaultGridProjectionTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/grid/support/DefaultProjectedGridTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/grid/support/DefaultProjectedGridTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/grid/support/ProjectionDataTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/grid/support/ProjectionDataTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/grid/support/TestDNSToSwitchMapping.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/grid/support/TestDNSToSwitchMapping.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/monitor/DefaultContainerMonitorTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/am/monitor/DefaultContainerMonitorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/client/ClientLocalizerIntegrationTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/client/ClientLocalizerIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/ClientNamespaceTest.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/ClientNamespaceTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/ConfigurationNamespaceTest.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/ConfigurationNamespaceTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/ContainerNamespaceTest.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/ContainerNamespaceTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/EnvironmentNamespaceTest.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/EnvironmentNamespaceTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/LocalresourcesNamespaceTest.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/LocalresourcesNamespaceTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/MasterNamespaceTest.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/MasterNamespaceTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/annotation/ClasspathEnvironmentAnnotationTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/annotation/ClasspathEnvironmentAnnotationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/annotation/ClasspathEnvironmentDefaultsTweakedAnnotationTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/annotation/ClasspathEnvironmentDefaultsTweakedAnnotationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/annotation/ClasspathMixedEnvironmentAnnotationTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/annotation/ClasspathMixedEnvironmentAnnotationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/annotation/ComplexConfigurationAnnotationTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/annotation/ComplexConfigurationAnnotationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/annotation/DefaultConfigurationAnnotationTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/annotation/DefaultConfigurationAnnotationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/annotation/DefaultEnvironmentAnnotationTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/annotation/DefaultEnvironmentAnnotationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/annotation/DefaultLocalresourcesAnnotationTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/annotation/DefaultLocalresourcesAnnotationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/annotation/DependencyBean.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/annotation/DependencyBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/annotation/NormalAnnotationConfigurationTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/annotation/NormalAnnotationConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/annotation/PropertiesEnvironmentAnnotationTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/annotation/PropertiesEnvironmentAnnotationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/annotation/SpringYarnAnnotationPostProcessorTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/annotation/SpringYarnAnnotationPostProcessorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/annotation/SpringYarnComplexConfigurationContainerActivatorTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/annotation/SpringYarnComplexConfigurationContainerActivatorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/annotation/SpringYarnConfigurationContainerActivatorTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/annotation/SpringYarnConfigurationContainerActivatorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/annotation/SpringYarnConfigurationContainerRefTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/annotation/SpringYarnConfigurationContainerRefTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/annotation/SpringYarnConfigurationContainerTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/annotation/SpringYarnConfigurationContainerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/annotation/SpringYarnConfigurationMasterAllocatorTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/annotation/SpringYarnConfigurationMasterAllocatorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/annotation/SpringYarnConfigurationMasterTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/annotation/SpringYarnConfigurationMasterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/annotation/XmlImportDependenciesTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/config/annotation/XmlImportDependenciesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/container/DefaultYarnContainerTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/container/DefaultYarnContainerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/container/MethodInvokingYarnContainerRuntimeProcessorTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/container/MethodInvokingYarnContainerRuntimeProcessorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/container/TestContainer.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/container/TestContainer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/fs/LocalResourcesSelectorTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/fs/LocalResourcesSelectorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/launch/AbstractCommandLineRunnerTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/launch/AbstractCommandLineRunnerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/launch/LaunchCommandsFactoryBeanTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/launch/LaunchCommandsFactoryBeanTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/support/ParsingUtilsTests.java
+++ b/spring-yarn/spring-yarn-core/src/test/java/org/springframework/yarn/support/ParsingUtilsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/IntegrationAppmasterService.java
+++ b/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/IntegrationAppmasterService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/IntegrationAppmasterServiceClient.java
+++ b/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/IntegrationAppmasterServiceClient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/IntegrationAppmasterServiceClientFactoryBean.java
+++ b/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/IntegrationAppmasterServiceClientFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/IntegrationAppmasterServiceFactoryBean.java
+++ b/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/IntegrationAppmasterServiceFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/config/IntegrationAmServiceClientParser.java
+++ b/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/config/IntegrationAmServiceClientParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/config/IntegrationAmServiceParser.java
+++ b/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/config/IntegrationAmServiceParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/config/IntegrationConverterParser.java
+++ b/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/config/IntegrationConverterParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/config/IntegrationNamespaceHandler.java
+++ b/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/config/IntegrationNamespaceHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/container/AbstractIntegrationYarnContainer.java
+++ b/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/container/AbstractIntegrationYarnContainer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/convert/ConversionServiceCreator.java
+++ b/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/convert/ConversionServiceCreator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/convert/ConverterRegistrar.java
+++ b/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/convert/ConverterRegistrar.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/convert/MindDataConversionException.java
+++ b/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/convert/MindDataConversionException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/convert/MindHolderToObjectConverter.java
+++ b/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/convert/MindHolderToObjectConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/convert/MindObjectToHolderConverter.java
+++ b/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/convert/MindObjectToHolderConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/ip/mind/AppmasterMindScOperations.java
+++ b/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/ip/mind/AppmasterMindScOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/ip/mind/DefaultMindAppmasterServiceClient.java
+++ b/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/ip/mind/DefaultMindAppmasterServiceClient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/ip/mind/MindAppmasterService.java
+++ b/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/ip/mind/MindAppmasterService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/ip/mind/MindAppmasterServiceClient.java
+++ b/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/ip/mind/MindAppmasterServiceClient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/ip/mind/MindRpcMessageHolder.java
+++ b/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/ip/mind/MindRpcMessageHolder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/ip/mind/MindRpcSerializer.java
+++ b/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/ip/mind/MindRpcSerializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/ip/mind/binding/BaseObject.java
+++ b/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/ip/mind/binding/BaseObject.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/ip/mind/binding/BaseResponseObject.java
+++ b/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/ip/mind/binding/BaseResponseObject.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/support/DefaultPortExposingTcpSocketSupport.java
+++ b/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/support/DefaultPortExposingTcpSocketSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/support/IntegrationContextUtils.java
+++ b/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/support/IntegrationContextUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/support/IntegrationObjectSupport.java
+++ b/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/support/IntegrationObjectSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/support/Jackson2ObjectMapperFactoryBean.java
+++ b/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/support/Jackson2ObjectMapperFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/support/PortExposingTcpSocketSupport.java
+++ b/spring-yarn/spring-yarn-integration/src/main/java/org/springframework/yarn/integration/support/PortExposingTcpSocketSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/test/java/org/springframework/yarn/integration/ServerBindTests.java
+++ b/spring-yarn/spring-yarn-integration/src/test/java/org/springframework/yarn/integration/ServerBindTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/test/java/org/springframework/yarn/integration/TestUtils.java
+++ b/spring-yarn/spring-yarn-integration/src/test/java/org/springframework/yarn/integration/TestUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/test/java/org/springframework/yarn/integration/config/AmserviceClientNamespaceTest.java
+++ b/spring-yarn/spring-yarn-integration/src/test/java/org/springframework/yarn/integration/config/AmserviceClientNamespaceTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/test/java/org/springframework/yarn/integration/config/AmserviceNamespaceTest.java
+++ b/spring-yarn/spring-yarn-integration/src/test/java/org/springframework/yarn/integration/config/AmserviceNamespaceTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/test/java/org/springframework/yarn/integration/convert/MindConverterTests.java
+++ b/spring-yarn/spring-yarn-integration/src/test/java/org/springframework/yarn/integration/convert/MindConverterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/test/java/org/springframework/yarn/integration/ip/mind/MindIntegrationDefaultTests.java
+++ b/spring-yarn/spring-yarn-integration/src/test/java/org/springframework/yarn/integration/ip/mind/MindIntegrationDefaultTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/test/java/org/springframework/yarn/integration/ip/mind/MindIntegrationNsTests.java
+++ b/spring-yarn/spring-yarn-integration/src/test/java/org/springframework/yarn/integration/ip/mind/MindIntegrationNsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/test/java/org/springframework/yarn/integration/ip/mind/MindIntegrationRawTests.java
+++ b/spring-yarn/spring-yarn-integration/src/test/java/org/springframework/yarn/integration/ip/mind/MindIntegrationRawTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/test/java/org/springframework/yarn/integration/ip/mind/MindSerializationTests.java
+++ b/spring-yarn/spring-yarn-integration/src/test/java/org/springframework/yarn/integration/ip/mind/MindSerializationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/test/java/org/springframework/yarn/integration/ip/mind/SimpleTestRequest.java
+++ b/spring-yarn/spring-yarn-integration/src/test/java/org/springframework/yarn/integration/ip/mind/SimpleTestRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/test/java/org/springframework/yarn/integration/ip/mind/SimpleTestRequest2.java
+++ b/spring-yarn/spring-yarn-integration/src/test/java/org/springframework/yarn/integration/ip/mind/SimpleTestRequest2.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/test/java/org/springframework/yarn/integration/ip/mind/SimpleTestResponse.java
+++ b/spring-yarn/spring-yarn-integration/src/test/java/org/springframework/yarn/integration/ip/mind/SimpleTestResponse.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/test/java/org/springframework/yarn/integration/ip/mind/TestService.java
+++ b/spring-yarn/spring-yarn-integration/src/test/java/org/springframework/yarn/integration/ip/mind/TestService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/test/java/org/springframework/yarn/integration/ip/mind/TestServiceClient.java
+++ b/spring-yarn/spring-yarn-integration/src/test/java/org/springframework/yarn/integration/ip/mind/TestServiceClient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/test/java/org/springframework/yarn/integration/support/PortExposingTcpSocketSupportNetTests.java
+++ b/spring-yarn/spring-yarn-integration/src/test/java/org/springframework/yarn/integration/support/PortExposingTcpSocketSupportNetTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-integration/src/test/java/org/springframework/yarn/integration/support/PortExposingTcpSocketSupportNioTests.java
+++ b/spring-yarn/spring-yarn-integration/src/test/java/org/springframework/yarn/integration/support/PortExposingTcpSocketSupportNioTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-test/src/main/java/org/springframework/yarn/test/YarnTestSystemConstants.java
+++ b/spring-yarn/spring-yarn-test/src/main/java/org/springframework/yarn/test/YarnTestSystemConstants.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-test/src/main/java/org/springframework/yarn/test/context/MetaAnnotationUtils.java
+++ b/spring-yarn/spring-yarn-test/src/main/java/org/springframework/yarn/test/context/MetaAnnotationUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-test/src/main/java/org/springframework/yarn/test/context/MiniYarnCluster.java
+++ b/spring-yarn/spring-yarn-test/src/main/java/org/springframework/yarn/test/context/MiniYarnCluster.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-test/src/main/java/org/springframework/yarn/test/context/MiniYarnClusterTest.java
+++ b/spring-yarn/spring-yarn-test/src/main/java/org/springframework/yarn/test/context/MiniYarnClusterTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-test/src/main/java/org/springframework/yarn/test/context/YarnCluster.java
+++ b/spring-yarn/spring-yarn-test/src/main/java/org/springframework/yarn/test/context/YarnCluster.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-test/src/main/java/org/springframework/yarn/test/context/YarnClusterInjectUtils.java
+++ b/spring-yarn/spring-yarn-test/src/main/java/org/springframework/yarn/test/context/YarnClusterInjectUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-test/src/main/java/org/springframework/yarn/test/context/YarnClusterInjectingAnnotationConfigContextLoader.java
+++ b/spring-yarn/spring-yarn-test/src/main/java/org/springframework/yarn/test/context/YarnClusterInjectingAnnotationConfigContextLoader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-test/src/main/java/org/springframework/yarn/test/context/YarnClusterInjectingXmlContextLoader.java
+++ b/spring-yarn/spring-yarn-test/src/main/java/org/springframework/yarn/test/context/YarnClusterInjectingXmlContextLoader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-test/src/main/java/org/springframework/yarn/test/context/YarnDelegatingSmartContextLoader.java
+++ b/spring-yarn/spring-yarn-test/src/main/java/org/springframework/yarn/test/context/YarnDelegatingSmartContextLoader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-test/src/main/java/org/springframework/yarn/test/junit/AbstractYarnClusterTests.java
+++ b/spring-yarn/spring-yarn-test/src/main/java/org/springframework/yarn/test/junit/AbstractYarnClusterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-test/src/main/java/org/springframework/yarn/test/junit/ApplicationInfo.java
+++ b/spring-yarn/spring-yarn-test/src/main/java/org/springframework/yarn/test/junit/ApplicationInfo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-test/src/main/java/org/springframework/yarn/test/support/ClusterDelegatingFactoryBean.java
+++ b/spring-yarn/spring-yarn-test/src/main/java/org/springframework/yarn/test/support/ClusterDelegatingFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-test/src/main/java/org/springframework/yarn/test/support/ClusterInfo.java
+++ b/spring-yarn/spring-yarn-test/src/main/java/org/springframework/yarn/test/support/ClusterInfo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-test/src/main/java/org/springframework/yarn/test/support/ConfigurationDelegatingFactoryBean.java
+++ b/spring-yarn/spring-yarn-test/src/main/java/org/springframework/yarn/test/support/ConfigurationDelegatingFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-test/src/main/java/org/springframework/yarn/test/support/ContainerLogUtils.java
+++ b/spring-yarn/spring-yarn-test/src/main/java/org/springframework/yarn/test/support/ContainerLogUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-test/src/main/java/org/springframework/yarn/test/support/StandaloneYarnCluster.java
+++ b/spring-yarn/spring-yarn-test/src/main/java/org/springframework/yarn/test/support/StandaloneYarnCluster.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-test/src/main/java/org/springframework/yarn/test/support/YarnClusterFactoryBean.java
+++ b/spring-yarn/spring-yarn-test/src/main/java/org/springframework/yarn/test/support/YarnClusterFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-test/src/main/java/org/springframework/yarn/test/support/YarnClusterManager.java
+++ b/spring-yarn/spring-yarn-test/src/main/java/org/springframework/yarn/test/support/YarnClusterManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-test/src/test/java/org/springframework/yarn/test/context/ComposedAnnotationCustomizeTests.java
+++ b/spring-yarn/spring-yarn-test/src/test/java/org/springframework/yarn/test/context/ComposedAnnotationCustomizeTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-test/src/test/java/org/springframework/yarn/test/context/ComposedAnnotationTests.java
+++ b/spring-yarn/spring-yarn-test/src/test/java/org/springframework/yarn/test/context/ComposedAnnotationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-test/src/test/java/org/springframework/yarn/test/context/CustomMiniYarnClusterTest.java
+++ b/spring-yarn/spring-yarn-test/src/test/java/org/springframework/yarn/test/context/CustomMiniYarnClusterTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-test/src/test/java/org/springframework/yarn/test/context/MiniYarnClusterTestOverrideTests.java
+++ b/spring-yarn/spring-yarn-test/src/test/java/org/springframework/yarn/test/context/MiniYarnClusterTestOverrideTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-test/src/test/java/org/springframework/yarn/test/context/YarnClusterInjectingAnnotationConfigContextLoaderTests.java
+++ b/spring-yarn/spring-yarn-test/src/test/java/org/springframework/yarn/test/context/YarnClusterInjectingAnnotationConfigContextLoaderTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-test/src/test/java/org/springframework/yarn/test/context/YarnClusterInjectingMiniYarnClusterTestContextLoaderTests.java
+++ b/spring-yarn/spring-yarn-test/src/test/java/org/springframework/yarn/test/context/YarnClusterInjectingMiniYarnClusterTestContextLoaderTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-test/src/test/java/org/springframework/yarn/test/context/YarnClusterInjectingXmlContextLoaderTests.java
+++ b/spring-yarn/spring-yarn-test/src/test/java/org/springframework/yarn/test/context/YarnClusterInjectingXmlContextLoaderTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-yarn/spring-yarn-test/src/test/java/org/springframework/yarn/test/support/YarnClusterManagerTests.java
+++ b/spring-yarn/spring-yarn-test/src/test/java/org/springframework/yarn/test/support/YarnClusterManagerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 1042 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).